### PR TITLE
vectorstores: add error handling of weaviate.Get() function

### DIFF
--- a/vectorstores/weaviate/weaviate.go
+++ b/vectorstores/weaviate/weaviate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -170,6 +171,14 @@ func (s Store) SimilaritySearch(
 }
 
 func (s Store) parseDocumentsByGraphQLResponse(res *models.GraphQLResponse) ([]schema.Document, error) {
+	if len(res.Errors) > 0 {
+		messages := make([]string, 0, len(res.Errors))
+		for _, e := range res.Errors {
+			messages = append(messages, e.Message)
+		}
+		return nil, fmt.Errorf("%w: %s", ErrInvalidResponse, strings.Join(messages, ", "))
+	}
+
 	data, ok := res.Data["Get"].(map[string]any)[s.indexName]
 	if !ok || data == nil {
 		return nil, ErrEmptyResponse


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

### Description
Hello,
I have added error handling when fetching data in Weaviate.

For example, including a property name in the search that is not pre-defined in Weaviate will result in a panic.
I have modified this so that it does not cause a panic, but instead returns an error.