### PR TITLE
feat(outputparser): Add Regex Dict Parser

### DIFF
--- a/docs/parity_matrix.md
+++ b/docs/parity_matrix.md
@@ -83,7 +83,7 @@ Please note that this page lists the current state of the LangChain Go project, 
 | Boolean                     | ❌     |
 | Combining Parsers           | ❌     |
 | Regex                       | ✅     |
-| Regex Dictionary            | ❌     |
+| Regex Dictionary            | ✅     |
 | Comma separated list        | ✅     |
 | Parser fixer                | ❌     |
 | Retry                       | ❌     |

--- a/outputparser/doc.go
+++ b/outputparser/doc.go
@@ -11,5 +11,7 @@ The outputparser package includes the following parsers:
     and returns them as a string slice.
   - RegexParser: a parser that takes a string, compiles it into a regular expression,
     and returns map[string]string of the regex groups.
+  - RegexDict: a pareser that searches a string for values in a dictionary format,
+    and returns a map[string]string of the keys and their associated value.
 */
 package outputparser

--- a/outputparser/doc.go
+++ b/outputparser/doc.go
@@ -11,7 +11,7 @@ The outputparser package includes the following parsers:
     and returns them as a string slice.
   - RegexParser: a parser that takes a string, compiles it into a regular expression,
     and returns map[string]string of the regex groups.
-  - RegexDict: a pareser that searches a string for values in a dictionary format,
+  - RegexDict: a parser that searches a string for values in a dictionary format,
     and returns a map[string]string of the keys and their associated value.
 */
 package outputparser

--- a/outputparser/regex_dict.go
+++ b/outputparser/regex_dict.go
@@ -1,0 +1,85 @@
+package outputparser
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/tmc/langchaingo/schema"
+)
+
+// RegexParser is an output parser used to parse the output of an llm as a map.
+type RegexDict struct {
+	OutputKeyToFormat map[string]string
+	NoUpdateValue     string
+}
+
+const (
+	REGEX_DICT_PATTERN = `(?:%s):\s?(?P<value>(?:[^.'\n']*)\.?)`
+)
+
+// NewRegexParser returns a new RegexParser.
+func NewRegexDict(outputKeyToFormat map[string]string, noUpdateValue string) RegexDict {
+	return RegexDict{
+		OutputKeyToFormat: outputKeyToFormat,
+		NoUpdateValue:     noUpdateValue,
+	}
+}
+
+// Statically assert that RegexParser implements the OutputParser interface.
+var _ schema.OutputParser[any] = RegexDict{}
+
+// GetFormatInstructions returns instructions on the expected output format.
+func (p RegexDict) GetFormatInstructions() string {
+	instructions := "Your output should be a map of strings. e.g.:\n"
+	instructions += "map[string]string{\"key1\": \"value1\", \"key2\": \"value2\"}\n"
+
+	return instructions
+}
+
+func (p RegexDict) parse(text string) (map[string]string, error) {
+	results := make(map[string]string, len(p.OutputKeyToFormat))
+
+	for key, format := range p.OutputKeyToFormat {
+		expression := regexp.MustCompile(fmt.Sprintf(REGEX_DICT_PATTERN, format))
+		matches := expression.FindStringSubmatch(text)
+
+		if len(matches) < 2 {
+			return nil, ParseError{
+				Text:   text,
+				Reason: fmt.Sprintf("No match found for expression %s", expression),
+			}
+		}
+
+		if len(matches) > 2 {
+			return nil, ParseError{
+				Text:   text,
+				Reason: fmt.Sprintf("Multiple matches found for expression %s", expression),
+			}
+		}
+
+		match := matches[1]
+
+		if match == p.NoUpdateValue {
+			continue
+		}
+
+		results[key] = match
+	}
+
+	return results, nil
+}
+
+// Parse parses the output of an llm into a map of strings.
+func (p RegexDict) Parse(text string) (any, error) {
+	return p.parse(text)
+}
+
+// ParseWithPrompt does the same as Parse.
+func (p RegexDict) ParseWithPrompt(text string, _ schema.PromptValue) (any, error) {
+	return p.parse(text)
+}
+
+// Type returns the type of the parser.
+func (p RegexDict) Type() string {
+	return "regex_dict_parser"
+}

--- a/outputparser/regex_dict.go
+++ b/outputparser/regex_dict.go
@@ -14,7 +14,7 @@ type RegexDict struct {
 }
 
 const (
-	REGEX_DICT_PATTERN = `(?:%s):\s?(?P<value>(?:[^.'\n']*)\.?)`
+	regexDictPattern = `(?:%s):\s?(?P<value>(?:[^.'\n']*)\.?)`
 )
 
 // NewRegexParser returns a new RegexParser.
@@ -38,19 +38,21 @@ func (p RegexDict) GetFormatInstructions() string {
 
 func (p RegexDict) parse(text string) (map[string]string, error) {
 	results := make(map[string]string, len(p.OutputKeyToFormat))
+	// We only expect to get a single matched value pair for each output key.
+	expectedMatches := 2
 
 	for key, format := range p.OutputKeyToFormat {
-		expression := regexp.MustCompile(fmt.Sprintf(REGEX_DICT_PATTERN, format))
+		expression := regexp.MustCompile(fmt.Sprintf(regexDictPattern, format))
 		matches := expression.FindStringSubmatch(text)
 
-		if len(matches) < 2 {
+		if len(matches) < expectedMatches {
 			return nil, ParseError{
 				Text:   text,
 				Reason: fmt.Sprintf("No match found for expression %s", expression),
 			}
 		}
 
-		if len(matches) > 2 {
+		if len(matches) > expectedMatches {
 			return nil, ParseError{
 				Text:   text,
 				Reason: fmt.Sprintf("Multiple matches found for expression %s", expression),

--- a/outputparser/regex_dict.go
+++ b/outputparser/regex_dict.go
@@ -7,7 +7,7 @@ import (
 	"github.com/tmc/langchaingo/schema"
 )
 
-// RegexParser is an output parser used to parse the output of an llm as a map.
+// RegexDict is an output parser used to parse the output of an llm as a map.
 type RegexDict struct {
 	OutputKeyToFormat map[string]string
 	NoUpdateValue     string
@@ -17,7 +17,7 @@ const (
 	regexDictPattern = `(?:%s):\s?(?P<value>(?:[^.'\n']*)\.?)`
 )
 
-// NewRegexParser returns a new RegexParser.
+// NewRegexDict returns a new RegexDict.
 func NewRegexDict(outputKeyToFormat map[string]string, noUpdateValue string) RegexDict {
 	return RegexDict{
 		OutputKeyToFormat: outputKeyToFormat,
@@ -25,7 +25,7 @@ func NewRegexDict(outputKeyToFormat map[string]string, noUpdateValue string) Reg
 	}
 }
 
-// Statically assert that RegexParser implements the OutputParser interface.
+// Statically assert that RegexDict implements the OutputParser interface.
 var _ schema.OutputParser[any] = RegexDict{}
 
 // GetFormatInstructions returns instructions on the expected output format.

--- a/outputparser/regex_dict.go
+++ b/outputparser/regex_dict.go
@@ -9,8 +9,12 @@ import (
 
 // RegexDict is an output parser used to parse the output of an llm as a map.
 type RegexDict struct {
+	// OutputKeyToFormat is a map which has a key that represents an identifier for the regex,
+	// and a value to search for as a key in the parsed text.
 	OutputKeyToFormat map[string]string
-	NoUpdateValue     string
+
+	// NoUpdateValue is a string that prevents assignment to parsed outputs map when matched.
+	NoUpdateValue string
 }
 
 const (

--- a/outputparser/regex_dict_test.go
+++ b/outputparser/regex_dict_test.go
@@ -32,10 +32,12 @@ we expect the result to only contain the following fields:
 }`
 
 	testCases := []struct {
-		outputKeys map[string]string
-		expected   map[string]string
+		noUpdateValue string
+		outputKeys    map[string]string
+		expected      map[string]string
 	}{
 		{
+			noUpdateValue: "",
 			outputKeys: map[string]string{
 				"action":       "Action",
 				"action_input": "Action Input",
@@ -45,10 +47,20 @@ we expect the result to only contain the following fields:
 				"action_input": "How to use this class?",
 			},
 		},
+		{
+			noUpdateValue: "Search",
+			outputKeys: map[string]string{
+				"action":       "Action",
+				"action_input": "Action Input",
+			},
+			expected: map[string]string{
+				"action_input": "How to use this class?",
+			},
+		},
 	}
 
 	for _, tc := range testCases {
-		parser := outputparser.NewRegexDict(tc.outputKeys, "")
+		parser := outputparser.NewRegexDict(tc.outputKeys, tc.noUpdateValue)
 
 		actual, err := parser.Parse(testText)
 		if err != nil {

--- a/outputparser/regex_dict_test.go
+++ b/outputparser/regex_dict_test.go
@@ -1,0 +1,62 @@
+package outputparser_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/tmc/langchaingo/outputparser"
+)
+
+func TestRegexDict(t *testing.T) {
+	t.Parallel()
+
+	testText := `We have just received a new result from the LLM, and our next step is
+to filter and read its format using regular expressions to identify specific fields,
+such as:
+
+- Action: Search
+- Action Input: How to use this class?
+- Additional Fields: "N/A"
+
+To assist us in this task, we use the regex_dict class. This class allows us to send a
+dictionary containing an output key and the expected format, which in turn enables us to
+retrieve the result of the matching formats and extract specific information from it.
+
+To exclude irrelevant information from our return dictionary, we can instruct the LLM to
+use a specific command that notifies us when it doesn't know the answer. We call this
+variable the "no_update_value", and for our current case, we set it to "N/A". Therefore,
+we expect the result to only contain the following fields:
+{
+ {key = action, value = search}
+ {key = action_input, value = "How to use this class?"}.
+}`
+
+	testCases := []struct {
+		outputKeys map[string]string
+		expected   map[string]string
+	}{
+		{
+			outputKeys: map[string]string{
+				"action":       "Action",
+				"action_input": "Action Input",
+			},
+			expected: map[string]string{
+				"action":       "Search",
+				"action_input": "How to use this class?",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		parser := outputparser.NewRegexDict(tc.outputKeys, "")
+
+		actual, err := parser.Parse(testText)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		if !reflect.DeepEqual(actual, tc.expected) {
+			t.Errorf("Expected %v, got %v", tc.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
References:
- [langchain (python) regex dict output parser](https://github.com/hwchase17/langchain/blob/master/langchain/output_parsers/regex_dict.py).

Changes:
- Adds functionality `outputparser` `RegexDict`.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
