### PR TITLE
textsplitter: allow configuration of RecursiveCharacter

### DIFF
--- a/textsplitter/options.go
+++ b/textsplitter/options.go
@@ -1,0 +1,32 @@
+package textsplitter
+
+// Option is a function that configures Options.
+type Option func(*Options)
+
+// Options is a set of options for configuring a text splitter.
+type Options struct {
+	Separators   []string
+	ChunkSize    int
+	ChunkOverlap int
+}
+
+// WithSeparators is an option for setting the separators.
+func WithSeparators(separators []string) Option {
+	return func(o *Options) {
+		o.Separators = separators
+	}
+}
+
+// WithChunkSize is an option for setting the chunk size.
+func WithChunkSize(size int) Option {
+	return func(o *Options) {
+		o.ChunkSize = size
+	}
+}
+
+// WithChunkSize is an option for setting the chunk overlap.
+func WithChunkOverlap(overlap int) Option {
+	return func(o *Options) {
+		o.ChunkOverlap = overlap
+	}
+}

--- a/textsplitter/recursive_character.go
+++ b/textsplitter/recursive_character.go
@@ -15,11 +15,20 @@ type RecursiveCharacter struct {
 // NewRecursiveCharacter creates a new recursive character splitter with default values. By
 // default the separators used are "\n\n", "\n", " " and "". The chunk size is set to 4000
 // and chunk overlap is set to 200.
-func NewRecursiveCharacter() RecursiveCharacter {
-	return RecursiveCharacter{
+func NewRecursiveCharacter(options ...Option) RecursiveCharacter {
+	opts := &Options{
 		Separators:   []string{"\n\n", "\n", " ", ""},
 		ChunkSize:    _defaultChunkSize,
 		ChunkOverlap: _defaultChunkOverlap,
+	}
+	for _, o := range options {
+		o(opts)
+	}
+
+	return RecursiveCharacter{
+		Separators:   opts.Separators,
+		ChunkSize:    opts.ChunkSize,
+		ChunkOverlap: opts.ChunkOverlap,
 	}
 }
 

--- a/textsplitter/recursive_character_test.go
+++ b/textsplitter/recursive_character_test.go
@@ -90,10 +90,9 @@ Bye!
 			},
 		},
 	}
-	splitter := NewRecursiveCharacter()
+
 	for _, tc := range testCases {
-		splitter.ChunkOverlap = tc.chunkOverlap
-		splitter.ChunkSize = tc.chunkSize
+		splitter := NewRecursiveCharacter(WithChunkOverlap(tc.chunkOverlap), WithChunkSize(tc.chunkSize))
 
 		docs, err := CreateDocuments(splitter, []string{tc.text}, nil)
 		assert.NoError(t, err)


### PR DESCRIPTION
### Description
Think it'll be helpful to allow clients to configure text splitters while keeping some of the sane defaults in place. I recently had to configure `ChunkSize` and `ChunkOverlap` but couldn't do so without manually creating a `RecursiveCharacter`:
```go
rc := textsplitter.RecursiveCharacter{
		Separators:   []string{"\n\n", "\n", " ", ""},
		ChunkSize:    1024,
		ChunkOverlap: 0,
}
```

I've tried to follow the patterns we have for functional options in other packages.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
