### PR TITLE
lint: adjust the line limit of funlen linter to 90

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,3 +21,11 @@ linters:
     - varnamelen
     - nlreturn
     - wrapcheck # TODO: we should probably enable this one (at least for new code).
+
+linters-settings:
+  funlen:
+    lines: 90
+
+run:
+  skip-dirs:
+    - 'exp'


### PR DESCRIPTION
Adjustments:

 - Adjusted the line limit of `funlen` linter to `90`.
 - Added `run.skip-dirs` in configuration with `exp` dir ignored


### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] ~~Describes source of new concepts.~~
- [ ] ~~References existing implementations as appropriate.~~
- [ ] ~~Contains test coverage for new functions.~~
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.