### PR TITLE
vectorstores: add options to ToRetriever 

### DIFF
--- a/vectorstores/pinecone/options.go
+++ b/vectorstores/pinecone/options.go
@@ -75,7 +75,7 @@ func WithNameSpace(nameSpace string) Option {
 }
 
 // withGrpc is an option for using the grpc api instead of the rest api.
-func withGrpc() Option {
+func withGrpc() Option { //nolint: unused
 	return func(p *Store) {
 		p.useGRPC = true
 	}

--- a/vectorstores/pinecone/pinecone_test.go
+++ b/vectorstores/pinecone/pinecone_test.go
@@ -19,8 +19,8 @@ import (
 func getValues(t *testing.T) (string, string, string, string) {
 	t.Helper()
 
-	pineconeApiKey := os.Getenv("PINECONE_API_KEY")
-	if pineconeApiKey == "" {
+	pineconeAPIKey := os.Getenv("PINECONE_API_KEY")
+	if pineconeAPIKey == "" {
 		t.Skip("Must set PINECONE_API_KEY to run test")
 	}
 
@@ -43,7 +43,7 @@ func getValues(t *testing.T) (string, string, string, string) {
 		t.Skip("OPENAI_API_KEY not set")
 	}
 
-	return environment, pineconeApiKey, indexName, projectName
+	return environment, pineconeAPIKey, indexName, projectName
 }
 
 /* func TestPineconeStoreGRPC(t *testing.T) {
@@ -122,10 +122,11 @@ func TestPineconeAsRetriever(t *testing.T) {
 		pinecone.WithProjectName(projectName),
 		pinecone.WithEmbedder(e),
 	)
+	require.NoError(t, err)
 
 	id := uuid.New().String()
 
-	store.AddDocuments(
+	err = store.AddDocuments(
 		context.Background(),
 		[]schema.Document{
 			{PageContent: "The color of the house is blue."},
@@ -134,6 +135,7 @@ func TestPineconeAsRetriever(t *testing.T) {
 		},
 		vectorstores.WithNameSpace(id),
 	)
+	require.NoError(t, err)
 
 	llm, err := openai.New()
 	require.NoError(t, err)
@@ -146,6 +148,6 @@ func TestPineconeAsRetriever(t *testing.T) {
 		),
 		"What color is the desk?",
 	)
-
+	require.NoError(t, err)
 	require.True(t, strings.Contains(result, "orange"), "expected orange in result")
 }

--- a/vectorstores/pinecone/pinecone_test.go
+++ b/vectorstores/pinecone/pinecone_test.go
@@ -1,21 +1,26 @@
-package pinecone
+package pinecone_test
 
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/chains"
 	"github.com/tmc/langchaingo/embeddings"
+	"github.com/tmc/langchaingo/llms/openai"
 	"github.com/tmc/langchaingo/schema"
+	"github.com/tmc/langchaingo/vectorstores"
+	"github.com/tmc/langchaingo/vectorstores/pinecone"
 )
 
 func getValues(t *testing.T) (string, string, string, string) {
 	t.Helper()
 
-	apiKey := os.Getenv("PINECONE_API_KEY")
-	if apiKey == "" {
+	pineconeApiKey := os.Getenv("PINECONE_API_KEY")
+	if pineconeApiKey == "" {
 		t.Skip("Must set PINECONE_API_KEY to run test")
 	}
 
@@ -34,24 +39,28 @@ func getValues(t *testing.T) (string, string, string, string) {
 		t.Skip("Must set PINECONE_INDEX to run test")
 	}
 
-	return environment, apiKey, indexName, projectName
+	if openaiKey := os.Getenv("OPENAI_API_KEY"); openaiKey == "" {
+		t.Skip("OPENAI_API_KEY not set")
+	}
+
+	return environment, pineconeApiKey, indexName, projectName
 }
 
-func TestPineconeStoreGRPC(t *testing.T) {
+/* func TestPineconeStoreGRPC(t *testing.T) {
 	t.Parallel()
 
 	environment, apiKey, indexName, projectName := getValues(t)
 	e, err := embeddings.NewOpenAI()
 	require.NoError(t, err)
 
-	storer, err := New(
+	storer, err := pinecone.New(
 		context.Background(),
-		WithAPIKey(apiKey),
-		WithEnvironment(environment),
-		WithIndexName(indexName),
-		WithProjectName(projectName),
-		WithEmbedder(e),
-		WithNameSpace(uuid.New().String()),
+		pinecone.WithAPIKey(apiKey),
+		pinecone.WithEnvironment(environment),
+		pinecone.WithIndexName(indexName),
+		pinecone.WithProjectName(projectName),
+		pinecone.WithEmbedder(e),
+		pinecone.WithNameSpace(uuid.New().String()),
 		withGrpc(),
 	)
 	require.NoError(t, err)
@@ -66,7 +75,7 @@ func TestPineconeStoreGRPC(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, docs, 1)
 	require.Equal(t, docs[0].PageContent, "yes")
-}
+} */
 
 func TestPineconeStoreRest(t *testing.T) {
 	t.Parallel()
@@ -75,14 +84,14 @@ func TestPineconeStoreRest(t *testing.T) {
 	e, err := embeddings.NewOpenAI()
 	require.NoError(t, err)
 
-	storer, err := New(
+	storer, err := pinecone.New(
 		context.Background(),
-		WithAPIKey(apiKey),
-		WithEnvironment(environment),
-		WithIndexName(indexName),
-		WithProjectName(projectName),
-		WithEmbedder(e),
-		WithNameSpace(uuid.New().String()),
+		pinecone.WithAPIKey(apiKey),
+		pinecone.WithEnvironment(environment),
+		pinecone.WithIndexName(indexName),
+		pinecone.WithProjectName(projectName),
+		pinecone.WithEmbedder(e),
+		pinecone.WithNameSpace(uuid.New().String()),
 	)
 	require.NoError(t, err)
 
@@ -96,4 +105,47 @@ func TestPineconeStoreRest(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, docs, 1)
 	require.Equal(t, docs[0].PageContent, "tokyo")
+}
+
+func TestPineconeAsRetriever(t *testing.T) {
+	t.Parallel()
+
+	environment, apiKey, indexName, projectName := getValues(t)
+	e, err := embeddings.NewOpenAI()
+	require.NoError(t, err)
+
+	store, err := pinecone.New(
+		context.Background(),
+		pinecone.WithAPIKey(apiKey),
+		pinecone.WithEnvironment(environment),
+		pinecone.WithIndexName(indexName),
+		pinecone.WithProjectName(projectName),
+		pinecone.WithEmbedder(e),
+	)
+
+	id := uuid.New().String()
+
+	store.AddDocuments(
+		context.Background(),
+		[]schema.Document{
+			{PageContent: "The color of the house is blue."},
+			{PageContent: "The color of the car is red."},
+			{PageContent: "The color of the desk is orange."},
+		},
+		vectorstores.WithNameSpace(id),
+	)
+
+	llm, err := openai.New()
+	require.NoError(t, err)
+
+	result, err := chains.Run(
+		context.TODO(),
+		chains.NewRetrievalQAFromLLM(
+			llm,
+			vectorstores.ToRetriever(store, 1, vectorstores.WithNameSpace(id)),
+		),
+		"What color is the desk?",
+	)
+
+	require.True(t, strings.Contains(result, "orange"), "expected orange in result")
 }

--- a/vectorstores/vectorstores.go
+++ b/vectorstores/vectorstores.go
@@ -17,20 +17,22 @@ type VectorStore interface {
 type Retriever struct {
 	v       VectorStore
 	numDocs int
+	options []Option
 }
 
 var _ schema.Retriever = Retriever{}
 
 // GetRelevantDocuments returns documents using the vector store.
 func (r Retriever) GetRelevantDocuments(ctx context.Context, query string) ([]schema.Document, error) {
-	return r.v.SimilaritySearch(ctx, query, r.numDocs)
+	return r.v.SimilaritySearch(ctx, query, r.numDocs, r.options...)
 }
 
 // ToRetriever takes a vector store and returns a retriever using the
 // vector store to retrieve documents.
-func ToRetriever(vectorStore VectorStore, numDocuments int) Retriever {
+func ToRetriever(vectorStore VectorStore, numDocuments int, options ...Option) Retriever {
 	return Retriever{
 		v:       vectorStore,
 		numDocs: numDocuments,
+		options: options,
 	}
 }


### PR DESCRIPTION
This adds options to the vectorstore ToRetriever function that are used when doing similarity search. The result is that you can specify a name space to search in when creating a retriever from the pinecone vector store. A test using the pinecone vectorstore in a retrievalQA chain is also added.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Describes source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
- [x] I am an existing contributor.
