### PR TITLE
chore: improve code qualities and use idiomatic way to implementation

### DIFF
--- a/exp/memory/memory.go
+++ b/exp/memory/memory.go
@@ -55,10 +55,8 @@ func getBufferString(messages []schema.ChatMessage, humanPrefix, aiPrefix string
 		switch message := messages[i].(type) {
 		case schema.AiChatMessage:
 			role = aiPrefix
-			break
 		case schema.HumanChatMessage:
 			role = humanPrefix
-			break
 		default:
 			role = message.GetType()
 

--- a/exp/textSplitters/textSpliters.go
+++ b/exp/textSplitters/textSpliters.go
@@ -2,6 +2,7 @@ package textSplitters
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/tmc/langchaingo/exp/schema"
@@ -119,7 +120,7 @@ func MergeSplits(splits []string, separator string, chunkSize int, chunkOverlap 
 	for _, split := range splits {
 		if total+len(split) > chunkSize {
 			if total > chunkSize+chunkOverlap {
-				fmt.Printf("Warning: created a chunk with size of %v, which is longer then the specified %v\n", total, chunkSize+chunkOverlap)
+				log.Printf("[WARN] created a chunk with size of %v, which is longer then the specified %v\n", total, chunkSize+chunkOverlap)
 			}
 
 			if len(currentDoc) > 0 {

--- a/exp/vectorStores/pinecone/internal/pineconeClient/createIndex.go
+++ b/exp/vectorStores/pinecone/internal/pineconeClient/createIndex.go
@@ -1,9 +1,11 @@
 package pineconeClient
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
+	"net/http"
 )
 
 var ErrIndexExists = errors.New("Index of given name already exists.")
@@ -31,19 +33,18 @@ func (c Client) createIndex() error {
 	if err != nil {
 		return err
 	}
-
-	if statusCode == 201 {
+	if statusCode == http.StatusCreated {
 		return nil
 	}
-
-	if statusCode == 409 {
+	if statusCode == http.StatusConflict {
 		return ErrIndexExists
 	}
 
-	errMessage, err := ioutil.ReadAll(body)
+	errBuf := new(bytes.Buffer)
+	_, err = io.Copy(errBuf, body)
 	if err != nil {
 		return fmt.Errorf("Error creating index. %s", err)
 	}
 
-	return fmt.Errorf("Error creating index. Status code: %v. %s", statusCode, errMessage)
+	return fmt.Errorf("Error creating index. Status code: %v. %s", statusCode, errBuf.String())
 }

--- a/exp/vectorStores/pinecone/internal/pineconeClient/query.go
+++ b/exp/vectorStores/pinecone/internal/pineconeClient/query.go
@@ -49,7 +49,7 @@ func (c Client) Query(ctx context.Context, vector []float64, numVectors int, nam
 	}
 	defer body.Close()
 
-	if statusCode != 200 {
+	if statusCode != http.StatusOK {
 		return QueriesResponse{}, errorMessageFromErrorResponse("querying index", body)
 	}
 

--- a/exp/vectorStores/pinecone/internal/pineconeClient/upsert.go
+++ b/exp/vectorStores/pinecone/internal/pineconeClient/upsert.go
@@ -1,10 +1,10 @@
 package pineconeClient
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/google/uuid"
 )
@@ -44,13 +44,14 @@ type errorResponse struct {
 	Details []detail `json:"details"`
 }
 
-func errorMessageFromErrorResponse(task string, body io.ReadCloser) error {
-	bytes, err := ioutil.ReadAll(body)
+func errorMessageFromErrorResponse(task string, body io.Reader) error {
+	buf := new(bytes.Buffer)
+	_, err := io.Copy(buf, body)
 	if err != nil {
 		return fmt.Errorf("error reading body of error message: %s", err.Error())
 	}
 
-	return fmt.Errorf("Error %s: body: %s", task, string(bytes))
+	return fmt.Errorf("Error %s: body: %s", task, buf.String())
 }
 
 func (c Client) Upsert(ctx context.Context, vectors []Vector, nameSpace string) error {


### PR DESCRIPTION
## Description

Improvements of #18 

- Removed unnecessary code
- Use `http.StatusXxx` instead of hardcoded numbers when checking http status
- Replaced incorrect use of `fmt.Printf(..)` with `log.Printf(...)` with idiomatic prefixes `[WARN]`
- Replaced incorrect use and deprecated `ioutil.ReadAll(...)` with `*bytes.Buffer` and `io.Copy(...)` for better performance