### PR TITLE
llm: add azure api support

### DIFF
--- a/chains/llm_azure_test.go
+++ b/chains/llm_azure_test.go
@@ -1,0 +1,41 @@
+package chains
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tmc/langchaingo/llms/openai"
+	"github.com/tmc/langchaingo/prompts"
+)
+
+func TestLLMChainAzure(t *testing.T) {
+	t.Parallel()
+	if openaiKey := os.Getenv("OPENAI_API_KEY"); openaiKey == "" {
+		t.Skip("OPENAI_API_KEY not set")
+	}
+	if openaiBase := os.Getenv("OPENAI_BASE_URL"); openaiBase == "" {
+		t.Skip("OPENAI_BASE_URL not set")
+	}
+	model, err := openai.NewAzure(openai.WithModel("gpt-35-turbo"))
+	require.NoError(t, err)
+
+	prompt := prompts.NewPromptTemplate(
+		"What is the capital of {{.country}}",
+		[]string{"country"},
+	)
+	require.NoError(t, err)
+
+	chain := NewLLMChain(model, prompt)
+
+	result, err := Predict(context.Background(), chain,
+		map[string]any{
+			"country": "France",
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, strings.Contains(result, "Paris"))
+}

--- a/chains/llm_azure_test.go
+++ b/chains/llm_azure_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"github.com/tmc/langchaingo/llms/openai"
 	"github.com/tmc/langchaingo/prompts"
 )

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -14,7 +14,6 @@ import (
 
 const (
 	defaultChatModel = "gpt-3.5-turbo"
-	defaultBaseURL   = "https://api.openai.com"
 )
 
 // ChatRequest is a request to create an embedding.
@@ -105,15 +104,12 @@ func (c *Client) createChat(ctx context.Context, payload *ChatRequest) (*ChatRes
 	if c.baseURL == "" {
 		c.baseURL = defaultBaseURL
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/v1/chat/completions", c.baseURL), body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.buildURL("/chat/completions"), body)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	if c.organization != "" {
-		req.Header.Set("OpenAI-Organization", c.organization)
-	}
+
+	c.setHeaders(req)
 
 	// Send request
 	r, err := http.DefaultClient.Do(req)

--- a/llms/openai/internal/openaiclient/completions.go
+++ b/llms/openai/internal/openaiclient/completions.go
@@ -84,20 +84,16 @@ func (c *Client) createCompletion(ctx context.Context, payload *completionPayloa
 	}
 
 	if c.baseURL == "" {
-		c.baseURL = "https://api.openai.com"
+		c.baseURL = defaultBaseURL
 	}
 
 	// Build request
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/v1/completions", c.baseURL), bytes.NewReader(payloadBytes))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.buildURL("/completions"), bytes.NewReader(payloadBytes))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	if c.organization != "" {
-		req.Header.Set("OpenAI-Organization", c.organization)
-	}
+	c.setHeaders(req)
 
 	// Send request
 	r, err := c.httpClient.Do(req)

--- a/llms/openai/internal/openaiclient/embeddings.go
+++ b/llms/openai/internal/openaiclient/embeddings.go
@@ -39,18 +39,14 @@ func (c *Client) createEmbedding(ctx context.Context, payload *embeddingPayload)
 		return nil, fmt.Errorf("marshal payload: %w", err)
 	}
 	if c.baseURL == "" {
-		c.baseURL = "https://api.openai.com"
+		c.baseURL = defaultBaseURL
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/v1/embeddings", c.baseURL), bytes.NewReader(payloadBytes))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.buildURL("/embeddings"), bytes.NewReader(payloadBytes))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	if c.organization != "" {
-		req.Header.Set("OpenAI-Organization", c.organization)
-	}
+	c.setHeaders(req)
 
 	r, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/llms/openai/internal/openaiclient/openaiclient.go
+++ b/llms/openai/internal/openaiclient/openaiclient.go
@@ -53,14 +53,11 @@ func WithHTTPClient(client Doer) Option {
 	}
 }
 
-var azureMap = map[string]string{
-	"gpt-3.5-turbo": "gpt-35-turbo",
-}
-
 // New returns a new OpenAI client.
 func New(token string, model string, baseURL string, organization string,
 	apiType APIType, apiVersion string,
-	opts ...Option) (*Client, error) {
+	opts ...Option,
+) (*Client, error) {
 	c := &Client{
 		token:        token,
 		Model:        model,
@@ -134,9 +131,6 @@ func (c *Client) CreateEmbedding(ctx context.Context, r *EmbeddingRequest) ([][]
 	if r.Model == "" {
 		r.Model = defaultEmbeddingModel
 	}
-	if len(r.Input) <= 0 {
-		return nil, ErrEmptyResponse
-	}
 
 	resp, err := c.createEmbedding(ctx, &embeddingPayload{
 		Model: r.Model,
@@ -203,7 +197,6 @@ func (c *Client) buildURL(suffix string) string {
 }
 
 func (c *Client) buildAzureURL(suffix string) string {
-
 	baseURL := c.baseURL
 	baseURL = strings.TrimRight(baseURL, "/")
 

--- a/llms/openai/internal/openaiclient/openaiclient.go
+++ b/llms/openai/internal/openaiclient/openaiclient.go
@@ -3,11 +3,25 @@ package openaiclient
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
+)
+
+const (
+	defaultBaseURL = "https://api.openai.com/v1"
 )
 
 // ErrEmptyResponse is returned when the OpenAI API returns an empty response.
 var ErrEmptyResponse = errors.New("empty response")
+
+type APIType string
+
+const (
+	APITypeOpenAI  APIType = "OPEN_AI"
+	APITypeAzure   APIType = "AZURE"
+	APITypeAzureAD APIType = "AZURE_AD"
+)
 
 // Client is a client for the OpenAI API.
 type Client struct {
@@ -15,7 +29,11 @@ type Client struct {
 	Model        string
 	baseURL      string
 	organization string
-	httpClient   Doer
+
+	apiType    APIType
+	apiVersion string // required when APIType is APITypeAzure or APITypeAzureAD
+
+	httpClient Doer
 }
 
 // Option is an option for the OpenAI client.
@@ -35,13 +53,21 @@ func WithHTTPClient(client Doer) Option {
 	}
 }
 
+var azureMap = map[string]string{
+	"gpt-3.5-turbo": "gpt-35-turbo",
+}
+
 // New returns a new OpenAI client.
-func New(token string, model string, baseURL string, organization string, opts ...Option) (*Client, error) {
+func New(token string, model string, baseURL string, organization string,
+	apiType APIType, apiVersion string,
+	opts ...Option) (*Client, error) {
 	c := &Client{
 		token:        token,
 		Model:        model,
 		baseURL:      baseURL,
 		organization: organization,
+		apiType:      apiType,
+		apiVersion:   apiVersion,
 		httpClient:   http.DefaultClient,
 	}
 
@@ -108,6 +134,9 @@ func (c *Client) CreateEmbedding(ctx context.Context, r *EmbeddingRequest) ([][]
 	if r.Model == "" {
 		r.Model = defaultEmbeddingModel
 	}
+	if len(r.Input) <= 0 {
+		return nil, ErrEmptyResponse
+	}
 
 	resp, err := c.createEmbedding(ctx, &embeddingPayload{
 		Model: r.Model,
@@ -143,4 +172,44 @@ func (c *Client) CreateChat(ctx context.Context, r *ChatRequest) (*ChatResponse,
 		return nil, ErrEmptyResponse
 	}
 	return resp, nil
+}
+
+func isAzure(apiType APIType) bool {
+	if apiType == APITypeAzure || apiType == APITypeAzureAD {
+		return true
+	}
+	return false
+}
+
+func (c *Client) setHeaders(req *http.Request) {
+	req.Header.Set("Content-Type", "application/json")
+	if isAzure(c.apiType) {
+		req.Header.Set("api-key", c.token)
+	} else {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	if c.organization != "" {
+		req.Header.Set("OpenAI-Organization", c.organization)
+	}
+}
+
+func (c *Client) buildURL(suffix string) string {
+	if isAzure(c.apiType) {
+		return c.buildAzureURL(suffix)
+	}
+
+	// open ai implement:
+	return fmt.Sprintf("%s%s", c.baseURL, suffix)
+}
+
+func (c *Client) buildAzureURL(suffix string) string {
+
+	baseURL := c.baseURL
+	baseURL = strings.TrimRight(baseURL, "/")
+
+	// azure example url:
+	// /openai/deployments/{model}/chat/completions?api-version={api_version}
+	return fmt.Sprintf("%s/openai/deployments/%s%s?api-version=%s",
+		baseURL, c.Model, suffix, c.apiVersion,
+	)
 }

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -209,6 +209,7 @@ func newClient(opts ...Option) (*openaiclient.Client, error) {
 		model:        os.Getenv(modelEnvVarName),
 		baseURL:      os.Getenv(baseURLEnvVarName),
 		organization: os.Getenv(organizationEnvVarName),
+		apiType:      APITypeOpenAI,
 	}
 
 	for _, opt := range opts {
@@ -219,5 +220,44 @@ func newClient(opts ...Option) (*openaiclient.Client, error) {
 		return nil, ErrMissingToken
 	}
 
-	return openaiclient.New(options.token, options.model, options.baseURL, options.organization)
+	return openaiclient.New(options.token, options.model, options.baseURL, options.organization,
+		openaiclient.APIType(options.apiType), "")
+}
+
+// NewAzure returns a new Azure OpenAI LLM .
+func NewAzure(opts ...Option) (*LLM, error) {
+	c, err := newAzureClient(opts...)
+	return &LLM{
+		client: c,
+	}, err
+}
+
+// NewAzureChat returns a new OpenAI chat LLM.
+func NewAzureChat(opts ...Option) (*Chat, error) {
+	c, err := newAzureClient(opts...)
+	return &Chat{
+		client: c,
+	}, err
+}
+
+func newAzureClient(opts ...Option) (*openaiclient.Client, error) {
+	options := &options{
+		token:        os.Getenv(tokenEnvVarName),
+		model:        os.Getenv(modelEnvVarName),
+		baseURL:      os.Getenv(baseURLEnvVarName),
+		organization: os.Getenv(organizationEnvVarName),
+		apiType:      APITypeAzure,
+		apiVersion:   DefaultApiVersion,
+	}
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if len(options.token) == 0 {
+		return nil, ErrMissingToken
+	}
+
+	return openaiclient.New(options.token, options.model, options.baseURL,
+		options.organization, openaiclient.APIType(options.apiType), options.apiVersion)
 }

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -247,7 +247,7 @@ func newAzureClient(opts ...Option) (*openaiclient.Client, error) {
 		baseURL:      os.Getenv(baseURLEnvVarName),
 		organization: os.Getenv(organizationEnvVarName),
 		apiType:      APITypeAzure,
-		apiVersion:   DefaultApiVersion,
+		apiVersion:   DefaultAPIVersion,
 	}
 
 	for _, opt := range opts {

--- a/llms/openai/openaillm_option.go
+++ b/llms/openai/openaillm_option.go
@@ -7,11 +7,26 @@ const (
 	organizationEnvVarName = "OPENAI_ORGANIZATION" //nolint:gosec
 )
 
+type APIType string
+
+const (
+	APITypeOpenAI  APIType = "OPEN_AI"
+	APITypeAzure   APIType = "AZURE"
+	APITypeAzureAD APIType = "AZURE_AD"
+)
+
+const (
+	DefaultApiVersion = "2023-05-15"
+)
+
 type options struct {
 	token        string
 	model        string
 	baseURL      string
 	organization string
+
+	apiType    APIType
+	apiVersion string // required when APIType is APITypeAzure or APITypeAzureAD
 }
 
 type Option func(*options)
@@ -34,7 +49,7 @@ func WithModel(model string) Option {
 
 // WithBaseURL passes the OpenAI base url to the client. If not set, the base url
 // is read from the OPENAI_BASE_URL environment variable. If still not set in ENV
-// VAR OPENAI_BASE_URL, then the default value is https://api.openai.com is used.
+// VAR OPENAI_BASE_URL, then the default value is https://api.openai.com/v1 is used.
 func WithBaseURL(baseURL string) Option {
 	return func(opts *options) {
 		opts.baseURL = baseURL
@@ -46,5 +61,21 @@ func WithBaseURL(baseURL string) Option {
 func WithOrganization(organization string) Option {
 	return func(opts *options) {
 		opts.organization = organization
+	}
+}
+
+// WithApiType passes the api type to the client. If not set, the default value
+// is APITypeOpenAI
+func WithApiType(apiType APIType) Option {
+	return func(opts *options) {
+		opts.apiType = apiType
+	}
+}
+
+// WithApiVersion passes the api version to the client. If not set, the default value
+// is DefaultApiVersion
+func WithApiVersion(apiVersion string) Option {
+	return func(opts *options) {
+		opts.apiVersion = apiVersion
 	}
 }

--- a/llms/openai/openaillm_option.go
+++ b/llms/openai/openaillm_option.go
@@ -16,7 +16,7 @@ const (
 )
 
 const (
-	DefaultApiVersion = "2023-05-15"
+	DefaultAPIVersion = "2023-05-15"
 )
 
 type options struct {
@@ -64,17 +64,17 @@ func WithOrganization(organization string) Option {
 	}
 }
 
-// WithApiType passes the api type to the client. If not set, the default value
-// is APITypeOpenAI
-func WithApiType(apiType APIType) Option {
+// WithAPIType passes the api type to the client. If not set, the default value
+// is APITypeOpenAI.
+func WithAPIType(apiType APIType) Option {
 	return func(opts *options) {
 		opts.apiType = apiType
 	}
 }
 
-// WithApiVersion passes the api version to the client. If not set, the default value
-// is DefaultApiVersion
-func WithApiVersion(apiVersion string) Option {
+// WithAPIVersion passes the api version to the client. If not set, the default value
+// is DefaultAPIVersion.
+func WithAPIVersion(apiVersion string) Option {
 	return func(opts *options) {
 		opts.apiVersion = apiVersion
 	}


### PR DESCRIPTION
This PR adds the support for azure openai support.

Some major changes

## 1. Change OPENAI_API_BASE env with "v1" inside. Align with the official openai repo:

https://github.com/openai/openai-python/blob/main/openai/__init__.py
Some concerns: may cause some users' compatibility issues. 
We can discuss about it. Whether we prefer the alignment or the compatibility. 
Also I can change the code adding "v1" it in the buildURL method if the compatibility wins.

## 2. Add Azure API support

Same as the feature in the python implementation. 
Doc: https://python.langchain.com/docs/modules/model_io/models/llms/integrations/azure_openai_example
Url Base Construction: https://github.com/openai/openai-python/blob/main/openai/api_resources/abstract/api_resource.py

## 3. Known Issues

The embedding still can not work in Azure API, the embeddings/embedding.go batchText
https://learn.microsoft.com/en-us/answers/questions/1189661/openai-sentence-embedding-input-array-limit
"Currently we accept a max array of 1." 
Will figure out how to do it later. 

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
