### PR TITLE
Function calling

### DIFF
--- a/examples/.update-all-to-latest.sh
+++ b/examples/.update-all-to-latest.sh
@@ -4,10 +4,12 @@
 export GOPROXY=direct
 export GOWORK=off
 
+syncref="${1:-main}"
+
 for gm in $(find . -name go.mod); do
   (
   cd $(dirname $gm)
-  go get -u github.com/tmc/langchaingo
+  go get -u github.com/tmc/langchaingo@${syncref}
   go mod tidy
 )
 done

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,8 @@
+SYNC_REF?=main
+
 .PHONY: sync
 sync: ## Sync all go.mod files
-	@sh .update-all-to-latest.sh
+	@sh .update-all-to-latest.sh ${SYNC_REF}
 
 .PHONY: add-go-work-files
 add-go-work-files: ## Add go work files to all examples

--- a/examples/cohere-llm-example/go.mod
+++ b/examples/cohere-llm-example/go.mod
@@ -2,7 +2,7 @@ module basic-llm-example
 
 go 1.19
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	github.com/cohere-ai/tokenizer v1.1.2 // indirect

--- a/examples/cohere-llm-example/go.sum
+++ b/examples/cohere-llm-example/go.sum
@@ -11,6 +11,6 @@ github.com/pkoukk/tiktoken-go v0.1.2 h1:u7PCSBiWJ3nJYoTGShyM9iHXz4dNyYkurwwp+GHt
 github.com/pkoukk/tiktoken-go v0.1.2/go.mod h1:boMWvk9pQCOTx11pgu0DrIdrAKgQzzJKUP6vLXaz7Rw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/examples/document-qa-example/go.mod
+++ b/examples/document-qa-example/go.mod
@@ -2,7 +2,7 @@ module document-qa-example
 
 go 1.19
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/document-qa-example/go.sum
+++ b/examples/document-qa-example/go.sum
@@ -66,8 +66,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.starlark.net v0.0.0-20230302034142-4b1e35fe2254 h1:Ss6D3hLXTM0KobyBYEAygXzFfGcjnmfEJOBgSbemCtg=
 go.starlark.net v0.0.0-20230302034142-4b1e35fe2254/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=

--- a/examples/huggingface-llm-example/go.mod
+++ b/examples/huggingface-llm-example/go.mod
@@ -2,7 +2,7 @@ module huggingface-llm-example
 
 go 1.19
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	github.com/dlclark/regexp2 v1.8.1 // indirect

--- a/examples/huggingface-llm-example/go.sum
+++ b/examples/huggingface-llm-example/go.sum
@@ -7,6 +7,6 @@ github.com/pkoukk/tiktoken-go v0.1.2 h1:u7PCSBiWJ3nJYoTGShyM9iHXz4dNyYkurwwp+GHt
 github.com/pkoukk/tiktoken-go v0.1.2/go.mod h1:boMWvk9pQCOTx11pgu0DrIdrAKgQzzJKUP6vLXaz7Rw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/examples/llm-chain-example/go.mod
+++ b/examples/llm-chain-example/go.mod
@@ -2,7 +2,7 @@ module llm-chain-example
 
 go 1.19
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/llm-chain-example/go.sum
+++ b/examples/llm-chain-example/go.sum
@@ -66,8 +66,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.starlark.net v0.0.0-20230302034142-4b1e35fe2254 h1:Ss6D3hLXTM0KobyBYEAygXzFfGcjnmfEJOBgSbemCtg=
 go.starlark.net v0.0.0-20230302034142-4b1e35fe2254/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=

--- a/examples/llmmath-chain-example/go.mod
+++ b/examples/llmmath-chain-example/go.mod
@@ -2,7 +2,7 @@ module llmmath-chain-example
 
 go 1.19
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/llmmath-chain-example/go.sum
+++ b/examples/llmmath-chain-example/go.sum
@@ -66,8 +66,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.starlark.net v0.0.0-20230302034142-4b1e35fe2254 h1:Ss6D3hLXTM0KobyBYEAygXzFfGcjnmfEJOBgSbemCtg=
 go.starlark.net v0.0.0-20230302034142-4b1e35fe2254/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=

--- a/examples/llmsummarization-chain-example/go.mod
+++ b/examples/llmsummarization-chain-example/go.mod
@@ -2,7 +2,7 @@ module llmsummarization-chain-example
 
 go 1.19
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	cloud.google.com/go v0.110.0 // indirect

--- a/examples/llmsummarization-chain-example/go.sum
+++ b/examples/llmsummarization-chain-example/go.sum
@@ -127,8 +127,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=

--- a/examples/local-llm-example/go.mod
+++ b/examples/local-llm-example/go.mod
@@ -2,7 +2,7 @@ module local-llm-example
 
 go 1.19
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	github.com/dlclark/regexp2 v1.8.1 // indirect

--- a/examples/local-llm-example/go.sum
+++ b/examples/local-llm-example/go.sum
@@ -7,6 +7,6 @@ github.com/pkoukk/tiktoken-go v0.1.2 h1:u7PCSBiWJ3nJYoTGShyM9iHXz4dNyYkurwwp+GHt
 github.com/pkoukk/tiktoken-go v0.1.2/go.mod h1:boMWvk9pQCOTx11pgu0DrIdrAKgQzzJKUP6vLXaz7Rw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/examples/mrkl-agent-example/go.mod
+++ b/examples/mrkl-agent-example/go.mod
@@ -2,7 +2,7 @@ module mrkl-agent-example
 
 go 1.19
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/mrkl-agent-example/go.sum
+++ b/examples/mrkl-agent-example/go.sum
@@ -66,8 +66,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.starlark.net v0.0.0-20230302034142-4b1e35fe2254 h1:Ss6D3hLXTM0KobyBYEAygXzFfGcjnmfEJOBgSbemCtg=
 go.starlark.net v0.0.0-20230302034142-4b1e35fe2254/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=

--- a/examples/openai-chat-example/go.mod
+++ b/examples/openai-chat-example/go.mod
@@ -2,7 +2,7 @@ module openai-chat-example
 
 go 1.19
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	github.com/dlclark/regexp2 v1.8.1 // indirect

--- a/examples/openai-chat-example/go.sum
+++ b/examples/openai-chat-example/go.sum
@@ -7,6 +7,6 @@ github.com/pkoukk/tiktoken-go v0.1.2 h1:u7PCSBiWJ3nJYoTGShyM9iHXz4dNyYkurwwp+GHt
 github.com/pkoukk/tiktoken-go v0.1.2/go.mod h1:boMWvk9pQCOTx11pgu0DrIdrAKgQzzJKUP6vLXaz7Rw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/examples/openai-chat-example/openai_chat_example.go
+++ b/examples/openai-chat-example/openai_chat_example.go
@@ -17,8 +17,8 @@ func main() {
 	}
 	ctx := context.Background()
 	completion, err := llm.Call(ctx, []schema.ChatMessage{
-		schema.SystemChatMessage{Text: "Hello, I am a friendly chatbot. I love to talk about movies, books and music. Answer in long form yaml."},
-		schema.HumanChatMessage{Text: "What would be a good company name a company that makes colorful socks?"},
+		schema.SystemChatMessage{Content: "Hello, I am a friendly chatbot. I love to talk about movies, books and music. Answer in long form yaml."},
+		schema.HumanChatMessage{Content: "What would be a good company name a company that makes colorful socks?"},
 	}, llms.WithStreamingFunc(func(ctx context.Context, chunk []byte) error {
 		fmt.Print(string(chunk))
 		return nil

--- a/examples/openai-completion-example/go.mod
+++ b/examples/openai-completion-example/go.mod
@@ -2,7 +2,7 @@ module openai-completion-example
 
 go 1.19
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	github.com/dlclark/regexp2 v1.8.1 // indirect

--- a/examples/openai-completion-example/go.sum
+++ b/examples/openai-completion-example/go.sum
@@ -7,6 +7,6 @@ github.com/pkoukk/tiktoken-go v0.1.2 h1:u7PCSBiWJ3nJYoTGShyM9iHXz4dNyYkurwwp+GHt
 github.com/pkoukk/tiktoken-go v0.1.2/go.mod h1:boMWvk9pQCOTx11pgu0DrIdrAKgQzzJKUP6vLXaz7Rw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/examples/openai-function-call-example/go.mod
+++ b/examples/openai-function-call-example/go.mod
@@ -1,0 +1,11 @@
+module openai-function-call-example
+
+go 1.19
+
+require github.com/tmc/langchaingo v0.0.0-20230723211219-75487792b319
+
+require (
+	github.com/dlclark/regexp2 v1.8.1 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/pkoukk/tiktoken-go v0.1.2 // indirect
+)

--- a/examples/openai-function-call-example/go.mod
+++ b/examples/openai-function-call-example/go.mod
@@ -2,7 +2,7 @@ module openai-function-call-example
 
 go 1.19
 
-require github.com/tmc/langchaingo v0.0.0-20230723211219-75487792b319
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	github.com/dlclark/regexp2 v1.8.1 // indirect

--- a/examples/openai-function-call-example/go.sum
+++ b/examples/openai-function-call-example/go.sum
@@ -7,8 +7,6 @@ github.com/pkoukk/tiktoken-go v0.1.2 h1:u7PCSBiWJ3nJYoTGShyM9iHXz4dNyYkurwwp+GHt
 github.com/pkoukk/tiktoken-go v0.1.2/go.mod h1:boMWvk9pQCOTx11pgu0DrIdrAKgQzzJKUP6vLXaz7Rw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
-github.com/tmc/langchaingo v0.0.0-20230723211219-75487792b319 h1:6F7zF+8Mgatxc3sBVycD9wnLcDLAN48bl3EFKWJEo0U=
-github.com/tmc/langchaingo v0.0.0-20230723211219-75487792b319/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/examples/openai-function-call-example/go.sum
+++ b/examples/openai-function-call-example/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/dlclark/regexp2 v1.8.1 h1:6Lcdwya6GjPUNsBct8Lg/yRPwMhABj269AAzdGSiR+0=
+github.com/dlclark/regexp2 v1.8.1/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pkoukk/tiktoken-go v0.1.2 h1:u7PCSBiWJ3nJYoTGShyM9iHXz4dNyYkurwwp+GHtyHY=
+github.com/pkoukk/tiktoken-go v0.1.2/go.mod h1:boMWvk9pQCOTx11pgu0DrIdrAKgQzzJKUP6vLXaz7Rw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
+github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723211219-75487792b319 h1:6F7zF+8Mgatxc3sBVycD9wnLcDLAN48bl3EFKWJEo0U=
+github.com/tmc/langchaingo v0.0.0-20230723211219-75487792b319/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/examples/openai-function-call-example/openai_function_call_example.go
+++ b/examples/openai-function-call-example/openai_function_call_example.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/openai"
+	"github.com/tmc/langchaingo/schema"
+)
+
+func main() {
+	llm, err := openai.NewChat(openai.WithModel("gpt-3.5-turbo-0613"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx := context.Background()
+	completion, err := llm.Call(ctx, []schema.ChatMessage{
+		schema.HumanChatMessage{Content: "What is the weather like in Boston?"},
+	}, llms.WithFunctions(functions))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if completion.FunctionCall != nil {
+		fmt.Printf("Function call: %v\n", completion.FunctionCall)
+	}
+}
+
+func getCurrentWeather(location string, unit string) (string, error) {
+	weatherInfo := map[string]interface{}{
+		"location":    location,
+		"temperature": "72",
+		"unit":        unit,
+		"forecast":    []string{"sunny", "windy"},
+	}
+	b, err := json.Marshal(weatherInfo)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+var functions = []llms.FunctionDefinition{
+	{
+		Name:        "getCurrentWeather",
+		Description: "Get the current weather in a given location",
+		Parameters:  json.RawMessage(`{"type": "object", "properties": {"location": {"type": "string", "description": "The city and state, e.g. San Francisco, CA"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location"]}`),
+	},
+}

--- a/examples/pinecone-vectorstore-example/go.mod
+++ b/examples/pinecone-vectorstore-example/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+	github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 )
 
 require (

--- a/examples/pinecone-vectorstore-example/go.sum
+++ b/examples/pinecone-vectorstore-example/go.sum
@@ -158,8 +158,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/examples/postgresql-database-chain-example/go.mod
+++ b/examples/postgresql-database-chain-example/go.mod
@@ -2,7 +2,7 @@ module postgresql-database-chain-example
 
 go 1.20
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/postgresql-database-chain-example/go.sum
+++ b/examples/postgresql-database-chain-example/go.sum
@@ -74,8 +74,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.starlark.net v0.0.0-20230302034142-4b1e35fe2254 h1:Ss6D3hLXTM0KobyBYEAygXzFfGcjnmfEJOBgSbemCtg=
 go.starlark.net v0.0.0-20230302034142-4b1e35fe2254/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=

--- a/examples/prompts-with-partial-example/go.mod
+++ b/examples/prompts-with-partial-example/go.mod
@@ -2,7 +2,7 @@ module prompts-with-partial-example
 
 go 1.20
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/prompts-with-partial-example/go.sum
+++ b/examples/prompts-with-partial-example/go.sum
@@ -29,8 +29,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/examples/prompts-with-partial-func-example/go.mod
+++ b/examples/prompts-with-partial-func-example/go.mod
@@ -2,7 +2,7 @@ module prompts-with-partial-func-example
 
 go 1.20
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/prompts-with-partial-func-example/go.sum
+++ b/examples/prompts-with-partial-func-example/go.sum
@@ -29,8 +29,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/examples/sql-database-chain-example/go.mod
+++ b/examples/sql-database-chain-example/go.mod
@@ -2,7 +2,7 @@ module sql-database-chain-example
 
 go 1.19
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/sql-database-chain-example/go.sum
+++ b/examples/sql-database-chain-example/go.sum
@@ -68,8 +68,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.starlark.net v0.0.0-20230302034142-4b1e35fe2254 h1:Ss6D3hLXTM0KobyBYEAygXzFfGcjnmfEJOBgSbemCtg=
 go.starlark.net v0.0.0-20230302034142-4b1e35fe2254/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=

--- a/examples/vertexai-palm-chat-example/go.mod
+++ b/examples/vertexai-palm-chat-example/go.mod
@@ -2,7 +2,7 @@ module vertexai-palm-chat-example
 
 go 1.19
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	cloud.google.com/go v0.110.0 // indirect

--- a/examples/vertexai-palm-chat-example/go.sum
+++ b/examples/vertexai-palm-chat-example/go.sum
@@ -90,8 +90,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=

--- a/examples/vertexai-palm-chat-example/vertexai_palm_chat_example.go
+++ b/examples/vertexai-palm-chat-example/vertexai_palm_chat_example.go
@@ -16,10 +16,10 @@ func main() {
 	}
 	ctx := context.Background()
 	question := schema.HumanChatMessage{
-		Text: "What would be a good company name a company that makes colorful socks?",
+		Content: "What would be a good company name a company that makes colorful socks?",
 	}
 	fmt.Println("---ASK---")
-	fmt.Println(question.GetText())
+	fmt.Println(question.GetContent())
 	messages := []schema.ChatMessage{question}
 	completion, err := llm.Call(ctx, messages)
 	if err != nil {
@@ -31,15 +31,13 @@ func main() {
 	fmt.Println(response)
 
 	// keep track of conversation
-	messages = append(messages, &schema.AIChatMessage{
-		Text: response,
-	})
+	messages = append(messages, response)
 
 	question = schema.HumanChatMessage{
-		Text: "Any other recommendation on how to get started with the company ?",
+		Content: "Any other recommendation on how to get started with the company ?",
 	}
 	fmt.Println("---ASK---")
-	fmt.Println(question.GetText())
+	fmt.Println(question.GetContent())
 	messages = append(messages, question)
 
 	completion, err = llm.Call(ctx, messages)

--- a/examples/vertexai-palm-completion-example/go.mod
+++ b/examples/vertexai-palm-completion-example/go.mod
@@ -2,7 +2,7 @@ module vertexai-palm-completion-example
 
 go 1.19
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	cloud.google.com/go v0.110.0 // indirect

--- a/examples/vertexai-palm-completion-example/go.sum
+++ b/examples/vertexai-palm-completion-example/go.sum
@@ -90,8 +90,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea h1:9TKCNMfYcIEyQbLwawGTcV4BeNFtfAE2eUb6MuCIvog=
-github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d h1:OgnDRjRLT/B+l+DvKEoWfVop+HHa/FOB+TCiwaTYmWc=
+github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=

--- a/examples/zapier-llm-example/go.mod
+++ b/examples/zapier-llm-example/go.mod
@@ -2,7 +2,7 @@ module zapier-llm-example
 
 go 1.19
 
-require github.com/tmc/langchaingo v0.0.0-20230723183709-cb9f67698bea
+require github.com/tmc/langchaingo v0.0.0-20230723222729-cdc57b5af63d
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/llms/llms.go
+++ b/llms/llms.go
@@ -22,7 +22,7 @@ type LLM interface {
 
 // ChatLLM is a langchaingo LLM that can be used for chatting.
 type ChatLLM interface {
-	Call(ctx context.Context, messages []schema.ChatMessage, options ...CallOption) (string, error)
+	Call(ctx context.Context, messages []schema.ChatMessage, options ...CallOption) (*schema.AIChatMessage, error)
 	Generate(ctx context.Context, messages [][]schema.ChatMessage, options ...CallOption) ([]*Generation, error)
 }
 

--- a/llms/openai/internal/openaiclient/openaiclient.go
+++ b/llms/openai/internal/openaiclient/openaiclient.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	defaultBaseURL = "https://api.openai.com/v1"
+	defaultBaseURL              = "https://api.openai.com/v1"
+	defaultFunctionCallBehavior = "auto"
 )
 
 // ErrEmptyResponse is returned when the OpenAI API returns an empty response.
@@ -159,6 +160,9 @@ func (c *Client) CreateChat(ctx context.Context, r *ChatRequest) (*ChatResponse,
 		} else {
 			r.Model = c.Model
 		}
+	}
+	if r.FunctionCallBehavior == "" {
+		r.FunctionCallBehavior = defaultFunctionCallBehavior
 	}
 	resp, err := c.createChat(ctx, r)
 	if err != nil {

--- a/llms/options.go
+++ b/llms/options.go
@@ -36,7 +36,35 @@ type CallOptions struct {
 	FrequencyPenalty float64 `json:"frequency_penalty"`
 	// PresencePenalty is the presence penalty for sampling.
 	PresencePenalty float64 `json:"presence_penalty"`
+
+	// Function defitions to include in the request.
+	Functions []FunctionDefinition `json:"functions"`
+	// FunctionCallBehavior is the behavior to use when calling functions.
+	//
+	// If a specific function should be invoked, use the format:
+	// `{"name": "my_function"}`
+	FunctionCallBehavior FunctionCallBehavior `json:"function_call"`
 }
+
+// FunctionDefinition is a definition of a function that can be called by the model.
+type FunctionDefinition struct {
+	// Name is the name of the function.
+	Name string `json:"name"`
+	// Description is a description of the function.
+	Description string `json:"description"`
+	// Parameters is a list of parameters for the function.
+	Parameters any `json:"parameters"`
+}
+
+// FunctionCallBehavior is the behavior to use when calling functions.
+type FunctionCallBehavior string
+
+const (
+	// FunctionCallBehaviorNone will not call any functions.
+	FunctionCallBehaviorNone FunctionCallBehavior = "none"
+	// FunctionCallBehaviorAuto will call functions automatically.
+	FunctionCallBehaviorAuto FunctionCallBehavior = "auto"
+)
 
 // WithModel is an option for LLM.Call.
 func WithModel(model string) CallOption {
@@ -140,5 +168,19 @@ func WithFrequencyPenalty(frequencyPenalty float64) CallOption {
 func WithPresencePenalty(presencePenalty float64) CallOption {
 	return func(o *CallOptions) {
 		o.PresencePenalty = presencePenalty
+	}
+}
+
+// WithFunctionCallBehavior will add an option to set the behavior to use when calling functions.
+func WithFunctionCallBehavior(behavior FunctionCallBehavior) CallOption {
+	return func(o *CallOptions) {
+		o.FunctionCallBehavior = behavior
+	}
+}
+
+// WithFunctions will add an option to set the functions to include in the request.
+func WithFunctions(functions []FunctionDefinition) CallOption {
+	return func(o *CallOptions) {
+		o.Functions = functions
 	}
 }

--- a/llms/vertexai/internal/vertexaiclient/palm_client.go
+++ b/llms/vertexai/internal/vertexaiclient/palm_client.go
@@ -182,7 +182,7 @@ func (m ChatMessage) GetType() schema.ChatMessageType {
 }
 
 // GetText returns the text of the message.
-func (m ChatMessage) GetText() string {
+func (m ChatMessage) GetContent() string {
 	return m.Content
 }
 

--- a/memory/buffer_test.go
+++ b/memory/buffer_test.go
@@ -45,8 +45,8 @@ func TestBufferMemoryReturnMessage(t *testing.T) {
 
 	expectedChatHistory := NewChatMessageHistory(
 		WithPreviousMessages([]schema.ChatMessage{
-			schema.HumanChatMessage{Text: "bar"},
-			schema.AIChatMessage{Text: "foo"},
+			schema.HumanChatMessage{Content: "bar"},
+			schema.AIChatMessage{Content: "foo"},
 		}),
 	)
 
@@ -59,8 +59,8 @@ func TestBufferMemoryWithPreLoadedHistory(t *testing.T) {
 
 	m := NewBuffer(WithChatHistory(NewChatMessageHistory(
 		WithPreviousMessages([]schema.ChatMessage{
-			schema.HumanChatMessage{Text: "bar"},
-			schema.AIChatMessage{Text: "foo"},
+			schema.HumanChatMessage{Content: "bar"},
+			schema.AIChatMessage{Content: "foo"},
 		}),
 	)))
 
@@ -88,8 +88,8 @@ func (t testChatMessageHistory) Clear() {
 
 func (t testChatMessageHistory) Messages() []schema.ChatMessage {
 	return []schema.ChatMessage{
-		schema.HumanChatMessage{Text: "user message test"},
-		schema.AIChatMessage{Text: "ai message test"},
+		schema.HumanChatMessage{Content: "user message test"},
+		schema.AIChatMessage{Content: "ai message test"},
 	}
 }
 

--- a/memory/chat.go
+++ b/memory/chat.go
@@ -22,12 +22,12 @@ func (h *ChatMessageHistory) Messages() []schema.ChatMessage {
 
 // AddAIMessage adds an AIMessage to the chat message history.
 func (h *ChatMessageHistory) AddAIMessage(text string) {
-	h.messages = append(h.messages, schema.AIChatMessage{Text: text})
+	h.messages = append(h.messages, schema.AIChatMessage{Content: text})
 }
 
 // AddUserMessage adds an user to the chat message history.
 func (h *ChatMessageHistory) AddUserMessage(text string) {
-	h.messages = append(h.messages, schema.HumanChatMessage{Text: text})
+	h.messages = append(h.messages, schema.HumanChatMessage{Content: text})
 }
 
 func (h *ChatMessageHistory) Clear() {

--- a/memory/chat_test.go
+++ b/memory/chat_test.go
@@ -14,20 +14,20 @@ func TestChatMessageHistory(t *testing.T) {
 	h.AddAIMessage("foo")
 	h.AddUserMessage("bar")
 	assert.Equal(t, []schema.ChatMessage{
-		schema.AIChatMessage{Text: "foo"},
-		schema.HumanChatMessage{Text: "bar"},
+		schema.AIChatMessage{Content: "foo"},
+		schema.HumanChatMessage{Content: "bar"},
 	}, h.Messages())
 
 	h = NewChatMessageHistory(
 		WithPreviousMessages([]schema.ChatMessage{
-			schema.AIChatMessage{Text: "foo"},
-			schema.SystemChatMessage{Text: "bar"},
+			schema.AIChatMessage{Content: "foo"},
+			schema.SystemChatMessage{Content: "bar"},
 		}),
 	)
 	h.AddUserMessage("zoo")
 	assert.Equal(t, []schema.ChatMessage{
-		schema.AIChatMessage{Text: "foo"},
-		schema.SystemChatMessage{Text: "bar"},
-		schema.HumanChatMessage{Text: "zoo"},
+		schema.AIChatMessage{Content: "foo"},
+		schema.SystemChatMessage{Content: "bar"},
+		schema.HumanChatMessage{Content: "zoo"},
 	}, h.Messages())
 }

--- a/prompts/chat_prompt_template_test.go
+++ b/prompts/chat_prompt_template_test.go
@@ -29,10 +29,10 @@ func TestChatPromptTemplate(t *testing.T) {
 	assert.NoError(t, err)
 	expectedMessages := []schema.ChatMessage{
 		schema.SystemChatMessage{
-			Text: "You are a translation engine that can only translate text and cannot interpret it.",
+			Content: "You are a translation engine that can only translate text and cannot interpret it.",
 		},
 		schema.HumanChatMessage{
-			Text: `translate this text from English to Chinese:\nI love programming`,
+			Content: `translate this text from English to Chinese:\nI love programming`,
 		},
 	}
 	require.Equal(t, expectedMessages, value.Messages())

--- a/prompts/message_promt_templage.go
+++ b/prompts/message_promt_templage.go
@@ -12,7 +12,7 @@ var _ MessageFormatter = SystemMessagePromptTemplate{}
 // FormatMessages formats the message with the values given.
 func (p SystemMessagePromptTemplate) FormatMessages(values map[string]any) ([]schema.ChatMessage, error) {
 	text, err := p.Prompt.Format(values)
-	return []schema.ChatMessage{schema.SystemChatMessage{Text: text}}, err
+	return []schema.ChatMessage{schema.SystemChatMessage{Content: text}}, err
 }
 
 // GetInputVariables returns the input variables the prompt expects.
@@ -37,7 +37,7 @@ var _ MessageFormatter = AIMessagePromptTemplate{}
 // FormatMessages formats the message with the values given.
 func (p AIMessagePromptTemplate) FormatMessages(values map[string]any) ([]schema.ChatMessage, error) {
 	text, err := p.Prompt.Format(values)
-	return []schema.ChatMessage{schema.AIChatMessage{Text: text}}, err
+	return []schema.ChatMessage{schema.AIChatMessage{Content: text}}, err
 }
 
 // GetInputVariables returns the input variables the prompt expects.
@@ -62,7 +62,7 @@ var _ MessageFormatter = HumanMessagePromptTemplate{}
 // FormatMessages formats the message with the values given.
 func (p HumanMessagePromptTemplate) FormatMessages(values map[string]any) ([]schema.ChatMessage, error) {
 	text, err := p.Prompt.Format(values)
-	return []schema.ChatMessage{schema.HumanChatMessage{Text: text}}, err
+	return []schema.ChatMessage{schema.HumanChatMessage{Content: text}}, err
 }
 
 // GetInputVariables returns the input variables the prompt expects.
@@ -88,7 +88,7 @@ var _ MessageFormatter = GenericMessagePromptTemplate{}
 // FormatMessages formats the message with the values given.
 func (p GenericMessagePromptTemplate) FormatMessages(values map[string]any) ([]schema.ChatMessage, error) {
 	text, err := p.Prompt.Format(values)
-	return []schema.ChatMessage{schema.GenericChatMessage{Text: text, Role: p.Role}}, err
+	return []schema.ChatMessage{schema.GenericChatMessage{Content: text, Role: p.Role}}, err
 }
 
 // GetInputVariables returns the input variables the prompt expects.

--- a/prompts/prompt_test.go
+++ b/prompts/prompt_test.go
@@ -29,5 +29,5 @@ func TestStringPromptValueMessages(t *testing.T) {
 	spv = StringPromptValue("test")
 	msgs = spv.Messages()
 	require.Len(t, msgs, 1)
-	assert.Equal(t, "test", msgs[0].GetText())
+	assert.Equal(t, "test", msgs[0].GetContent())
 }

--- a/prompts/string_prompt.go
+++ b/prompts/string_prompt.go
@@ -16,6 +16,6 @@ func (v StringPromptValue) String() string {
 // Messages returns a single-element ChatMessage slice.
 func (v StringPromptValue) Messages() []schema.ChatMessage {
 	return []schema.ChatMessage{
-		schema.HumanChatMessage{Text: string(v)},
+		schema.HumanChatMessage{Content: string(v)},
 	}
 }

--- a/schema/chat_messages_test.go
+++ b/schema/chat_messages_test.go
@@ -27,10 +27,10 @@ func TestGetBufferString(t *testing.T) {
 		{
 			name: "Mixed messages",
 			messages: []schema.ChatMessage{
-				schema.HumanChatMessage{Text: "Hello, how are you?"},
-				schema.AIChatMessage{Text: "I'm doing great!"},
-				schema.SystemChatMessage{Text: "Please be polite."},
-				schema.GenericChatMessage{Role: "Moderator", Text: "Keep the conversation on topic."},
+				schema.HumanChatMessage{Content: "Hello, how are you?"},
+				schema.AIChatMessage{Content: "I'm doing great!"},
+				schema.SystemChatMessage{Content: "Please be polite."},
+				schema.GenericChatMessage{Role: "Moderator", Content: "Keep the conversation on topic."},
 			},
 			humanPrefix: "Human",
 			aiPrefix:    "AI",
@@ -68,4 +68,4 @@ func TestGetBufferString(t *testing.T) {
 type unsupportedChatMessage struct{}
 
 func (m unsupportedChatMessage) GetType() schema.ChatMessageType { return "unsupported" }
-func (m unsupportedChatMessage) GetText() string                 { return "Unsupported message" }
+func (m unsupportedChatMessage) GetContent() string              { return "Unsupported message" }


### PR DESCRIPTION
This adds initial support for function calling semantics. This doesn't add high level helpers to go from a go function to an appropriate schema nor does it container helpers to invoke a Go function from a call but it does expose the basic semantics and wires it up for the openai based implementation.

This includes some related refactors to bring out schema types closer to upstream.

Fixes https://github.com/tmc/langchaingo/issues/162

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
