### PR TITLE
pinecone: fix panic in doRequest

### DIFF
--- a/vectorstores/pinecone/restapi.go
+++ b/vectorstores/pinecone/restapi.go
@@ -184,6 +184,9 @@ func doRequest(ctx context.Context, payload any, url, apiKey, method string) (io
 	req.Header.Set("Api-Key", apiKey)
 
 	r, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
 	return r.Body, r.StatusCode, err
 }
 


### PR DESCRIPTION
## Proposed Changes
- fix panic in pinecone doRequest() function if resp is nil
```console
[INF] storing generated embeddings in pinecone
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x40 pc=0x1014e1f28]

goroutine 1 [running]:
github.com/tmc/langchaingo/vectorstores/pinecone.doRequest({0x101706578, 0x14000192018}, {0x101673480?, 0x140004d7260?}, {0x140000421e0, 0x57}, {0x140001cd440, 0x24}, {0x1014e488f, 0x4})
	/Users/tarun/go/pkg/mod/github.com/tmc/langchaingo@v0.0.0-20230514182324-27d8b7bf4dda/vectorstores/pinecone/restapi.go:187 +0x2d8
github.com/tmc/langchaingo/vectorstores/pinecone.Store.restUpsert({{0x101705510, 0x140001a1470}, 0x0, {0x0, 0x0}, {0x1014e8331, 0x7}, {0x1014eeca2, 0xf}, {0x1014f5f94, ...}, ...}, ...)
	/Users/tarun/go/pkg/mod/github.com/tmc/langchaingo@v0.0.0-20230514182324-27d8b7bf4dda/vectorstores/pinecone/restapi.go:67 +0x2bc
github.com/tmc/langchaingo/vectorstores/pinecone.Store.AddDocuments({{0x101705510, 0x140001a1470}, 0x0, {0x0, 0x0}, {0x1014e8331, 0x7}, {0x1014eeca2, 0xf}, {0x1014f5f94, ...}, ...}, ...)
	/Users/tarun/go/pkg/mod/github.com/tmc/langchaingo@v0.0.0-20230514182324-27d8b7bf4dda/vectorstores/pinecone/pinecone.go:97 +0x3e4
main.main()
```

### caused by
- accessing response without checking error

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Describes source of new concepts.
- [ ] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
