### PR TITLE
feature: map rerank chain

### DIFF
--- a/chains/chains.go
+++ b/chains/chains.go
@@ -8,6 +8,9 @@ import (
 	"github.com/tmc/langchaingo/schema"
 )
 
+// Key name used to store the intermediate steps in the output, when configured.
+const _intermediateStepsOutputKey = "intermediateSteps"
+
 // Chain is the interface all chains must implement.
 type Chain interface {
 	// Call runs the logic of the chain and returns the output. This method should

--- a/chains/map_reduce.go
+++ b/chains/map_reduce.go
@@ -9,8 +9,6 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-const _intermediateStepsOutputKey = "intermediateSteps"
-
 // MapReduceDocuments is a chain that combines documents by mapping a chain over them, then
 // combining the results using another chain.
 type MapReduceDocuments struct {

--- a/chains/map_rerank_documents.go
+++ b/chains/map_rerank_documents.go
@@ -1,0 +1,190 @@
+package chains
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/tmc/langchaingo/memory"
+	"github.com/tmc/langchaingo/outputparser"
+	"github.com/tmc/langchaingo/schema"
+	"golang.org/x/exp/maps"
+)
+
+const (
+	_mapRerankDocumentsDefaultDocumentTemplate = "{{.page_content}}"
+	_mapRerankDocumentsDefaultRankKey          = "score"
+	_mapRerankDocumentsDefaultAnswerKey        = "answer"
+)
+
+type MapRerankDocuments struct {
+	// Chain used to rerank the documents.
+	LLMChain *LLMChain
+
+	// Number of workers to concurrently run apply on documents.
+	MaxConcurrentWorkers int
+
+	// The input variable where the documents should be placed int the LLMChain.
+	LLMChainInputVariableName string
+
+	// The name of the document variable in the LLMChain.
+	DocumentVariableName string
+	// Key used to access document inputs.
+	InputKey string
+	// Key used to access map results.
+	OutputKey string
+
+	// Key used for comparison to sort documents.
+	RankKey string
+
+	// Key used to return the answer.
+	AnswerKey string
+
+	// When true, the intermediate steps of the map rerank are returned.
+	ReturnIntermediateSteps bool
+}
+
+var _ Chain = MapRerankDocuments{}
+
+// NewMapRerankDocuments creates a new map rerank documents chain.
+func NewMapRerankDocuments(mapRerankLLMChain *LLMChain) MapRerankDocuments {
+	mapRerankRE := `\s*(?P<answer>.*?)\nScore: (?P<score>.*)`
+	mapRerankLLMChain.OutputParser = outputparser.NewRegexParser(mapRerankRE)
+
+	return MapRerankDocuments{
+		LLMChain:                  mapRerankLLMChain,
+		MaxConcurrentWorkers:      1,
+		LLMChainInputVariableName: _combineDocumentsDefaultDocumentVariableName,
+		DocumentVariableName:      _combineDocumentsDefaultDocumentVariableName,
+		InputKey:                  _combineDocumentsDefaultInputKey,
+		OutputKey:                 _combineDocumentsDefaultOutputKey,
+		RankKey:                   _mapRerankDocumentsDefaultRankKey,
+		AnswerKey:                 _mapRerankDocumentsDefaultAnswerKey,
+	}
+}
+
+// Call handles the inner logic of the MapRerankDocuments chain.
+func (c MapRerankDocuments) Call(ctx context.Context, values map[string]any, options ...ChainCallOption) (map[string]any, error) { //nolint:lll
+	// Get the documents from the input key.
+	docs, ok := values[c.InputKey].([]schema.Document)
+
+	if !ok {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidInputValues, ErrInputValuesWrongType)
+	}
+
+	if len(docs) == 0 {
+		return nil, fmt.Errorf("%w: documents slice has no elements", ErrInvalidInputValues)
+	}
+
+	applyInputs := c.getApplyInputs(values, docs)
+	mapResults, err := Apply(ctx, c.LLMChain, applyInputs, c.MaxConcurrentWorkers, options...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// create a slice of outputs to return after sorting the ranks.
+	outputs := make([]map[string]any, len(mapResults))
+
+	for i, res := range mapResults {
+		output := c.parseMapResults(res[c.LLMChain.OutputKey].(map[string]string))
+		if err != nil {
+			return nil, ErrInvalidOutputValues
+		}
+
+		outputs[i] = output
+	}
+
+	sort.Slice(outputs, func(i, j int) bool {
+		curr, err := strconv.Atoi(outputs[i][c.RankKey].(string))
+		if err != nil {
+			return false
+		}
+
+		compare, err := strconv.Atoi(outputs[j][c.RankKey].(string))
+		if err != nil {
+			return true
+		}
+
+		return curr > compare
+	})
+
+	return c.formatOutputs(outputs), nil
+}
+
+// getInputVariable returns the input variable name to use for the LLM chain.
+func (c MapRerankDocuments) getInputVariable(givenInputName string, chainInputVariables []string) string {
+	if len(chainInputVariables) == 1 {
+		return chainInputVariables[0]
+	}
+
+	return givenInputName
+}
+
+// getApplyInputs returns the inputs to use for the apply call.
+func (c MapRerankDocuments) getApplyInputs(values map[string]any, docs []schema.Document) []map[string]any {
+	llmChainInputVariable := c.getInputVariable(c.LLMChainInputVariableName, c.LLMChain.GetInputKeys())
+	inputs := make([]map[string]any, 0, len(docs))
+	for _, d := range docs {
+		curInput := c.copyInputValuesWithoutInputKey(values)
+		curInput[llmChainInputVariable] = d.PageContent
+		inputs = append(inputs, curInput)
+	}
+
+	return inputs
+}
+
+// copyInputValuesWithoutInputKey copies the input values without the input key.
+func (c MapRerankDocuments) copyInputValuesWithoutInputKey(inputValues map[string]any) map[string]any {
+	inputValuesCopy := make(map[string]any)
+	maps.Copy(inputValuesCopy, inputValues)
+	delete(inputValuesCopy, c.InputKey)
+	return inputValuesCopy
+}
+
+// parseMapResults converts the map[string]string results to map[string]any to be usable by chain calls.
+func (c MapRerankDocuments) parseMapResults(inputs map[string]string) map[string]any {
+	outputs := make(map[string]any)
+
+	for i, input := range inputs {
+		outputs[i] = input
+	}
+
+	return outputs
+}
+
+// formatOutputs returns the first output and the intermediate steps, if enabled.
+func (c MapRerankDocuments) formatOutputs(outputs []map[string]any) map[string]any {
+	formattedOutputs := make(map[string]any)
+	formattedOutputs = outputs[0]
+
+	if c.ReturnIntermediateSteps {
+		formattedOutputs[_intermediateStepsOutputKey] = outputs
+	}
+
+	return formattedOutputs
+}
+
+// GetInputKeys returns the input keys for the MapRerankDocuments chain.
+func (c MapRerankDocuments) GetInputKeys() []string {
+	inputKeys := []string{c.InputKey}
+	for _, key := range c.LLMChain.GetInputKeys() {
+		if key == c.DocumentVariableName {
+			continue
+		}
+		inputKeys = append(inputKeys, key)
+	}
+
+	return inputKeys
+}
+
+// GetOutputKeys returns the output keys for the MapRerankDocuments chain.
+func (c MapRerankDocuments) GetOutputKeys() []string {
+	return []string{c.RankKey, c.AnswerKey}
+}
+
+// GetMemory returns the memory for the MapRerankDocuments chain.
+func (c MapRerankDocuments) GetMemory() schema.Memory { //nolint:ireturn
+	return memory.NewSimple()
+}

--- a/chains/map_rerank_documents.go
+++ b/chains/map_rerank_documents.go
@@ -164,9 +164,7 @@ func (c MapRerankDocuments) formatOutputs(outputs []map[string]any) map[string]a
 	formattedOutputs := make(map[string]any)
 	answerOutput := maps.Clone(outputs[0])
 
-	for _, outputKey := range c.LLMChain.GetOutputKeys() {
-		formattedOutputs[outputKey] = answerOutput[c.AnswerKey]
-	}
+	formattedOutputs[c.LLMChain.OutputKey] = answerOutput[c.AnswerKey]
 
 	if !c.ReturnIntermediateSteps {
 		return formattedOutputs

--- a/chains/map_rerank_documents.go
+++ b/chains/map_rerank_documents.go
@@ -30,8 +30,10 @@ type MapRerankDocuments struct {
 
 	// The name of the document variable in the LLMChain.
 	DocumentVariableName string
+
 	// Key used to access document inputs.
 	InputKey string
+
 	// Key used to access map results.
 	OutputKey string
 

--- a/chains/map_rerank_documents.go
+++ b/chains/map_rerank_documents.go
@@ -90,12 +90,12 @@ func (c MapRerankDocuments) Call(ctx context.Context, values map[string]any, opt
 	outputs := make([]map[string]any, len(mapResults))
 
 	for i, res := range mapResults {
-		output := c.parseMapResults(res[c.LLMChain.OutputKey].(map[string]string))
-		if err != nil {
+		rankedAnswer, ok := res[c.LLMChain.OutputKey].(map[string]string)
+		if !ok {
 			return nil, ErrInvalidOutputValues
 		}
 
-		outputs[i] = output
+		outputs[i] = c.parseMapResults(rankedAnswer)
 	}
 
 	sort.Slice(outputs, func(i, j int) bool {
@@ -158,7 +158,12 @@ func (c MapRerankDocuments) parseMapResults(inputs map[string]string) map[string
 
 // formatOutputs returns the first output and the intermediate steps, if enabled.
 func (c MapRerankDocuments) formatOutputs(outputs []map[string]any) map[string]any {
-	formattedOutputs := make(map[string]any)
+	var formattedOutputs map[string]any
+
+	if len(outputs) == 0 {
+		return nil
+	}
+
 	formattedOutputs = outputs[0]
 
 	if c.ReturnIntermediateSteps {

--- a/chains/map_rerank_documents.go
+++ b/chains/map_rerank_documents.go
@@ -81,7 +81,6 @@ func (c MapRerankDocuments) Call(ctx context.Context, values map[string]any, opt
 
 	applyInputs := c.getApplyInputs(values, docs)
 	mapResults, err := Apply(ctx, c.LLMChain, applyInputs, c.MaxConcurrentWorkers, options...)
-
 	if err != nil {
 		return nil, err
 	}

--- a/chains/map_rerank_documents_test.go
+++ b/chains/map_rerank_documents_test.go
@@ -1,0 +1,1 @@
+package chains

--- a/chains/map_rerank_documents_test.go
+++ b/chains/map_rerank_documents_test.go
@@ -52,7 +52,7 @@ func TestMapRerankDocumentsCall(t *testing.T) {
 
 	// Test that the answer cannot be processed if ReturnIntermediateSteps is true.
 	mapRerankDocumentsChain.ReturnIntermediateSteps = true
-	answer, err = Run(context.Background(), mapRerankDocumentsChain, docs)
+	_, err = Run(context.Background(), mapRerankDocumentsChain, docs)
 
 	require.Error(t, err)
 }

--- a/chains/map_rerank_documents_test.go
+++ b/chains/map_rerank_documents_test.go
@@ -1,1 +1,56 @@
 package chains
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/prompts"
+	"github.com/tmc/langchaingo/schema"
+)
+
+func TestMapRerankInputVariables(t *testing.T) {
+	t.Parallel()
+
+	mapRerankLLMChain := NewLLMChain(
+		testLanguageModel{},
+		prompts.NewPromptTemplate("{{.text}} {{.foo}}", []string{"text", "foo"}),
+	)
+
+	c := MapRerankDocuments{
+		LLMChain:                  mapRerankLLMChain,
+		DocumentVariableName:      "texts",
+		LLMChainInputVariableName: "text",
+		InputKey:                  "input",
+	}
+
+	inputKeys := c.GetInputKeys()
+	expectedLength := 3
+	require.Equal(t, expectedLength, len(inputKeys))
+}
+
+func TestMapRerankDocumentsCall(t *testing.T) {
+	mapRerankLLMChain := NewLLMChain(
+		testLanguageModel{},
+		prompts.NewPromptTemplate("{{.context}}", []string{"context"}),
+	)
+
+	docs := []schema.Document{
+		{PageContent: "Test Low\nScore: 20"},
+		{PageContent: "Test High\nScore: 100"},
+	}
+
+	mapRerankDocumentsChain := NewMapRerankDocuments(mapRerankLLMChain)
+
+	// Test that the answer is the highest scoring document.
+	answer, err := Run(context.Background(), mapRerankDocumentsChain, docs)
+
+	require.NoError(t, err)
+	require.Equal(t, "Test High", answer)
+
+	// Test that the answer cannot be processed if ReturnIntermediateSteps is true.
+	mapRerankDocumentsChain.ReturnIntermediateSteps = true
+	answer, err = Run(context.Background(), mapRerankDocumentsChain, docs)
+
+	require.Error(t, err)
+}

--- a/chains/map_rerank_documents_test.go
+++ b/chains/map_rerank_documents_test.go
@@ -55,4 +55,15 @@ func TestMapRerankDocumentsCall(t *testing.T) {
 	_, err = Run(context.Background(), mapRerankDocumentsChain, docs)
 
 	require.Error(t, err)
+
+	// Test that an error is returned if the score cannot be processed.
+	mapRerankDocumentsChain.ReturnIntermediateSteps = false
+	docs = []schema.Document{
+		{PageContent: "Test Low\nScore:"},
+		{PageContent: "Test High\nScore:"},
+	}
+
+	_, err = Run(context.Background(), mapRerankDocumentsChain, docs)
+
+	require.Error(t, err)
 }

--- a/chains/map_rerank_documents_test.go
+++ b/chains/map_rerank_documents_test.go
@@ -30,6 +30,8 @@ func TestMapRerankInputVariables(t *testing.T) {
 }
 
 func TestMapRerankDocumentsCall(t *testing.T) {
+	t.Parallel()
+
 	mapRerankLLMChain := NewLLMChain(
 		testLanguageModel{},
 		prompts.NewPromptTemplate("{{.context}}", []string{"context"}),

--- a/chains/question_answering.go
+++ b/chains/question_answering.go
@@ -40,6 +40,48 @@ QUESTION: {{.question}}
 =========
 FINAL ANSWER:`
 
+const _defaultMapRerankTemplate = `Use the following pieces of context to answer the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.
+In addition to giving an answer, also return a score of how fully it answered the user's question. This should be in the following format:
+Question: [question here]
+Helpful Answer: [answer here]
+Score: [score between 0 and 100]
+How to determine the score:
+- Higher is a better answer
+- Better responds fully to the asked question, with sufficient level of detail
+- If you do not know the answer based on the context, that should be a score of 0
+- Don't be overconfident!
+Example #1
+Context:
+---------
+Apples are red
+---------
+Question: what color are apples?
+Helpful Answer: red
+Score: 100
+Example #2
+Context:
+---------
+it was night and the witness forgot his glasses. he was not sure if it was a sports car or an suv
+---------
+Question: what type was the car?
+Helpful Answer: a sports car or an suv
+Score: 60
+Example #3
+Context:
+---------
+Pears are either red or orange
+---------
+Question: what color are apples?
+Helpful Answer: This document does not answer the question
+Score: 0
+Begin!
+Context:
+---------
+{{.context}}
+---------
+Question: {{.question}}
+Helpful Answer:`
+
 // LoadStuffQA loads a StuffDocuments chain with default prompts for the llm chain.
 func LoadStuffQA(llm llms.LanguageModel) StuffDocuments {
 	defaultQAPromptTemplate := prompts.NewPromptTemplate(
@@ -92,4 +134,17 @@ func LoadMapReduceQA(llm llms.LanguageModel) MapReduceDocuments {
 	)
 
 	return NewMapReduceDocuments(mapChain, reduceChain)
+}
+
+// LoadMapRerankQA loads a map rerank documents chain for question answering. Inputs are
+// "question" and "input_documents".
+func LoadMapRerankQA(llm llms.LanguageModel) MapRerankDocuments {
+	mapRerankPrompt := prompts.NewPromptTemplate(
+		_defaultMapRerankTemplate,
+		[]string{"context", "question"},
+	)
+
+	mapRerankLLMChain := NewLLMChain(llm, mapRerankPrompt)
+
+	return NewMapRerankDocuments(mapRerankLLMChain)
 }

--- a/chains/question_answering.go
+++ b/chains/question_answering.go
@@ -40,6 +40,7 @@ QUESTION: {{.question}}
 =========
 FINAL ANSWER:`
 
+//nolint:lll
 const _defaultMapRerankTemplate = `Use the following pieces of context to answer the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.
 In addition to giving an answer, also return a score of how fully it answered the user's question. This should be in the following format:
 Question: [question here]

--- a/chains/question_answering.go
+++ b/chains/question_answering.go
@@ -147,5 +147,7 @@ func LoadMapRerankQA(llm llms.LanguageModel) MapRerankDocuments {
 
 	mapRerankLLMChain := NewLLMChain(llm, mapRerankPrompt)
 
-	return NewMapRerankDocuments(mapRerankLLMChain)
+	mapRerank := NewMapRerankDocuments(mapRerankLLMChain)
+
+	return *mapRerank
 }

--- a/chains/question_answering_test.go
+++ b/chains/question_answering_test.go
@@ -56,6 +56,37 @@ func TestMapReduceQA(t *testing.T) {
 			"question":        "What is the name of the lion?",
 		},
 	)
+
 	require.NoError(t, err)
 	require.True(t, strings.Contains(result, "Leo"), "result does not contain correct answer Leo")
+}
+
+func TestMapRerankQA(t *testing.T) {
+	t.Parallel()
+
+	if openaiKey := os.Getenv("OPENAI_API_KEY"); openaiKey == "" {
+		t.Skip("OPENAI_API_KEY not set")
+	}
+	llm, err := openai.New()
+	require.NoError(t, err)
+
+	docs := loadTestData(t)
+	mapRerankChain := LoadMapRerankQA(llm)
+
+	results, err := Call(
+		context.Background(),
+		mapRerankChain,
+		map[string]any{
+			"input_documents": docs,
+			"question":        "What is the name of the lion?",
+		},
+	)
+
+	answer, ok := results["answer"].(string)
+	require.True(t, ok, "result does not contain answer key")
+	require.True(t, strings.Contains(answer, "Leo"), "result does not contain correct answer Leo")
+
+	score, ok := results["score"].(string)
+	require.True(t, ok, "result does not contain score key")
+	require.True(t, strings.Contains(score, "100"), "result does not score answer as 100")
 }

--- a/chains/question_answering_test.go
+++ b/chains/question_answering_test.go
@@ -82,6 +82,8 @@ func TestMapRerankQA(t *testing.T) {
 		},
 	)
 
+	require.NoError(t, err)
+
 	answer, ok := results["answer"].(string)
 	require.True(t, ok, "result does not contain answer key")
 	require.True(t, strings.Contains(answer, "Leo"), "result does not contain correct answer Leo")

--- a/chains/question_answering_test.go
+++ b/chains/question_answering_test.go
@@ -84,11 +84,7 @@ func TestMapRerankQA(t *testing.T) {
 
 	require.NoError(t, err)
 
-	answer, ok := results["answer"].(string)
-	require.True(t, ok, "result does not contain answer key")
+	answer, ok := results["text"].(string)
+	require.True(t, ok, "result does not contain text key")
 	require.True(t, strings.Contains(answer, "Leo"), "result does not contain correct answer Leo")
-
-	score, ok := results["score"].(string)
-	require.True(t, ok, "result does not contain score key")
-	require.True(t, strings.Contains(score, "100"), "result does not score answer as 100")
 }

--- a/docs/parity_matrix.md
+++ b/docs/parity_matrix.md
@@ -30,7 +30,7 @@ Please note that this page lists the current state of the LangChain Go project, 
 | Retrieval QA Chain                     | ✅     |
 | Map Reduce Combine Documents Chain     | ✅     |
 | Refine Combine Documents Chain         | ✅     |
-| Map Rerank Combine Documents Chain     | ❌ [#68](https://github.com/tmc/langchaingo/issues/68) |
+| Map Rerank Combine Documents Chain     | ✅     |
 | Chat Vector DB Chain                   | ❌     |
 | Vector DB QA Chain                     | ❌     |
 | Analyze Document Chain                 | ❌     |

--- a/outputparser/doc.go
+++ b/outputparser/doc.go
@@ -9,5 +9,7 @@ The outputparser package includes the following parsers:
     a map[string]string while validating against a provided schema.
   - CommaSeparatedList: a parser that takes a string with comma-separated values
     and returns them as a string slice.
+  - RegexParser: a parser that takes a string, compiles it into a regular expression,
+    and returns map[string]string of the regex groups.
 */
 package outputparser

--- a/outputparser/regex_parser.go
+++ b/outputparser/regex_parser.go
@@ -25,7 +25,7 @@ func NewRegexParser(expressionStr string) RegexParser {
 }
 
 // Statically assert that RegexParser implements the OutputParser interface.
-var _ schema.OutputParser[map[string]string] = RegexParser{}
+var _ schema.OutputParser[any] = RegexParser{}
 
 // GetFormatInstructions returns instructions on the expected output format.
 func (p RegexParser) GetFormatInstructions() string {
@@ -58,12 +58,12 @@ func (p RegexParser) parse(text string) (map[string]string, error) {
 }
 
 // Parse parses the output of an llm into a map of strings.
-func (p RegexParser) Parse(text string) (map[string]string, error) {
+func (p RegexParser) Parse(text string) (any, error) {
 	return p.parse(text)
 }
 
 // ParseWithPrompt does the same as Parse.
-func (p RegexParser) ParseWithPrompt(text string, _ schema.PromptValue) (map[string]string, error) {
+func (p RegexParser) ParseWithPrompt(text string, _ schema.PromptValue) (any, error) {
 	return p.parse(text)
 }
 


### PR DESCRIPTION
#68.

Relevant Documents:
- [LangChain Map Rerank](https://docs.langchain.com/docs/components/chains/index_related_chains#map-rerank).
- [Python Implementation](https://github.com/hwchase17/langchain/pull/516).

Would appreciate sanity check here, not sure I fully grok this chain. I believe this behaves similarly to its python counterpart, with some functionality provided by @FluffyKebab's `MapReduce` addition.

Changes:
- Moves `_intermediateStepsOutputKey` var to central file (out of `chains/map_reduce.go`).
- Fixes the output of the `RegexParser` so it can be used by LLM chains, updates/adds some documentation.
- Adds MapRerankDocuments functionality.


### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
