### PR TITLE
ci: Add linting, building, and testing to ci

### DIFF
--- a/.github/workflows/lint-build-test.yaml
+++ b/.github/workflows/lint-build-test.yaml
@@ -7,8 +7,9 @@ jobs:
         strategy:
             matrix:
                 version: ["1.20"]
+                os: [macos-latest, windows-latest]
 
-        runs-on: ubuntu-latest
+        runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/setup-go@v4
               with:
@@ -21,6 +22,7 @@ jobs:
               uses: golangci/golangci-lint-action@v3
               with:
                 version: v1.29
+                only-new-issues: true
 
     build-test:
         strategy:

--- a/.github/workflows/lint-build-test.yaml
+++ b/.github/workflows/lint-build-test.yaml
@@ -1,0 +1,39 @@
+name: lint-build-test
+
+on: push
+
+jobs:
+    lint:
+        strategy:
+            matrix:
+                version: ["1.20"]
+
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/setup-go@v4
+              with:
+                go-version: ${{ matrix.version }}
+                # Cache is managed by golangci-lint
+                # https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs
+                cache: false
+            - uses: actions/checkout@v3
+            - name: golangci-lint
+              uses: golangci/golangci-lint-action@v3
+              with:
+                version: v1.29
+
+    build-test:
+        strategy:
+            matrix:
+                version: ["1.20", "stable"]
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/setup-go@v4
+              with:
+                go-version: ${{ matrix.version }}
+                cache: false
+            - uses: actions/checkout@v3
+            - name: Build
+              run: go build -v ./...
+            - name: Test
+              run: go test -v ./...

--- a/.github/workflows/lint-build-test.yaml
+++ b/.github/workflows/lint-build-test.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 version: ["1.20"]
-                os: [macos-latest, windows-latest]
+                os: [ubuntu-latest]
 
         runs-on: ${{ matrix.os }}
         steps:
@@ -19,9 +19,8 @@ jobs:
                 cache: false
             - uses: actions/checkout@v3
             - name: golangci-lint
-              uses: golangci/golangci-lint-action@v3
+              uses: golangci/golangci-lint-action@v3.4.0
               with:
-                version: v1.29
                 only-new-issues: true
 
     build-test:

--- a/exp/chains/llmChain_test.go
+++ b/exp/chains/llmChain_test.go
@@ -36,7 +36,7 @@ func TestLLMChain(t *testing.T) {
 		return
 	}
 
-	result, ok := resultAny.(string)
+	result, _ := resultAny.(string)
 	result = strings.TrimSpace(result)
 
 	if result != "Paris." {

--- a/exp/vectorStores/pinecone/internal/pineconeClient/upsert.go
+++ b/exp/vectorStores/pinecone/internal/pineconeClient/upsert.go
@@ -33,17 +33,6 @@ type upsertPayload struct {
 	Namespace string   `json:"namespace"`
 }
 
-type detail struct {
-	TypeUrl string `json:"typeUrl"`
-	Value   string `json:"value"`
-}
-
-type errorResponse struct {
-	Code    int      `json:"code"`
-	Message string   `json:"message"`
-	Details []detail `json:"details"`
-}
-
 func errorMessageFromErrorResponse(task string, body io.Reader) error {
 	buf := new(bytes.Buffer)
 	_, err := io.Copy(buf, body)


### PR DESCRIPTION
**summary:** add's CI linting, building, and testing. Corrects existing lint failures.

closes https://github.com/tmc/langchaingo/issues/6