### PR TITLE
chains: use langauge model instead of LLM and add predict 

### DIFF
--- a/agents/conversational.go
+++ b/agents/conversational.go
@@ -35,7 +35,7 @@ type ConversationalAgent struct {
 
 var _ Agent = (*ConversationalAgent)(nil)
 
-func NewConversationalAgent(llm llms.LLM, tools []tools.Tool, opts ...CreationOption) *ConversationalAgent {
+func NewConversationalAgent(llm llms.LanguageModel, tools []tools.Tool, opts ...CreationOption) *ConversationalAgent {
 	options := conversationalDefaultOptions()
 	for _, opt := range opts {
 		opt(&options)

--- a/agents/initialize.go
+++ b/agents/initialize.go
@@ -23,7 +23,7 @@ const (
 // model, tools, agent type, and options. It returns an Executor or an error
 // if there is any issues during the creation process.
 func Initialize(
-	llm llms.LLM,
+	llm llms.LanguageModel,
 	tools []tools.Tool,
 	agentType AgentType,
 	opts ...CreationOption,

--- a/agents/mrkl.go
+++ b/agents/mrkl.go
@@ -38,7 +38,7 @@ var _ Agent = (*OneShotZeroAgent)(nil)
 // NewOneShotAgent creates a new OneShotZeroAgent with the given LLM model, tools,
 // and options. It returns a pointer to the created agent. The opts parameter
 // represents the options for the agent.
-func NewOneShotAgent(llm llms.LLM, tools []tools.Tool, opts ...CreationOption) *OneShotZeroAgent {
+func NewOneShotAgent(llm llms.LanguageModel, tools []tools.Tool, opts ...CreationOption) *OneShotZeroAgent {
 	options := mrklDefaultOptions()
 	for _, opt := range opts {
 		opt(&options)

--- a/chains/api.go
+++ b/chains/api.go
@@ -40,7 +40,7 @@ type HTTPRequester interface {
 	Get(url string) (resp *http.Response, err error)
 }
 
-// APIChain is a chain used for request api.
+// APIChain is a chain used for letting llms interact with APIs.
 type APIChain struct {
 	RequestChain *LLMChain
 	AnswerChain  *LLMChain
@@ -49,7 +49,7 @@ type APIChain struct {
 
 // NewAPIChain creates a chain that makes API calls base the docs and
 // summarizes the responses to answer a question.
-func NewAPIChain(llm llms.LLM, requester HTTPRequester) APIChain {
+func NewAPIChain(llm llms.LanguageModel, requester HTTPRequester) APIChain {
 	reqP := prompts.NewPromptTemplate(_llmAPIURLPrompt, []string{"api_docs", "question"})
 	reqC := NewLLMChain(llm, reqP)
 
@@ -63,7 +63,7 @@ func NewAPIChain(llm llms.LLM, requester HTTPRequester) APIChain {
 	}
 }
 
-// Call call api chain.
+// Call handles the inner logic of the api chain.
 // Input: api_docs, question.
 // Output: answer.
 func (a APIChain) Call(ctx context.Context, values map[string]any, opts ...ChainCallOption) (map[string]any, error) {

--- a/chains/api_test.go
+++ b/chains/api_test.go
@@ -45,7 +45,7 @@ snow_depth	Instant	meters	Snow depth on the ground
 freezinglevel_height	Instant	meters	Altitude above sea level of the 0°C level
 visibility	Instant	meters	Viewing distance in meters. Influenced by low clouds, humidity and aerosols. Maximum visibility is approximately 24 km.`
 
-func TestLLMAPI(t *testing.T) {
+func TestAPI(t *testing.T) {
 	t.Parallel()
 	if openaiKey := os.Getenv("OPENAI_API_KEY"); openaiKey == "" {
 		t.Skip("OPENAI_API_KEY not set")
@@ -57,7 +57,7 @@ func TestLLMAPI(t *testing.T) {
 	chain := NewAPIChain(llm, http.DefaultClient)
 	q := map[string]any{
 		"api_docs": MeteoDocs,
-		"question": "What is the weather of [latitude:52.52, longitude:13.419998]?",
+		"question": "What is the weather like right now in Munich, Germany in degrees Fahrenheit?",
 	}
 	result, err := Call(context.Background(), chain, q)
 	require.NoError(t, err)
@@ -66,5 +66,5 @@ func TestLLMAPI(t *testing.T) {
 	if !ok {
 		t.Fatal("expected answer to be a string")
 	}
-	require.True(t, strings.Contains(answer, "weather"), `result does not contain the keyword 'weather'`)
+	require.True(t, strings.Contains(answer, "temperature"), `result does not contain the keyword 'temperature'`)
 }

--- a/chains/errors.go
+++ b/chains/errors.go
@@ -25,7 +25,10 @@ var (
 	// a value that is not a string.
 	ErrWrongOutputTypeInRun = errors.New("run not supported in chain that returns value that is not string")
 
-	// ErrOutputNotStringInPredict is returned if the output parser in the llm chain
-	// returns a value that is not a string in the llm chain.
-	ErrOutputNotStringInPredict = errors.New("predict is not supported with a llm chain that does not return a string")
+	// ErrOutputNotStringInPredict is returned if a chain does not return a string
+	// in the predict function.
+	ErrOutputNotStringInPredict = errors.New("predict is not supported with a chain that does not return a string")
+	// ErrMultipleOutputsInPredict is returned if a chain has multiple return values
+	// in predict.
+	ErrMultipleOutputsInPredict = errors.New("predict is not supported with a chain that returns multiple values")
 )

--- a/chains/llm.go
+++ b/chains/llm.go
@@ -14,7 +14,7 @@ const _llmChainDefaultOutputKey = "text"
 
 type LLMChain struct {
 	prompt       prompts.PromptTemplate
-	llm          llms.LLM
+	llm          llms.LanguageModel
 	Memory       schema.Memory
 	OutputParser schema.OutputParser[any]
 
@@ -24,7 +24,7 @@ type LLMChain struct {
 var _ Chain = &LLMChain{}
 
 // NewLLMChain creates a new LLMChain with an llm and a prompt.
-func NewLLMChain(llm llms.LLM, prompt prompts.PromptTemplate) *LLMChain {
+func NewLLMChain(llm llms.LanguageModel, prompt prompts.PromptTemplate) *LLMChain {
 	chain := &LLMChain{
 		prompt:       prompt,
 		llm:          llm,
@@ -47,32 +47,21 @@ func (c LLMChain) Call(ctx context.Context, values map[string]any, options ...Ch
 		return nil, err
 	}
 
-	generations, err := c.llm.Generate(ctx, []string{promptValue.String()}, getLLMCallOptions(options...)...)
+	result, err := c.llm.GeneratePrompt(
+		ctx,
+		[]schema.PromptValue{promptValue},
+		getLLMCallOptions(options...)...,
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	finalOutput, err := c.OutputParser.ParseWithPrompt(generations[0].Text, promptValue)
+	finalOutput, err := c.OutputParser.ParseWithPrompt(result.Generations[0][0].Text, promptValue)
 	if err != nil {
 		return nil, err
 	}
 
 	return map[string]any{c.OutputKey: finalOutput}, nil
-}
-
-// Predict runs the chain and returns the output as a string. Returns an error
-// if the output parser in the llm chain does not return a string.
-func (c LLMChain) Predict(ctx context.Context, values map[string]any, options ...ChainCallOption) (string, error) {
-	result, err := Call(ctx, c, values, options...)
-	if err != nil {
-		return "", err
-	}
-
-	output, ok := result[c.OutputKey].(string)
-	if !ok {
-		return "", ErrOutputNotStringInPredict
-	}
-	return output, nil
 }
 
 // GetMemory returns the memory.

--- a/chains/llm_math.go
+++ b/chains/llm_math.go
@@ -42,7 +42,7 @@ type LLMMathChain struct {
 
 var _ Chain = LLMMathChain{}
 
-func NewLLMMathChain(llm llms.LLM) LLMMathChain {
+func NewLLMMathChain(llm llms.LanguageModel) LLMMathChain {
 	p := prompts.NewPromptTemplate(_llmMathPrompt, []string{"question"})
 	c := NewLLMChain(llm, p)
 	return LLMMathChain{
@@ -52,14 +52,14 @@ func NewLLMMathChain(llm llms.LLM) LLMMathChain {
 
 // Call gets relevant documents from the retriever and gives them to the combine
 // documents chain.
-func (c LLMMathChain) Call(ctx context.Context, values map[string]any, _ ...ChainCallOption) (map[string]any, error) { //nolint: lll
+func (c LLMMathChain) Call(ctx context.Context, values map[string]any, options ...ChainCallOption) (map[string]any, error) { //nolint: lll
 	question, ok := values["question"].(string)
 	if !ok {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidInputValues, ErrInputValuesWrongType)
 	}
 	output, err := Call(ctx, c.LLMChain, map[string]any{
 		"question": question,
-	})
+	}, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/chains/prompt_selector.go
+++ b/chains/prompt_selector.go
@@ -8,7 +8,7 @@ import (
 // PromptSelector is the interface for selecting a formatter depending on the
 // LLM given.
 type PromptSelector interface {
-	GetPrompt(llms.LLM) prompts.PromptTemplate
+	GetPrompt(llms.LanguageModel) prompts.PromptTemplate
 }
 
 // ConditionalPromptSelector is a formatter selector that selects a prompt
@@ -16,14 +16,14 @@ type PromptSelector interface {
 type ConditionalPromptSelector struct {
 	DefaultPrompt prompts.PromptTemplate
 	Conditionals  []struct {
-		Condition func(llms.LLM) bool
+		Condition func(llms.LanguageModel) bool
 		Prompt    prompts.PromptTemplate
 	}
 }
 
 var _ PromptSelector = ConditionalPromptSelector{}
 
-func (s ConditionalPromptSelector) GetPrompt(llm llms.LLM) prompts.PromptTemplate {
+func (s ConditionalPromptSelector) GetPrompt(llm llms.LanguageModel) prompts.PromptTemplate {
 	for _, conditional := range s.Conditionals {
 		if conditional.Condition(llm) {
 			return conditional.Prompt

--- a/chains/question_answering.go
+++ b/chains/question_answering.go
@@ -24,7 +24,7 @@ Given the new context, refine the original answer to better answer the question.
 If the context isn't useful, return the original answer.`
 
 // LoadStuffQA loads a StuffDocuments chain with default prompts for the llm chain.
-func LoadStuffQA(llm llms.LLM) StuffDocuments {
+func LoadStuffQA(llm llms.LanguageModel) StuffDocuments {
 	defaultQAPromptTemplate := prompts.NewPromptTemplate(
 		_defaultStuffQATemplate,
 		[]string{"context", "question"},
@@ -41,7 +41,7 @@ func LoadStuffQA(llm llms.LLM) StuffDocuments {
 
 // LoadRefineQA loads a refine documents chain for question answering. Inputs are
 // "question" and "input_documents".
-func LoadRefineQA(llm llms.LLM) RefineDocuments {
+func LoadRefineQA(llm llms.LanguageModel) RefineDocuments {
 	questionPrompt := prompts.NewPromptTemplate(
 		_defaultStuffQATemplate,
 		[]string{"context", "question"},

--- a/chains/refine_documents.go
+++ b/chains/refine_documents.go
@@ -57,7 +57,7 @@ func NewRefineDocuments(initialLLMChain, refineLLMChain *LLMChain) RefineDocumen
 }
 
 // Call handles the inner logic of the refine documents chain.
-func (c RefineDocuments) Call(ctx context.Context, values map[string]any, _ ...ChainCallOption) (map[string]any, error) { //nolint:lll
+func (c RefineDocuments) Call(ctx context.Context, values map[string]any, options ...ChainCallOption) (map[string]any, error) { //nolint:lll
 	// Get the documents to be combined.
 	docs, ok := values[c.InputKey].([]schema.Document)
 	if !ok {
@@ -81,7 +81,7 @@ func (c RefineDocuments) Call(ctx context.Context, values map[string]any, _ ...C
 	if err != nil {
 		return nil, err
 	}
-	response, err := c.LLMChain.Predict(ctx, initialInputs)
+	response, err := Predict(ctx, c.LLMChain, initialInputs, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (c RefineDocuments) Call(ctx context.Context, values map[string]any, _ ...C
 		if err != nil {
 			return nil, err
 		}
-		response, err = c.RefineLLMChain.Predict(ctx, refineInputs)
+		response, err = Predict(ctx, c.RefineLLMChain, refineInputs, options...)
 		if err != nil {
 			return nil, err
 		}

--- a/chains/retrival_qa.go
+++ b/chains/retrival_qa.go
@@ -50,7 +50,7 @@ func NewRetrievalQA(combineDocumentsChain Chain, retriever schema.Retriever) Ret
 
 // NewRetrievalQAFromLLM loads a question answering combine documents chain
 // from the llm and creates a new retrievalQA chain.
-func NewRetrievalQAFromLLM(llm llms.LLM, retriever schema.Retriever) RetrievalQA {
+func NewRetrievalQAFromLLM(llm llms.LanguageModel, retriever schema.Retriever) RetrievalQA {
 	return NewRetrievalQA(
 		LoadStuffQA(llm),
 		retriever,

--- a/chains/stuff_documents.go
+++ b/chains/stuff_documents.go
@@ -51,7 +51,7 @@ func NewStuffDocuments(llmChain *LLMChain) StuffDocuments {
 }
 
 // Call handles the inner logic of the StuffDocuments chain.
-func (c StuffDocuments) Call(ctx context.Context, values map[string]any, _ ...ChainCallOption) (map[string]any, error) { //nolint: lll
+func (c StuffDocuments) Call(ctx context.Context, values map[string]any, options ...ChainCallOption) (map[string]any, error) { //nolint: lll
 	docs, ok := values[c.InputKey].([]schema.Document)
 	if !ok {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidInputValues, ErrInputValuesWrongType)
@@ -68,7 +68,7 @@ func (c StuffDocuments) Call(ctx context.Context, values map[string]any, _ ...Ch
 	}
 
 	inputValues[c.DocumentVariableName] = text
-	return Call(ctx, c.LLMChain, inputValues)
+	return Call(ctx, c.LLMChain, inputValues, options...)
 }
 
 // GetMemory returns a simple memory.

--- a/chains/summarization.go
+++ b/chains/summarization.go
@@ -28,7 +28,7 @@ REFINED SUMMARY:`
 
 // LoadStuffSummarization loads a summarization chain that stuffs all documents
 // given into the prompt.
-func LoadStuffSummarization(llm llms.LLM) StuffDocuments {
+func LoadStuffSummarization(llm llms.LanguageModel) StuffDocuments {
 	llmChain := NewLLMChain(llm, prompts.NewPromptTemplate(
 		_stuffSummarizationTemplate, []string{"context"},
 	))
@@ -38,7 +38,7 @@ func LoadStuffSummarization(llm llms.LLM) StuffDocuments {
 
 // LoadRefineSummarization loads a refine documents chain for summarization of
 // documents.
-func LoadRefineSummarization(llm llms.LLM) RefineDocuments {
+func LoadRefineSummarization(llm llms.LanguageModel) RefineDocuments {
 	llmChain := NewLLMChain(llm, prompts.NewPromptTemplate(
 		_stuffSummarizationTemplate, []string{"context"},
 	))


### PR DESCRIPTION
This changes the chains and agents packages to use the language model interface instead of the LLM interface so that chat models can be used. The predict function is also added to execute chains that returns a single string. The function exists in the python and typescript version.
https://github.com/hwchase17/langchain/blob/afc292e58d768d96245272ebe7d985f72b03da73/langchain/chains/llm.py

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
