### PR TITLE
Refactor(llms): simplify option handling

### DIFF
--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"context"
 	"errors"
+	"os"
 
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/openai/internal/openaiclient"
@@ -125,11 +126,10 @@ func (o *LLM) CreateEmbedding(ctx context.Context, inputTexts []string) ([][]flo
 
 // New returns a new OpenAI LLM.
 func New(opts ...Option) (*LLM, error) {
-	// Ensure options are initialized only once.
-	initOptions.Do(initOpts)
-
-	options := &options{}
-	*options = *defaultOptions // Copy default options.
+	options := &options{
+		token: os.Getenv(tokenEnvVarName),
+		model: os.Getenv(modelEnvVarName),
+	}
 
 	for _, opt := range opts {
 		opt(options)

--- a/llms/openai/openaillm_option.go
+++ b/llms/openai/openaillm_option.go
@@ -1,21 +1,8 @@
 package openai
 
-import (
-	"os"
-	"sync"
-)
-
 const (
 	tokenEnvVarName = "OPENAI_API_KEY" //nolint:gosec
 	modelEnvVarName = "OPENAI_MODEL"   //nolint:gosec
-)
-
-var (
-	// nolint: gochecknoglobals
-	initOptions sync.Once
-
-	// nolint: gochecknoglobals
-	defaultOptions *options
 )
 
 type options struct {
@@ -24,14 +11,6 @@ type options struct {
 }
 
 type Option func(*options)
-
-// initOpts initializes defaultOptions with the environment variables.
-func initOpts() {
-	defaultOptions = &options{
-		token: os.Getenv(tokenEnvVarName),
-		model: os.Getenv(modelEnvVarName),
-	}
-}
 
 // WithToken passes the OpenAI API token to the client. If not set, the token
 // is read from the OPENAI_API_KEY environment variable.


### PR DESCRIPTION
This removes unneeded code in the `llms` package: the sync.once is not needed, the default options can just be initialized in when New() is called.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Describes source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
- [x] (remove and do not use this row unless you are a trusted contributor) I am an existing
  contributor.
