### PR TITLE
llms: add cohere support

### DIFF
--- a/examples/cohere-llm-example/cohere_completion_example.go
+++ b/examples/cohere-llm-example/cohere_completion_example.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/tmc/langchaingo/llms/cohere"
+)
+
+func main() {
+	llm, err := cohere.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx := context.Background()
+	input := "The first man to walk on the moon"
+	completion, err := llm.Call(ctx, input)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(completion)
+
+	inputToken := llm.GetNumTokens(input)
+	outputToken := llm.GetNumTokens(completion)
+
+	fmt.Printf("%v/%v\n", inputToken, outputToken)
+}

--- a/examples/cohere-llm-example/go.mod
+++ b/examples/cohere-llm-example/go.mod
@@ -1,0 +1,11 @@
+module basic-llm-example
+
+go 1.19
+
+require github.com/tmc/langchaingo v0.0.0-20230710002755-32d9295eb39d
+
+require (
+	github.com/dlclark/regexp2 v1.8.1 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/pkoukk/tiktoken-go v0.1.2 // indirect
+)

--- a/examples/cohere-llm-example/go.sum
+++ b/examples/cohere-llm-example/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/dlclark/regexp2 v1.8.1 h1:6Lcdwya6GjPUNsBct8Lg/yRPwMhABj269AAzdGSiR+0=
+github.com/dlclark/regexp2 v1.8.1/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pkoukk/tiktoken-go v0.1.2 h1:u7PCSBiWJ3nJYoTGShyM9iHXz4dNyYkurwwp+GHtyHY=
+github.com/pkoukk/tiktoken-go v0.1.2/go.mod h1:boMWvk9pQCOTx11pgu0DrIdrAKgQzzJKUP6vLXaz7Rw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/tmc/langchaingo v0.0.0-20230710002755-32d9295eb39d h1:zkcbEKyLnynM2ffsvkFJrLKSx/UxCDV4xAIwllFCmXc=
+github.com/tmc/langchaingo v0.0.0-20230710002755-32d9295eb39d/go.mod h1:IkN52/XAQwAbscbatQibuBbB2BKpSWQ6mhCRK8oCZjI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
@@ -67,6 +68,7 @@ require (
 	cloud.google.com/go/aiplatform v1.42.0
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/PuerkitoBio/goquery v1.8.1
+	github.com/cohere-ai/tokenizer v1.1.2
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cohere-ai/tokenizer v1.1.2 h1:t3KwUBSpKiBVFtpnHBfVIQNmjfZUuqFVYuSFkZYOWpU=
+github.com/cohere-ai/tokenizer v1.1.2/go.mod h1:9MNFPd9j1fuiEK3ua2HSCUxxcrfGMlSqpa93livg/C0=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -287,6 +289,7 @@ github.com/pinecone-io/go-pinecone v0.3.0 h1:+t0CiYaaA+JN6YM9QRNlvfLEr2kkGzcVEj/
 github.com/pinecone-io/go-pinecone v0.3.0/go.mod h1:VdSieE1r4jT3XydjFi+iL5w9qsGRz/x8LxWach2Hnv8=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkoukk/tiktoken-go v0.1.2 h1:u7PCSBiWJ3nJYoTGShyM9iHXz4dNyYkurwwp+GHtyHY=
 github.com/pkoukk/tiktoken-go v0.1.2/go.mod h1:boMWvk9pQCOTx11pgu0DrIdrAKgQzzJKUP6vLXaz7Rw=

--- a/llms/cohere/coherellm.go
+++ b/llms/cohere/coherellm.go
@@ -1,0 +1,101 @@
+package cohere
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/cohere/internal/cohereclient"
+	"github.com/tmc/langchaingo/schema"
+)
+
+var (
+	ErrEmptyResponse = errors.New("no response")
+	ErrMissingToken  = errors.New("missing the COHERE_API_KEY key, set it in the COHERE_API_KEY environment variable")
+
+	ErrUnexpectedResponseLength = errors.New("unexpected length of response")
+)
+
+type LLM struct {
+	client *cohereclient.Client
+}
+
+var (
+	_ llms.LLM           = (*LLM)(nil)
+	_ llms.LanguageModel = (*LLM)(nil)
+)
+
+// Call requests a generation for the given prompt.
+func (o *LLM) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
+	r, err := o.Generate(ctx, []string{prompt}, options...)
+	if err != nil {
+		return "", err
+	}
+	if len(r) == 0 {
+		return "", ErrEmptyResponse
+	}
+	return r[0].Text, nil
+}
+
+func (o *LLM) Generate(ctx context.Context, prompts []string, options ...llms.CallOption) ([]*llms.Generation, error) {
+	opts := llms.CallOptions{}
+	for _, opt := range options {
+		opt(&opts)
+	}
+
+	generations := make([]*llms.Generation, 0, len(prompts))
+
+	for _, prompt := range prompts {
+		result, err := o.client.CreateGeneration(ctx, &cohereclient.GenerationRequest{
+			Prompt: prompt,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		generations = append(generations, &llms.Generation{
+			Text: result.Text,
+		})
+	}
+
+	return generations, nil
+}
+
+func (o *LLM) GetNumTokens(text string) int {
+	return o.client.GetNumTokens(text)
+}
+
+func (o *LLM) GeneratePrompt(
+	ctx context.Context,
+	promptValues []schema.PromptValue,
+	options ...llms.CallOption,
+) (llms.LLMResult, error) { //nolint:lll
+	return llms.GeneratePrompt(ctx, o, promptValues, options...)
+}
+
+// New returns a new Cohere LLM.
+func New(opts ...Option) (*LLM, error) {
+	c, err := newClient(opts...)
+	return &LLM{
+		client: c,
+	}, err
+}
+
+func newClient(opts ...Option) (*cohereclient.Client, error) {
+	options := &options{
+		token:   os.Getenv(tokenEnvVarName),
+		baseURL: os.Getenv(baseURLEnvVarName),
+		model:   os.Getenv(modelEnvVarName),
+	}
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if len(options.token) == 0 {
+		return nil, ErrMissingToken
+	}
+
+	return cohereclient.New(options.token, options.baseURL, options.model)
+}

--- a/llms/cohere/coherellm.go
+++ b/llms/cohere/coherellm.go
@@ -26,7 +26,6 @@ var (
 	_ llms.LanguageModel = (*LLM)(nil)
 )
 
-// Call requests a generation for the given prompt.
 func (o *LLM) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
 	r, err := o.Generate(ctx, []string{prompt}, options...)
 	if err != nil {
@@ -74,7 +73,6 @@ func (o *LLM) GeneratePrompt(
 	return llms.GeneratePrompt(ctx, o, promptValues, options...)
 }
 
-// New returns a new Cohere LLM.
 func New(opts ...Option) (*LLM, error) {
 	c, err := newClient(opts...)
 	return &LLM{

--- a/llms/cohere/coherellm_option.go
+++ b/llms/cohere/coherellm_option.go
@@ -1,0 +1,40 @@
+package cohere
+
+const (
+	tokenEnvVarName   = "COHERE_API_KEY"  //nolint:gosec
+	modelEnvVarName   = "COHERE_MODEL"    //nolint:gosec
+	baseURLEnvVarName = "COHERE_BASE_URL" //nolint:gosec
+)
+
+type options struct {
+	token   string
+	model   string
+	baseURL string
+}
+
+type Option func(*options)
+
+// WithToken passes the Cohere API token to the client. If not set, the token
+// is read from the COHERE_API_KEY environment variable.
+func WithToken(token string) Option {
+	return func(opts *options) {
+		opts.token = token
+	}
+}
+
+// WithModel passes the Cohere model to the client. If not set, the model
+// is read from the COHERE_MODEL environment variable.
+func WithModel(model string) Option {
+	return func(opts *options) {
+		opts.model = model
+	}
+}
+
+// WithBaseURL passes the Cohere base url to the client. If not set, the base url
+// is read from the COHERE_BASE_URL environment variable. If still not set in ENV
+// VAR COHERE_BASE_URL, then the default value is https://api.cohere.ai is used.
+func WithBaseURL(baseURL string) Option {
+	return func(opts *options) {
+		opts.baseURL = baseURL
+	}
+}

--- a/llms/cohere/internal/cohereclient/cohereclient.go
+++ b/llms/cohere/internal/cohereclient/cohereclient.go
@@ -1,0 +1,142 @@
+package cohereclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/cohere-ai/tokenizer"
+)
+
+var ErrEmptyResponse = errors.New("empty response")
+
+type Client struct {
+	token      string
+	baseURL    string
+	model      string
+	httpClient Doer
+	encoder    *tokenizer.Encoder
+}
+
+type Option func(*Client) error
+
+// Doer performs a HTTP request.
+type Doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// WithHTTPClient allows setting a custom HTTP client.
+func WithHTTPClient(client Doer) Option {
+	return func(c *Client) error {
+		c.httpClient = client
+
+		return nil
+	}
+}
+
+func New(token string, baseURL string, model string, opts ...Option) (*Client, error) {
+	encoder, err := tokenizer.NewFromPrebuilt("coheretext-50k")
+	if err != nil {
+		return nil, fmt.Errorf("create tokenizer: %w", err)
+	}
+
+	c := &Client{
+		token:      token,
+		baseURL:    baseURL,
+		model:      model,
+		httpClient: http.DefaultClient,
+		encoder:    encoder,
+	}
+
+	for _, opt := range opts {
+		if err := opt(c); err != nil {
+			return nil, err
+		}
+	}
+
+	return c, nil
+}
+
+// GenerationRequest is a request to create a generation.
+type GenerationRequest struct {
+	Prompt string `json:"prompt"`
+}
+
+// Generation is a generation.
+type Generation struct {
+	Text string `json:"text"`
+}
+
+type generateRequestPayload struct {
+	Prompt string `json:"prompt"`
+	Model  string `json:"model"`
+}
+
+type generateResponsePayload struct {
+	ID          string `json:"id,omitempty"`
+	Message     string `json:"message,omitempty"`
+	Generations []struct {
+		ID   string `json:"id,omitempty"`
+		Text string `json:"text,omitempty"`
+	} `json:"generations,omitempty"`
+}
+
+// CreateGeneration creates a generation.
+func (c *Client) CreateGeneration(ctx context.Context, r *GenerationRequest) (*Generation, error) {
+	if c.baseURL == "" {
+		c.baseURL = "https://api.cohere.ai"
+	}
+
+	payload := generateRequestPayload{
+		Prompt: r.Prompt,
+		Model:  c.model,
+	}
+
+	payloadBytes, err := json.Marshal(&payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal payload: %w", err)
+	}
+
+	// build request
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		fmt.Sprintf("%s/v1/generate", c.baseURL),
+		bytes.NewReader(payloadBytes),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("authorization", "bearer "+c.token)
+
+	// send request
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send request: %w", err)
+	}
+	defer res.Body.Close()
+
+	var response generateResponsePayload
+	if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	if len(response.Generations) == 0 {
+		return nil, ErrEmptyResponse
+	}
+
+	var generation Generation
+	generation.Text = response.Generations[0].Text
+
+	return &generation, nil
+}
+
+func (c *Client) GetNumTokens(text string) int {
+	encoded, _ := c.encoder.Encode(text)
+	return len(encoded)
+}

--- a/llms/doc.go
+++ b/llms/doc.go
@@ -7,6 +7,7 @@
 // 2. Local LLM:         llms/local/
 // 3. OpenAI:            llms/openai/
 // 4. Vertex AI:         llms/vertexai/
+// 5. Cohere:            llms/cohere/
 //
 // Each subpackage includes provider-specific LLM implementations and helper files for communication
 // with supported LLM providers. The internal directories within these subpackages contain provider-specific


### PR DESCRIPTION
This pull request introduces support for [cohere](https://cohere.com)'s LLM text generation
It doesn't incorporate yet all the options from cohere's API, currently only the prompt is available.

I tried to keep the same structure as the other LLM implementations.

I also added the dependency [github.com/cohere-ai/tokenizer](https://chat.openai.com/github.com/cohere-ai/tokenizer). This was necessary to implement the GetNumTokens function without necessitating a request to cohere's API.

Mirroring the OpenAI implementation, the token must be specified via the COHERE_API_TOKEN environment variable, while the model is set with the COHERE_MODEL variable.

[Python Implementation](https://github.com/hwchase17/langchain/blob/master/langchain/llms/cohere.py)

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
