### PR TITLE
docs: added Pull Request template and improved CONTRIBUTING.md

### DIFF
--- a/.github /PULL_REQUEST_TEMPLATE.md
+++ b/.github /PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,14 @@
 - [ ] Name your Pull Request title clearly and concisely, prefixed the type of changes you made according to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). (such as `feat: added memory support` or `docs: updated memory module documentations`)
 - [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
 - [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
-- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
+- [ ] Contains test coverage for new functions
+- [ ] Passes all golangci-lint checks
+
+<!-- if you are introducing new concepts -->
+<!--
+- [ ] Describes source of new concepts.
+- [ ] References existing implementations as appropriate.
+-->
 
 ---
 

--- a/.github /PULL_REQUEST_TEMPLATE.md
+++ b/.github /PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@
 
 - [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
 - [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
+- [ ] Name your Pull Request title clearly and concisely, prefixed the type of changes you made according to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). (such as `feat: added memory support` or `docs: updated memory module documentations`)
 - [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
 - [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
 - [ ] Ideally, include relevant tests that fail without this PR but pass with it.

--- a/.github /PULL_REQUEST_TEMPLATE.md
+++ b/.github /PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 - [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
 - [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
-- [ ] Name your Pull Request title clearly and concisely, prefixed the type of changes you made according to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). (such as `feat: added memory support` or `docs: updated memory module documentations`)
+- [ ] - Name your Pull Request title clearly, concisely, and prefixed with the name of primarily affected package you changed according to [Go Contribute Guideline](https://go.dev/doc/contribute#commit_messages). (such as `memory: added interfaces` or `util: added helpers`)
 - [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
 - [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
 - [ ] Contains test coverage for new functions

--- a/.github /PULL_REQUEST_TEMPLATE.md
+++ b/.github /PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!-- Thank you for contributing! -->
+
+### Before submitting the PR, please make sure you do the following
+
+- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
+- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
+- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
+- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
+- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
+
+---
+
+### Description
+
+<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
+
+### Additional context
+
+<!-- e.g. is there anything you'd like reviewers to focus on? -->

--- a/.github /PULL_REQUEST_TEMPLATE.md
+++ b/.github /PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,5 @@
 <!-- Thank you for contributing! -->
 
-### Before submitting the PR, please make sure you do the following
-
-- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
-- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
-- [ ] - Name your Pull Request title clearly, concisely, and prefixed with the name of primarily affected package you changed according to [Go Contribute Guideline](https://go.dev/doc/contribute#commit_messages). (such as `memory: added interfaces` or `util: added helpers`)
-- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
-- [ ] Contains test coverage for new functions
-- [ ] Passes all golangci-lint checks
-
-<!-- if you are introducing new concepts -->
-<!--
-- [ ] Describes source of new concepts.
-- [ ] References existing implementations as appropriate.
--->
-
----
-
 ### Description
 
 <!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
@@ -25,3 +7,17 @@
 ### Additional context
 
 <!-- e.g. is there anything you'd like reviewers to focus on? -->
+
+---
+
+### PR Checklist
+
+- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
+- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
+- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of primarily affected package you changed according to [Go Contribute](https://go.dev/doc/contribute#commit_messages) (such as `memory: added interfaces` or `util: added helpers`).
+- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
+- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
+- [ ] Describes source of new concepts.
+- [ ] References existing implementations as appropriate.
+- [ ] Contains test coverage for new functions.
+- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ Commit the changes once you are happy with them. Don't forget to self-review to 
 #### Pull Request
 
 When you're finished with the changes, create a pull request, also known as a PR.
-- Name your Pull Request title clearly and concisely, prefixed the type of changes you made according to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). (such as `feat: added memory support` or `docs: updated memory module documentations`)
+- Name your Pull Request title clearly, concisely, and prefixed with the name of primarily affected package you changed according to [Go Contribute Guideline](https://go.dev/doc/contribute#commit_messages). (such as `memory: added interfaces` or `util: added helpers`)
 - **We strive to conceptually align with the Python and TypeScript versions of Langchain. Please link/reference the associated concepts in those codebases when introducing a new concept.**
 - Fill the "Ready for review" template so that we can review your PR. This template helps reviewers understand your changes as well as the purpose of your pull request.
 - Don't forget to [link PR to issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) if you are solving one.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,11 +148,12 @@ Commit the changes once you are happy with them. Don't forget to self-review to 
 #### Pull Request
 
 When you're finished with the changes, create a pull request, also known as a PR.
+- Name your Pull Request title clearly and concisely with the types of changes you made prefixed according to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). (such as `feat: added memory support` or `docs: updated memory module documentations`)
 - **We strive to conceptually align with the Python and TypeScript versions of Langchain. Please link/reference the associated concepts in those codebases when introducing a new concept.**
 - Fill the "Ready for review" template so that we can review your PR. This template helps reviewers understand your changes as well as the purpose of your pull request.
 - Don't forget to [link PR to issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) if you are solving one.
 - Enable the checkbox to [allow maintainer edits](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) so the branch can be updated for a merge.
-Once you submit your PR, a Docs team member will review your proposal. We may ask questions or request additional information.
+Once you submit your PR, a team member will review your proposal. We may ask questions or request additional information.
 - We may ask for changes to be made before a PR can be merged, either using [suggested changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request) or pull request comments. You can apply suggested changes directly through the UI. You can make any other changes in your fork, then commit them to your branch.
 - As you update your PR and apply changes, mark each conversation as [resolved](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/commenting-on-a-pull-request#resolving-conversations).
 - If you run into any merge issues, checkout this [git tutorial](https://github.com/skills/resolve-merge-conflicts) to help you resolve merge conflicts and other issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ Commit the changes once you are happy with them. Don't forget to self-review to 
 #### Pull Request
 
 When you're finished with the changes, create a pull request, also known as a PR.
-- Name your Pull Request title clearly and concisely with the types of changes you made prefixed according to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). (such as `feat: added memory support` or `docs: updated memory module documentations`)
+- Name your Pull Request title clearly and concisely, prefixed the type of changes you made according to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). (such as `feat: added memory support` or `docs: updated memory module documentations`)
 - **We strive to conceptually align with the Python and TypeScript versions of Langchain. Please link/reference the associated concepts in those codebases when introducing a new concept.**
 - Fill the "Ready for review" template so that we can review your PR. This template helps reviewers understand your changes as well as the purpose of your pull request.
 - Don't forget to [link PR to issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) if you are solving one.


### PR DESCRIPTION
### Description

I found out PR titles were often hard to understand and navigate, and PR descriptions were often missing or just not following a stable or readable pattern when developers organizing it. So I added the `.github /PULL_REQUEST_TEMPLATE.md` to help everyone get more clear about how to write and what to write obviously when they submitting the PR.

- Added `.github /PULL_REQUEST_TEMPLATE.md` for Pull Request template
- Tweaked the `CONTRIBUTING.md` file to state out the PR title requirements, removed unnecessary terms in `CONTRIBUTING.md`