### PR TITLE
tools/duckduckgo: fix for response status 403 and 302

### DIFF
--- a/tools/duckduckgo/ddg.go
+++ b/tools/duckduckgo/ddg.go
@@ -14,10 +14,9 @@ type Tool struct {
 
 var _ tools.Tool = Tool{}
 
-func New() (*Tool, error) {
-	maxResults := 5
+func New(maxResults int, userAgent string) (*Tool, error) {
 	return &Tool{
-		client: internal.New(maxResults),
+		client: internal.New(maxResults, userAgent),
 	}, nil
 }
 


### PR DESCRIPTION
- Adding a `user-agent` fixes `403` response status which seems to happen randomly.
- Adding a subdomain `html` to the search url to avoid a redirect (`302` response status).
- Also: accepting the `maxResults` and `userAgent` via the `New` func.

You can test the redirects with curl:

```
curl -sf -o /dev/null -D - 'https://duckduckgo.com/html/?q=olivia%20wilde' | grep 'HTTP\|ocation'
HTTP/2 302
location: https://html.duckduckgo.com/html/?q=olivia%20wilde
```
vs
```
curl -sf -o /dev/null -D - 'https://html.duckduckgo.com/html/?q=olivia%20wilde' | grep 'HTTP\|ocation'
HTTP/2 200
```

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
