### PR TITLE
Feat(openaiclient): add Option for custom HTTP client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ coverage.out
 
 # macOS Specific
 .DS_Store
+
+.idea

--- a/llms/openai/internal/openaiclient/completions.go
+++ b/llms/openai/internal/openaiclient/completions.go
@@ -63,7 +63,7 @@ func (c *Client) createCompletion(ctx context.Context, payload *completionPayloa
 	req.Header.Set("Authorization", "Bearer "+c.token)
 
 	// Send request
-	r, err := http.DefaultClient.Do(req)
+	r, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This MR adds a variadic `Option` to the OpenAI client, allowing for future customizations. It also adds the `WithHTTPClient` option that allows setting custom HTTP clients.

Closes #90 

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Describes source of new concepts.
- [x] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
- [ ] (remove and do not use this row unless you are a trusted contributor) I am an existing
  contributor.
