### PR TITLE
Move namespace in pinecone index from a struct field to function argument

### DIFF
--- a/examples/QA-example/main.go
+++ b/examples/QA-example/main.go
@@ -36,12 +36,12 @@ func main() {
 
 	// We also need to create a vector database to store these embeddings for queries. Here is how it's done using pinecone
 	// Because pinecone takes time to initialize indexes, this should be an index that already exists
-	p, err := pinecone.NewPinecone(embedding, pineconeEnv, indexName, textFile, dimensions)
+	p, err := pinecone.NewPinecone(embedding, pineconeEnv, indexName, dimensions)
 	if err != nil {
 		log.Fatal(err.Error())
 	}
 
-	p.AddDocuments(docs, []string{})
+	p.AddDocuments(docs, []string{}, textFile)
 
 	llm, err := openai.New()
 	if err != nil {
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	// Now we can create a RetrievalQAChain using the pinecone index and a llm
-	chain := chains.NewRetrievalQAChainFromLLM(llm, p.ToRetriever(numDocsInReq))
+	chain := chains.NewRetrievalQAChainFromLLM(llm, p.ToRetriever(numDocsInReq, textFile))
 
 	for {
 		fmt.Print("Enter query: ")


### PR DESCRIPTION
Move the namespace field in the pinecone index from a struct field to function argument. This will give users the option to have one pinecone index for multiple namespaces, reducing the api calls done when creating a new pinecone client.