### PR TITLE
feat: LocalLLM improvments, llms.CallOptions as local-llm call arguments

### DIFF
--- a/examples/huggingface-llm-example/huggingface_example.go
+++ b/examples/huggingface-llm-example/huggingface_example.go
@@ -30,12 +30,11 @@ func main() {
 	// Or override default model to another one
 	generateOptions := []llms.CallOption{
 		llms.WithModel("gpt2"),
-		//llms.WithTopK(10),
-		//llms.WithTopP(0.95),
-		//llms.WithSeed(13),
+		// llms.WithTopK(10),
+		// llms.WithTopP(0.95),
+		// llms.WithSeed(13),
 	}
 	completion, err := llm.Call(ctx, "What would be a good company name be for name a company that makes colorful socks?", generateOptions...)
-
 	// Check for errors
 	if err != nil {
 		log.Fatal(err)

--- a/examples/local-llm-example/local_llm_example.go
+++ b/examples/local-llm-example/local_llm_example.go
@@ -9,7 +9,6 @@ import (
 )
 
 func main() {
-
 	// You may instantiate a client with a default bin and args from environment variable
 	llm, err := local.New()
 	if err != nil {
@@ -29,7 +28,6 @@ func main() {
 
 	// By default, library will use default bin and args
 	completion, err := llm.Call(ctx, "How many sides does a square have?")
-
 	// Or append to default args options from global llms.Options
 	//generateOptions := []llms.CallOption{
 	//	llms.WithTopK(10),
@@ -38,7 +36,6 @@ func main() {
 	//}
 	// In that case command will look like: /path/to/bin --arg1=value1 --arg2=value2 --top_k=10 --top_p=0.95 --seed=13 "How many sides does a square have?"
 	//completion, err := llm.Call(ctx, "How many sides does a square have?", generateOptions...)
-
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/local-llm-example/local_llm_example.go
+++ b/examples/local-llm-example/local_llm_example.go
@@ -9,12 +9,36 @@ import (
 )
 
 func main() {
+
+	// You may instantiate a client with a default bin and args from environment variable
 	llm, err := local.New()
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Or instantiate a client with a custom bin and args options
+	//clientOptions := []local.Option{
+	//	local.WithBin("/usr/bin/echo"),
+	//	local.WithArgs("--arg1=value1 --arg2=value2"),
+	//	local.WithGlobalAsArgs(), // build key-value arguments from global llms.Options, then append to args
+	//}
+	//llm, err := local.New(clientOptions...)
+
+	// Init context
 	ctx := context.Background()
+
+	// By default, library will use default bin and args
 	completion, err := llm.Call(ctx, "How many sides does a square have?")
+
+	// Or append to default args options from global llms.Options
+	//generateOptions := []llms.CallOption{
+	//	llms.WithTopK(10),
+	//	llms.WithTopP(0.95),
+	//	llms.WithSeed(13),
+	//}
+	// In that case command will look like: /path/to/bin --arg1=value1 --arg2=value2 --top_k=10 --top_p=0.95 --seed=13 "How many sides does a square have?"
+	//completion, err := llm.Call(ctx, "How many sides does a square have?", generateOptions...)
+
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/llms/local/internal/localclient/completions.go
+++ b/llms/local/internal/localclient/completions.go
@@ -3,6 +3,7 @@ package localclient
 import (
 	"context"
 	"os/exec"
+	"strconv"
 )
 
 type completionPayload struct {
@@ -15,10 +16,10 @@ type completionResponsePayload struct {
 
 func (c *Client) createCompletion(ctx context.Context, payload *completionPayload) (*completionResponsePayload, error) {
 	// Append the prompt to the args
-	c.args = append(c.args, payload.Prompt)
+	c.Args = append(c.Args, strconv.Quote(payload.Prompt))
 
 	// #nosec G204
-	out, err := exec.CommandContext(ctx, c.binPath, c.args...).Output()
+	out, err := exec.CommandContext(ctx, c.BinPath, c.Args...).Output()
 	if err != nil {
 		return nil, err
 	}

--- a/llms/local/internal/localclient/localclient.go
+++ b/llms/local/internal/localclient/localclient.go
@@ -10,13 +10,14 @@ var ErrEmptyResponse = errors.New("empty response")
 
 // Client is a client for a local LLM.
 type Client struct {
-	binPath string
-	args    []string
+	BinPath      string
+	Args         []string
+	GlobalAsArgs bool
 }
 
 // New returns a new local client.
-func New(binPath string, args ...string) (*Client, error) {
-	c := &Client{binPath: binPath, args: args}
+func New(binPath string, globalAsArgs bool, args ...string) (*Client, error) {
+	c := &Client{BinPath: binPath, GlobalAsArgs: globalAsArgs, Args: args}
 	return c, nil
 }
 

--- a/llms/local/localllm.go
+++ b/llms/local/localllm.go
@@ -90,7 +90,6 @@ func (o *LLM) Generate(ctx context.Context, prompts []string, options ...llms.Ca
 
 // New creates a new local LLM implementation.
 func New(opts ...Option) (*LLM, error) {
-
 	options := &options{
 		bin:  os.Getenv(localLLMBinVarName),
 		args: os.Getenv(localLLMArgsVarName),

--- a/llms/local/localllm_option.go
+++ b/llms/local/localllm_option.go
@@ -1,0 +1,40 @@
+package local
+
+const (
+	// The name of the environment variable that contains the path to the local LLM binary.
+	localLLMBinVarName = "LOCAL_LLM_BIN"
+	// The name of the environment variable that contains the CLI arguments to pass to the local LLM binary.
+	localLLMArgsVarName = "LOCAL_LLM_ARGS"
+)
+
+type options struct {
+	bin          string
+	args         string
+	globalAsArgs bool // build key-value arguments from global llms.Options
+}
+
+type Option func(*options)
+
+// WithBin passes the path to the local LLM binary to the client.
+// If not set, then will be used the LOCAL_LLM_BIN environment variable.
+func WithBin(bin string) Option {
+	return func(opts *options) {
+		opts.bin = bin
+	}
+}
+
+// WithArgs passes the CLI arguments to the local LLM binary.
+// If not set, then will be used the LOCAL_LLM_ARGS environment variable.
+func WithArgs(args string) Option {
+	return func(opts *options) {
+		opts.args = args
+	}
+}
+
+// WithGlobalAsArgs passes the CLI arguments to the local LLM binary
+// formed from global llms.Options.
+func WithGlobalAsArgs() Option {
+	return func(opts *options) {
+		opts.globalAsArgs = true
+	}
+}


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Describes source of new concepts.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

---

Hello! 

This PR implements the enhancements proposed in ticket #116 for the Local LLM package.

The update includes the following changes:

- The `localllm` package now includes `options`, which implement specific functions such as `WithBin`, `WithArgs`, and `WithGlobalAsArgs`.
- These new functionalities are embedded within the logic of the `localllm` package, hence, setting the environment variables `LOCAL_LLM_BIN` and `LOCAL_LLM_ARGS` is no longer mandatory - everything can now be performed programmatically.
- The most significant part of the update comes with the activation of the `WithGlobalAsArgs` option. This option compels the package to utilize specific global options of `llms.CallOption` during its operation. If an option is not set or is equal to zero, then it will not be added. The full mapping of permissible options includes:

    ```
    Temperature => --temperature
    TopP => --top_p
    TopK => --top_k
    MinLength => --min_length
    MaxLength => --max_length
    RepetitionPenalty => --repetition_penalty
    Seed => --seed
    ```
- A complete description has been added to the example for better understanding of these implementations.

Small example to to use:
```go
package main

import (
	"context"
	"fmt"
	"log"

	"github.com/tmc/langchaingo/llms"
	"github.com/tmc/langchaingo/llms/local"
)

func main() {
	clientOptions := []local.Option{
		local.WithBin("/usr/bin/echo"),
		local.WithArgs("--arg1=value1 --arg2=value2"),
		local.WithGlobalAsArgs(),
	}
	llm, err := local.New(clientOptions...)
	ctx := context.Background()

	generateOptions := []llms.CallOption{
		llms.WithTopK(10),
		llms.WithTopP(0.95),
		llms.WithSeed(13),
	}
	// In that case command will look like:
	// `/usr/bin/echo --arg1=value1 --arg2=value2 --top_k=10 --top_p=0.95 --seed=13 "How many sides does a square have?"`
	completion, err := llm.Call(ctx, "How many sides does a square have?", generateOptions...)

	if err != nil {
		log.Fatal(err)
	}
	fmt.Println(completion)
}
```

Please review these changes and let me know if you have any suggestions or questions. Looking forward to your feedback!