### PR TITLE
Add support for local LLMs

### DIFF
--- a/examples/local-llm-example/go.mod
+++ b/examples/local-llm-example/go.mod
@@ -1,0 +1,5 @@
+module basic-llm-example
+
+go 1.19
+
+require github.com/tmc/langchaingo v0.0.0-20230219000743-8950907292bc

--- a/examples/local-llm-example/go.sum
+++ b/examples/local-llm-example/go.sum
@@ -1,0 +1,2 @@
+github.com/tmc/langchaingo v0.0.0-20230219000743-8950907292bc h1:iCMXk/CfmCRUrDTi4w/2eK/aJd7wT+EMwkmu53XCN8k=
+github.com/tmc/langchaingo v0.0.0-20230219000743-8950907292bc/go.mod h1:B2R9IMuJkokhLAzZz8ow1LiJaFag6JdMd1Ha2koSyBo=

--- a/examples/local-llm-example/local_llm_example.go
+++ b/examples/local-llm-example/local_llm_example.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/tmc/langchaingo/llms/local"
+)
+
+func main() {
+	llm, err := local.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	completion, err := llm.Call("How many sides does a square have?")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(completion)
+}

--- a/llms/local/internal/localclient/completions.go
+++ b/llms/local/internal/localclient/completions.go
@@ -1,0 +1,28 @@
+package localclient
+
+import (
+	"context"
+	"os/exec"
+)
+
+type completionPayload struct {
+	Prompt string `json:"prompt"`
+}
+
+type completionResponsePayload struct {
+	Response string
+}
+
+func (c *Client) createCompletion(ctx context.Context, payload *completionPayload) (*completionResponsePayload, error) {
+	// Append the prompt to the args
+	c.args = append(c.args, payload.Prompt)
+
+	out, err := exec.CommandContext(ctx, c.binPath, c.args...).Output()
+	if err != nil {
+		return nil, err
+	}
+
+	return &completionResponsePayload{
+		Response: string(out),
+	}, nil
+}

--- a/llms/local/internal/localclient/localclient.go
+++ b/llms/local/internal/localclient/localclient.go
@@ -1,0 +1,68 @@
+package localclient
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrEmptyResponse is returned when the OpenAI API returns an empty response.
+var ErrEmptyResponse = errors.New("empty response")
+
+// Client is a client for a local LLM.
+type Client struct {
+	binPath string
+	args    []string
+}
+
+// New returns a new local client.
+func New(binPath string, args string) (*Client, error) {
+	var parts []string
+	var currentPart string
+	var inDoubleQuote, inSingleQuote bool
+
+	for _, char := range args {
+		switch {
+		case char == ' ' && !inDoubleQuote && !inSingleQuote:
+			if currentPart != "" {
+				parts = append(parts, currentPart)
+				currentPart = ""
+			}
+		case char == '"' && !inSingleQuote:
+			inDoubleQuote = !inDoubleQuote
+		case char == '\'' && !inDoubleQuote:
+			inSingleQuote = !inSingleQuote
+		default:
+			currentPart += string(char)
+		}
+	}
+
+	if currentPart != "" {
+		parts = append(parts, currentPart)
+	}
+
+	c := &Client{binPath: binPath, args: parts}
+	return c, nil
+}
+
+// CompletionRequest is a request to create a completion.
+type CompletionRequest struct {
+	Prompt string `json:"prompt"`
+}
+
+// Completion is a completion.
+type Completion struct {
+	Text string `json:"text"`
+}
+
+// CreateCompletion creates a completion.
+func (c *Client) CreateCompletion(ctx context.Context, r *CompletionRequest) (*Completion, error) {
+	resp, err := c.createCompletion(ctx, &completionPayload{
+		Prompt: r.Prompt,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Completion{
+		Text: resp.Response,
+	}, nil
+}

--- a/llms/local/localllm.go
+++ b/llms/local/localllm.go
@@ -1,0 +1,61 @@
+package local
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/local/internal/localclient"
+)
+
+const localLLMBinVarName = "LOCAL_LLM_BIN"
+const localLLMArgsVarName = "LOCAL_LLM_ARGS"
+
+var ErrEmptyResponse = errors.New("no response")
+var ErrMissingBin = errors.New("missing the local LLM binary path, set the LOCAL_LLM_BIN environment variable")
+
+type LLM struct {
+	client *localclient.Client
+}
+
+var _ llms.LLM = (*LLM)(nil)
+
+func (o *LLM) Call(prompt string) (string, error) {
+	r, err := o.Generate([]string{prompt})
+	if err != nil {
+		return "", err
+	}
+	if len(r) == 0 {
+		return "", ErrEmptyResponse
+	}
+	return r[0].Text, nil
+}
+
+func (o *LLM) Generate(prompts []string) ([]*llms.Generation, error) {
+	result, err := o.client.CreateCompletion(context.TODO(), &localclient.CompletionRequest{
+		Prompt: prompts[0],
+	})
+	if err != nil {
+		return nil, err
+	}
+	return []*llms.Generation{
+		{Text: result.Text},
+	}, nil
+}
+
+func New() (*LLM, error) {
+	// Require the user to set the path to the local LLM binary
+	binPath := os.Getenv(localLLMBinVarName)
+	if binPath == "" {
+		return nil, ErrMissingBin
+	}
+
+	// Allow the user to pass CLI arguments to the local LLM binary (optional)
+	args := os.Getenv(localLLMArgsVarName)
+
+	c, err := localclient.New(binPath, args)
+	return &LLM{
+		client: c,
+	}, err
+}


### PR DESCRIPTION
This implements support for local LLMs.

Tested with various local completion/chat engines.

```
╰─ 〉LOCAL_LLM_BIN="/path/to/alpaca/chat" LOCAL_LLM_ARGS="-m /path/to/alpaca/ggml-alpaca-7b-q4.bin -p" go run .
A square has four equal sides, so it has 4 sides in total.
```

You can test with any local binary if you don't have a local LLM set up on your machine.

For example, `LOCAL_LLM_BIN="/usr/bin/say" LOCAL_LLM_ARGS="-v 'Good News'" go run main.go` works on macOS.