### PR TITLE
memory: Feature conversational retrieval interface fix and rename

### DIFF
--- a/agents/conversational_test.go
+++ b/agents/conversational_test.go
@@ -26,7 +26,7 @@ func TestConversationalWithMemory(t *testing.T) {
 		llm,
 		[]tools.Tool{tools.Calculator{}},
 		ConversationalReactDescription,
-		WithMemory(memory.NewBuffer()),
+		WithMemory(memory.NewConversationBuffer()),
 	)
 	require.NoError(t, err)
 

--- a/chains/conversation_test.go
+++ b/chains/conversation_test.go
@@ -20,7 +20,7 @@ func TestConversation(t *testing.T) {
 	llm, err := openai.New()
 	require.NoError(t, err)
 
-	c := NewConversation(llm, memory.NewBuffer())
+	c := NewConversation(llm, memory.NewConversationBuffer())
 	_, err = Run(context.Background(), c, "Hi! I'm Jim")
 	require.NoError(t, err)
 
@@ -39,7 +39,7 @@ func TestConversationMemoryPrune(t *testing.T) {
 	llm, err := openai.New()
 	require.NoError(t, err)
 
-	c := NewConversation(llm, memory.NewTokenBuffer(llm, 50))
+	c := NewConversation(llm, memory.NewConversationTokenBuffer(llm, 50))
 	_, err = Run(context.Background(), c, "Hi! I'm Jim")
 	require.NoError(t, err)
 

--- a/chains/conversational_retrieval_qa.go
+++ b/chains/conversational_retrieval_qa.go
@@ -49,9 +49,6 @@ type ConversationalRetrievalQA struct {
 
 	// ReturnSourceDocuments Return the retrieved source documents as part of the final result.
 	ReturnSourceDocuments bool
-
-	// get_chat_history: Optional[Callable[[List[CHAT_TURN_TYPE]], str]] = None
-	// """An optional function to get a string of the chat history.
 }
 
 var _ Chain = ConversationalRetrievalQA{}

--- a/chains/conversational_retrieval_qa_test.go
+++ b/chains/conversational_retrieval_qa_test.go
@@ -77,7 +77,7 @@ func TestConversationalRetrievalQA(t *testing.T) {
 		combinedStuffQAChain,
 		combinedQuestionGeneratorChain,
 		r,
-		memory.NewConversationBuffer(memory.WithReturnMessages(true)),
+		memory.NewConversationBuffer(),
 	)
 	result, err := Run(ctx, chain, "What did the president say about Ketanji Brown Jackson")
 	require.NoError(t, err)
@@ -88,7 +88,7 @@ func TestConversationalRetrievalQA(t *testing.T) {
 	require.True(t, strings.Contains(result, "Justice Stephen Breyer"), "expected  Justice Stephen Breyer in result")
 }
 
-func TestConversationalRetrievalQAInvalidMemoryValue(t *testing.T) {
+func TestConversationalRetrievalQAWithReturnMessages(t *testing.T) {
 	t.Parallel()
 	if openaiKey := os.Getenv("OPENAI_API_KEY"); openaiKey == "" {
 		t.Skip("OPENAI_API_KEY not set")
@@ -107,11 +107,15 @@ func TestConversationalRetrievalQAInvalidMemoryValue(t *testing.T) {
 		combinedStuffQAChain,
 		combinedQuestionGeneratorChain,
 		r,
-		memory.NewConversationBuffer(memory.WithReturnMessages(false)),
+		memory.NewConversationBuffer(memory.WithReturnMessages(true)),
 	)
-	_, err = Run(ctx, chain, "What did the president say about Ketanji Brown Jackson")
-	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), ErrMemoryValuesWrongType.Error()), "expected valid error to be thrown")
+	result, err := Run(ctx, chain, "What did the president say about Ketanji Brown Jackson")
+	require.NoError(t, err)
+	require.True(t, strings.Contains(result, "Ketanji Brown Jackson"), "expected Ketanji Brown Jackson in result")
+
+	result, err = Run(ctx, chain, "Did he mention who she succeeded")
+	require.NoError(t, err)
+	require.True(t, strings.Contains(result, "Justice Stephen Breyer"), "expected  Justice Stephen Breyer in result")
 }
 
 func TestConversationalRetrievalQAFromLLM(t *testing.T) {
@@ -126,14 +130,14 @@ func TestConversationalRetrievalQAFromLLM(t *testing.T) {
 	llm, err := openai.New()
 	require.NoError(t, err)
 
-	chain := NewConversationalRetrievalQAFromLLM(llm, r, memory.NewConversationBuffer(memory.WithReturnMessages(true)))
+	chain := NewConversationalRetrievalQAFromLLM(llm, r, memory.NewConversationBuffer())
 	result, err := Run(context.Background(), chain, "What did the president say about Ketanji Brown Jackson")
 	require.NoError(t, err)
 	require.True(t, strings.Contains(result, "Ketanji Brown Jackson"), "expected Ketanji Brown Jackson in result")
 
 	result, err = Run(ctx, chain, "Did he mention who she succeeded")
 	require.NoError(t, err)
-	require.True(t, strings.Contains(result, " Justice Stephen Breyer"), "expected  Justice Stephen Breyer in result")
+	require.True(t, strings.Contains(result, "Justice Stephen Breyer"), "expected  Justice Stephen Breyer in result")
 }
 
 func TestConversationalRetrievalQAFromLLMWithConversationTokenBuffer(t *testing.T) {
@@ -151,7 +155,7 @@ func TestConversationalRetrievalQAFromLLMWithConversationTokenBuffer(t *testing.
 	chain := NewConversationalRetrievalQAFromLLM(
 		llm,
 		r,
-		memory.NewConversationTokenBuffer(llm, 2000, memory.WithReturnMessages(true)),
+		memory.NewConversationTokenBuffer(llm, 2000),
 	)
 	result, err := Run(context.Background(), chain, "What did the president say about Ketanji Brown Jackson")
 	require.NoError(t, err)
@@ -159,5 +163,5 @@ func TestConversationalRetrievalQAFromLLMWithConversationTokenBuffer(t *testing.
 
 	result, err = Run(ctx, chain, "Did he mention who she succeeded")
 	require.NoError(t, err)
-	require.True(t, strings.Contains(result, " Justice Stephen Breyer"), "expected  Justice Stephen Breyer in result")
+	require.True(t, strings.Contains(result, "Justice Stephen Breyer"), "expected  Justice Stephen Breyer in result")
 }

--- a/chains/errors.go
+++ b/chains/errors.go
@@ -11,6 +11,12 @@ var (
 	// ErrInputValuesWrongType is returned if an input value to a chain is of
 	// wrong type.
 	ErrInputValuesWrongType = errors.New("input key is of wrong type")
+	// ErrMissingMemoryKeyValues is returned when some expected input values keys to
+	// a chain is missing.
+	ErrMissingMemoryKeyValues = errors.New("missing memory key in input values")
+	// ErrMemoryValuesWrongType is returned if the memory value to a chain is of
+	// wrong type.
+	ErrMemoryValuesWrongType = errors.New("memory key is of wrong type")
 	// ErrInvalidOutputValues is returned when expected output keys to a chain does
 	// not match the actual keys in the return output values map.
 	ErrInvalidOutputValues = errors.New("missing key in output values")
@@ -21,7 +27,7 @@ var (
 	// ErrMultipleOutputsInRun is returned in the run function if the chain expects
 	// more then one output values.
 	ErrMultipleOutputsInRun = errors.New("run not supported in chain with more then one expected output")
-	// ErrMultipleOutputsInRun is returned in the run function if the chain returns
+	// ErrWrongOutputTypeInRun is returned in the run function if the chain returns
 	// a value that is not a string.
 	ErrWrongOutputTypeInRun = errors.New("run not supported in chain that returns value that is not string")
 
@@ -31,6 +37,6 @@ var (
 	// ErrMultipleOutputsInPredict is returned if a chain has multiple return values
 	// in predict.
 	ErrMultipleOutputsInPredict = errors.New("predict is not supported with a chain that returns multiple values")
-	// ErrChainNotInitialized is returned if a chain is not initialized appropriately.
+	// ErrChainInitialization is returned if a chain is not initialized appropriately.
 	ErrChainInitialization = errors.New("error initializing chain")
 )

--- a/chains/sequential_test.go
+++ b/chains/sequential_test.go
@@ -171,8 +171,10 @@ func TestSequentialChainErrors(t *testing.T) {
 			chains: []Chain{
 				&testLLMChain{inputKeys: []string{"input1"}, outputKeys: []string{"output"}},
 			},
-			initErr:      ErrChainInitialization,
-			seqChainOpts: []SequentialChainOption{WithSeqChainMemory(memory.NewBuffer(memory.WithMemoryKey("input1")))},
+			initErr: ErrChainInitialization,
+			seqChainOpts: []SequentialChainOption{WithSeqChainMemory(
+				memory.NewConversationBuffer(memory.WithMemoryKey("input1")),
+			)},
 		},
 	}
 

--- a/memory/buffer.go
+++ b/memory/buffer.go
@@ -12,7 +12,7 @@ var ErrInvalidInputValues = errors.New("invalid input values")
 
 // ConversationBuffer is a simple form of memory that remembers previous conversational back and forths directly.
 type ConversationBuffer struct {
-	chatHistory schema.ChatMessageHistory
+	ChatHistory schema.ChatMessageHistory
 
 	ReturnMessages bool
 	InputKey       string
@@ -32,7 +32,7 @@ func NewConversationBuffer(options ...ConversationBufferOption) *ConversationBuf
 
 // Buffer gets buffer from memory.
 func (m *ConversationBuffer) Buffer() []schema.ChatMessage {
-	return m.chatHistory.Messages()
+	return m.ChatHistory.Messages()
 }
 
 // MemoryVariables gets the input key the buffer memory class will load dynamically.
@@ -47,11 +47,11 @@ func (m *ConversationBuffer) MemoryVariables() []string {
 func (m *ConversationBuffer) LoadMemoryVariables(map[string]any) (map[string]any, error) {
 	if m.ReturnMessages {
 		return map[string]any{
-			m.MemoryKey: m.chatHistory.Messages(),
+			m.MemoryKey: m.ChatHistory.Messages(),
 		}, nil
 	}
 
-	bufferString, err := schema.GetBufferString(m.chatHistory.Messages(), m.HumanPrefix, m.AIPrefix)
+	bufferString, err := schema.GetBufferString(m.ChatHistory.Messages(), m.HumanPrefix, m.AIPrefix)
 	if err != nil {
 		return nil, err
 	}
@@ -73,20 +73,20 @@ func (m *ConversationBuffer) SaveContext(inputValues map[string]any, outputValue
 	if err != nil {
 		return err
 	}
-	m.chatHistory.AddUserMessage(userInputValue)
+	m.ChatHistory.AddUserMessage(userInputValue)
 
 	aiOutputValue, err := getInputValue(outputValues, m.OutputKey)
 	if err != nil {
 		return err
 	}
-	m.chatHistory.AddAIMessage(aiOutputValue)
+	m.ChatHistory.AddAIMessage(aiOutputValue)
 
 	return nil
 }
 
 // Clear sets the chat messages to a new and empty chat message history.
 func (m *ConversationBuffer) Clear() error {
-	m.chatHistory.Clear()
+	m.ChatHistory.Clear()
 	return nil
 }
 

--- a/memory/buffer.go
+++ b/memory/buffer.go
@@ -10,9 +10,9 @@ import (
 // ErrInvalidInputValues is returned when input values given to a memory in save context are invalid.
 var ErrInvalidInputValues = errors.New("invalid input values")
 
-// Buffer is a simple form of memory that remembers previous conversational back and forths directly.
-type Buffer struct {
-	ChatHistory schema.ChatMessageHistory
+// ConversationBuffer is a simple form of memory that remembers previous conversational back and forths directly.
+type ConversationBuffer struct {
+	chatHistory schema.ChatMessageHistory
 
 	ReturnMessages bool
 	InputKey       string
@@ -22,16 +22,21 @@ type Buffer struct {
 	MemoryKey      string
 }
 
-// Statically assert that Buffer implement the memory interface.
-var _ schema.Memory = &Buffer{}
+// Statically assert that ConversationBuffer implement the memory interface.
+var _ schema.Memory = &ConversationBuffer{}
 
-// NewBuffer is a function for crating a new buffer memory.
-func NewBuffer(options ...BufferOption) *Buffer {
+// NewConversationBuffer is a function for crating a new buffer memory.
+func NewConversationBuffer(options ...ConversationBufferOption) *ConversationBuffer {
 	return applyBufferOptions(options...)
 }
 
+// Buffer gets buffer from memory.
+func (m *ConversationBuffer) Buffer() []schema.ChatMessage {
+	return m.chatHistory.Messages()
+}
+
 // MemoryVariables gets the input key the buffer memory class will load dynamically.
-func (m *Buffer) MemoryVariables() []string {
+func (m *ConversationBuffer) MemoryVariables() []string {
 	return []string{m.MemoryKey}
 }
 
@@ -39,14 +44,14 @@ func (m *Buffer) MemoryVariables() []string {
 // are returned in a map with the key specified in the MemoryKey field. This key defaults to
 // "history". If ReturnMessages is set to true the output is a slice of schema.ChatMessage. Otherwise
 // the output is a buffer string of the chat messages.
-func (m *Buffer) LoadMemoryVariables(map[string]any) (map[string]any, error) {
+func (m *ConversationBuffer) LoadMemoryVariables(map[string]any) (map[string]any, error) {
 	if m.ReturnMessages {
 		return map[string]any{
-			m.MemoryKey: m.ChatHistory.Messages(),
+			m.MemoryKey: m.chatHistory.Messages(),
 		}, nil
 	}
 
-	bufferString, err := schema.GetBufferString(m.ChatHistory.Messages(), m.HumanPrefix, m.AIPrefix)
+	bufferString, err := schema.GetBufferString(m.chatHistory.Messages(), m.HumanPrefix, m.AIPrefix)
 	if err != nil {
 		return nil, err
 	}
@@ -63,28 +68,30 @@ func (m *Buffer) LoadMemoryVariables(map[string]any) (map[string]any, error) {
 // input key must be a key in the input values and the output key must be a key in the output
 // values. The values in the input and output values used to save a user and ai message must
 // be strings.
-func (m *Buffer) SaveContext(inputValues map[string]any, outputValues map[string]any) error {
+func (m *ConversationBuffer) SaveContext(inputValues map[string]any, outputValues map[string]any) error {
 	userInputValue, err := getInputValue(inputValues, m.InputKey)
 	if err != nil {
 		return err
 	}
-
-	m.ChatHistory.AddUserMessage(userInputValue)
+	m.chatHistory.AddUserMessage(userInputValue)
 
 	aiOutputValue, err := getInputValue(outputValues, m.OutputKey)
 	if err != nil {
 		return err
 	}
-
-	m.ChatHistory.AddAIMessage(aiOutputValue)
+	m.chatHistory.AddAIMessage(aiOutputValue)
 
 	return nil
 }
 
 // Clear sets the chat messages to a new and empty chat message history.
-func (m *Buffer) Clear() error {
-	m.ChatHistory.Clear()
+func (m *ConversationBuffer) Clear() error {
+	m.chatHistory.Clear()
 	return nil
+}
+
+func (m *ConversationBuffer) GetMemoryKey() string {
+	return m.MemoryKey
 }
 
 func getInputValue(inputValues map[string]any, inputKey string) (string, error) {

--- a/memory/buffer_options.go
+++ b/memory/buffer_options.go
@@ -2,61 +2,61 @@ package memory
 
 import "github.com/tmc/langchaingo/schema"
 
-// BufferOption is a function for creating new buffer
+// ConversationBufferOption is a function for creating new buffer
 // with other then the default values.
-type BufferOption func(b *Buffer)
+type ConversationBufferOption func(b *ConversationBuffer)
 
 // WithChatHistory is an option for providing the chat history store.
-func WithChatHistory(chatHistory schema.ChatMessageHistory) BufferOption {
-	return func(b *Buffer) {
-		b.ChatHistory = chatHistory
+func WithChatHistory(chatHistory schema.ChatMessageHistory) ConversationBufferOption {
+	return func(b *ConversationBuffer) {
+		b.chatHistory = chatHistory
 	}
 }
 
 // WithReturnMessages is an option for specifying should it return messages.
-func WithReturnMessages(returnMessages bool) BufferOption {
-	return func(b *Buffer) {
+func WithReturnMessages(returnMessages bool) ConversationBufferOption {
+	return func(b *ConversationBuffer) {
 		b.ReturnMessages = returnMessages
 	}
 }
 
 // WithInputKey is an option for specifying the input key.
-func WithInputKey(inputKey string) BufferOption {
-	return func(b *Buffer) {
+func WithInputKey(inputKey string) ConversationBufferOption {
+	return func(b *ConversationBuffer) {
 		b.InputKey = inputKey
 	}
 }
 
 // WithOutputKey is an option for specifying the output key.
-func WithOutputKey(outputKey string) BufferOption {
-	return func(b *Buffer) {
+func WithOutputKey(outputKey string) ConversationBufferOption {
+	return func(b *ConversationBuffer) {
 		b.OutputKey = outputKey
 	}
 }
 
 // WithHumanPrefix is an option for specifying the human prefix.
-func WithHumanPrefix(humanPrefix string) BufferOption {
-	return func(b *Buffer) {
+func WithHumanPrefix(humanPrefix string) ConversationBufferOption {
+	return func(b *ConversationBuffer) {
 		b.HumanPrefix = humanPrefix
 	}
 }
 
 // WithAIPrefix is an option for specifying the AI prefix.
-func WithAIPrefix(aiPrefix string) BufferOption {
-	return func(b *Buffer) {
+func WithAIPrefix(aiPrefix string) ConversationBufferOption {
+	return func(b *ConversationBuffer) {
 		b.AIPrefix = aiPrefix
 	}
 }
 
 // WithMemoryKey is an option for specifying the memory key.
-func WithMemoryKey(memoryKey string) BufferOption {
-	return func(b *Buffer) {
+func WithMemoryKey(memoryKey string) ConversationBufferOption {
+	return func(b *ConversationBuffer) {
 		b.MemoryKey = memoryKey
 	}
 }
 
-func applyBufferOptions(opts ...BufferOption) *Buffer {
-	m := &Buffer{
+func applyBufferOptions(opts ...ConversationBufferOption) *ConversationBuffer {
+	m := &ConversationBuffer{
 		ReturnMessages: false,
 		InputKey:       "",
 		OutputKey:      "",
@@ -69,8 +69,8 @@ func applyBufferOptions(opts ...BufferOption) *Buffer {
 		opt(m)
 	}
 
-	if m.ChatHistory == nil {
-		m.ChatHistory = NewChatMessageHistory()
+	if m.chatHistory == nil {
+		m.chatHistory = NewChatMessageHistory()
 	}
 
 	return m

--- a/memory/buffer_options.go
+++ b/memory/buffer_options.go
@@ -9,7 +9,7 @@ type ConversationBufferOption func(b *ConversationBuffer)
 // WithChatHistory is an option for providing the chat history store.
 func WithChatHistory(chatHistory schema.ChatMessageHistory) ConversationBufferOption {
 	return func(b *ConversationBuffer) {
-		b.chatHistory = chatHistory
+		b.ChatHistory = chatHistory
 	}
 }
 
@@ -69,8 +69,8 @@ func applyBufferOptions(opts ...ConversationBufferOption) *ConversationBuffer {
 		opt(m)
 	}
 
-	if m.chatHistory == nil {
-		m.chatHistory = NewChatMessageHistory()
+	if m.ChatHistory == nil {
+		m.ChatHistory = NewChatMessageHistory()
 	}
 
 	return m

--- a/memory/buffer_test.go
+++ b/memory/buffer_test.go
@@ -50,7 +50,9 @@ func TestBufferMemoryReturnMessage(t *testing.T) {
 		}),
 	)
 
-	expected2 := map[string]any{"history": expectedChatHistory.Messages()}
+	messages, err := expectedChatHistory.Messages()
+	assert.NoError(t, err)
+	expected2 := map[string]any{"history": messages}
 	assert.Equal(t, expected2, result2)
 }
 
@@ -74,26 +76,31 @@ type testChatMessageHistory struct{}
 
 var _ schema.ChatMessageHistory = testChatMessageHistory{}
 
-func (t testChatMessageHistory) AddUserMessage(_ string) {
+func (t testChatMessageHistory) AddUserMessage(_ string) error {
+	return nil
 }
 
-func (t testChatMessageHistory) AddAIMessage(_ string) {
+func (t testChatMessageHistory) AddAIMessage(_ string) error {
+	return nil
 }
 
-func (t testChatMessageHistory) AddMessage(_ schema.ChatMessage) {
+func (t testChatMessageHistory) AddMessage(_ schema.ChatMessage) error {
+	return nil
 }
 
-func (t testChatMessageHistory) Clear() {
+func (t testChatMessageHistory) Clear() error {
+	return nil
 }
 
-func (t testChatMessageHistory) SetMessages(_ []schema.ChatMessage) {
+func (t testChatMessageHistory) SetMessages(_ []schema.ChatMessage) error {
+	return nil
 }
 
-func (t testChatMessageHistory) Messages() []schema.ChatMessage {
+func (t testChatMessageHistory) Messages() ([]schema.ChatMessage, error) {
 	return []schema.ChatMessage{
 		schema.HumanChatMessage{Content: "user message test"},
 		schema.AIChatMessage{Content: "ai message test"},
-	}
+	}, nil
 }
 
 func TestBufferMemoryWithChatHistoryOption(t *testing.T) {

--- a/memory/buffer_test.go
+++ b/memory/buffer_test.go
@@ -11,7 +11,7 @@ import (
 func TestBufferMemory(t *testing.T) {
 	t.Parallel()
 
-	m := NewBuffer()
+	m := NewConversationBuffer()
 	result1, err := m.LoadMemoryVariables(map[string]any{})
 	require.NoError(t, err)
 	expected1 := map[string]any{"history": ""}
@@ -30,7 +30,7 @@ func TestBufferMemory(t *testing.T) {
 func TestBufferMemoryReturnMessage(t *testing.T) {
 	t.Parallel()
 
-	m := NewBuffer()
+	m := NewConversationBuffer()
 	m.ReturnMessages = true
 	expected1 := map[string]any{"history": []schema.ChatMessage{}}
 	result1, err := m.LoadMemoryVariables(map[string]any{})
@@ -57,7 +57,7 @@ func TestBufferMemoryReturnMessage(t *testing.T) {
 func TestBufferMemoryWithPreLoadedHistory(t *testing.T) {
 	t.Parallel()
 
-	m := NewBuffer(WithChatHistory(NewChatMessageHistory(
+	m := NewConversationBuffer(WithChatHistory(NewChatMessageHistory(
 		WithPreviousMessages([]schema.ChatMessage{
 			schema.HumanChatMessage{Content: "bar"},
 			schema.AIChatMessage{Content: "foo"},
@@ -100,7 +100,7 @@ func TestBufferMemoryWithChatHistoryOption(t *testing.T) {
 	t.Parallel()
 
 	chatMessageHistory := testChatMessageHistory{}
-	m := NewBuffer(WithChatHistory(chatMessageHistory))
+	m := NewConversationBuffer(WithChatHistory(chatMessageHistory))
 
 	result, err := m.LoadMemoryVariables(map[string]any{})
 	require.NoError(t, err)

--- a/memory/chat.go
+++ b/memory/chat.go
@@ -16,28 +16,33 @@ func NewChatMessageHistory(options ...ChatMessageHistoryOption) *ChatMessageHist
 }
 
 // Messages returns all messages stored.
-func (h *ChatMessageHistory) Messages() []schema.ChatMessage {
-	return h.messages
+func (h *ChatMessageHistory) Messages() ([]schema.ChatMessage, error) {
+	return h.messages, nil
 }
 
 // AddAIMessage adds an AIMessage to the chat message history.
-func (h *ChatMessageHistory) AddAIMessage(text string) {
+func (h *ChatMessageHistory) AddAIMessage(text string) error {
 	h.messages = append(h.messages, schema.AIChatMessage{Content: text})
+	return nil
 }
 
 // AddUserMessage adds an user to the chat message history.
-func (h *ChatMessageHistory) AddUserMessage(text string) {
+func (h *ChatMessageHistory) AddUserMessage(text string) error {
 	h.messages = append(h.messages, schema.HumanChatMessage{Content: text})
+	return nil
 }
 
-func (h *ChatMessageHistory) Clear() {
+func (h *ChatMessageHistory) Clear() error {
 	h.messages = make([]schema.ChatMessage, 0)
+	return nil
 }
 
-func (h *ChatMessageHistory) AddMessage(message schema.ChatMessage) {
+func (h *ChatMessageHistory) AddMessage(message schema.ChatMessage) error {
 	h.messages = append(h.messages, message)
+	return nil
 }
 
-func (h *ChatMessageHistory) SetMessages(messages []schema.ChatMessage) {
+func (h *ChatMessageHistory) SetMessages(messages []schema.ChatMessage) error {
 	h.messages = messages
+	return nil
 }

--- a/memory/chat_test.go
+++ b/memory/chat_test.go
@@ -11,12 +11,18 @@ func TestChatMessageHistory(t *testing.T) {
 	t.Parallel()
 
 	h := NewChatMessageHistory()
-	h.AddAIMessage("foo")
-	h.AddUserMessage("bar")
+	err := h.AddAIMessage("foo")
+	assert.NoError(t, err)
+	err = h.AddUserMessage("bar")
+	assert.NoError(t, err)
+
+	messages, err := h.Messages()
+	assert.NoError(t, err)
+
 	assert.Equal(t, []schema.ChatMessage{
 		schema.AIChatMessage{Content: "foo"},
 		schema.HumanChatMessage{Content: "bar"},
-	}, h.Messages())
+	}, messages)
 
 	h = NewChatMessageHistory(
 		WithPreviousMessages([]schema.ChatMessage{
@@ -24,10 +30,15 @@ func TestChatMessageHistory(t *testing.T) {
 			schema.SystemChatMessage{Content: "bar"},
 		}),
 	)
-	h.AddUserMessage("zoo")
+	err = h.AddUserMessage("zoo")
+	assert.NoError(t, err)
+
+	messages, err = h.Messages()
+	assert.NoError(t, err)
+
 	assert.Equal(t, []schema.ChatMessage{
 		schema.AIChatMessage{Content: "foo"},
 		schema.SystemChatMessage{Content: "bar"},
 		schema.HumanChatMessage{Content: "zoo"},
-	}, h.Messages())
+	}, messages)
 }

--- a/memory/doc.go
+++ b/memory/doc.go
@@ -4,6 +4,6 @@ a variety of implementations for storing and retrieving that data.
 
 The main components of this package are:
 - ChatMessageHistory: a struct that stores chat messages.
-- Buffer: a simple form of memory that remembers previous conversational back and forths directly.
+- ConversationBuffer: a simple form of memory that remembers previous conversational back and forths directly.
 */
 package memory

--- a/memory/simple.go
+++ b/memory/simple.go
@@ -30,3 +30,7 @@ func (m Simple) SaveContext(map[string]any, map[string]any) error {
 func (m Simple) Clear() error {
 	return nil
 }
+
+func (m Simple) GetMemoryKey() string {
+	return ""
+}

--- a/memory/token_buffer.go
+++ b/memory/token_buffer.go
@@ -55,11 +55,11 @@ func (tb *ConversationTokenBuffer) SaveContext(inputValues map[string]any, outpu
 		// while currBufferLength is greater than MaxTokenLimit we keep removing messages from the memory
 		// from the oldest
 		for currBufferLength > tb.MaxTokenLimit {
-			if len(tb.chatHistory.Messages()) == 0 {
+			if len(tb.ChatHistory.Messages()) == 0 {
 				break
 			}
 
-			tb.chatHistory.SetMessages(append(tb.chatHistory.Messages()[:0], tb.chatHistory.Messages()[1:]...))
+			tb.ChatHistory.SetMessages(append(tb.ChatHistory.Messages()[:0], tb.ChatHistory.Messages()[1:]...))
 			currBufferLength, err = tb.getNumTokensFromMessages()
 			if err != nil {
 				return err
@@ -77,7 +77,7 @@ func (tb *ConversationTokenBuffer) Clear() error {
 
 func (tb *ConversationTokenBuffer) getNumTokensFromMessages() (int, error) {
 	bufferString, err := schema.GetBufferString(
-		tb.chatHistory.Messages(),
+		tb.ChatHistory.Messages(),
 		tb.ConversationBuffer.HumanPrefix,
 		tb.ConversationBuffer.AIPrefix,
 	)

--- a/memory/token_buffer_test.go
+++ b/memory/token_buffer_test.go
@@ -19,7 +19,7 @@ func TestTokenBufferMemory(t *testing.T) {
 
 	llm, err := openai.New()
 	require.NoError(t, err)
-	m := NewTokenBuffer(llm, 2000)
+	m := NewConversationTokenBuffer(llm, 2000)
 
 	result1, err := m.LoadMemoryVariables(map[string]any{})
 	require.NoError(t, err)
@@ -45,7 +45,7 @@ func TestTokenBufferMemoryReturnMessage(t *testing.T) {
 
 	llm, err := openai.New()
 	require.NoError(t, err)
-	m := NewTokenBuffer(llm, 2000, WithReturnMessages(true))
+	m := NewConversationTokenBuffer(llm, 2000, WithReturnMessages(true))
 
 	expected1 := map[string]any{"history": []schema.ChatMessage{}}
 	result1, err := m.LoadMemoryVariables(map[string]any{})
@@ -79,7 +79,7 @@ func TestTokenBufferMemoryWithPreLoadedHistory(t *testing.T) {
 	llm, err := openai.New()
 	require.NoError(t, err)
 
-	m := NewTokenBuffer(llm, 2000, WithChatHistory(NewChatMessageHistory(
+	m := NewConversationTokenBuffer(llm, 2000, WithChatHistory(NewChatMessageHistory(
 		WithPreviousMessages([]schema.ChatMessage{
 			schema.HumanChatMessage{Content: "bar"},
 			schema.AIChatMessage{Content: "foo"},

--- a/memory/token_buffer_test.go
+++ b/memory/token_buffer_test.go
@@ -65,7 +65,9 @@ func TestTokenBufferMemoryReturnMessage(t *testing.T) {
 		}),
 	)
 
-	expected2 := map[string]any{"history": expectedChatHistory.Messages()}
+	messages, err := expectedChatHistory.Messages()
+	require.NoError(t, err)
+	expected2 := map[string]any{"history": messages}
 	assert.Equal(t, expected2, result2)
 }
 

--- a/schema/chat_message_history.go
+++ b/schema/chat_message_history.go
@@ -3,20 +3,20 @@ package schema
 // ChatMessageHistory is the interface for chat history in memory/store.
 type ChatMessageHistory interface {
 	// AddUserMessage Convenience method for adding a human message string to the store.
-	AddUserMessage(message string)
+	AddUserMessage(message string) error
 
 	// AddAIMessage Convenience method for adding an AI message string to the store.
-	AddAIMessage(message string)
+	AddAIMessage(message string) error
 
 	// AddMessage Add a Message object to the store.
-	AddMessage(message ChatMessage)
+	AddMessage(message ChatMessage) error
 
 	// Clear Remove all messages from the store.
-	Clear()
+	Clear() error
 
 	// Messages get all messages from the store
-	Messages() []ChatMessage
+	Messages() ([]ChatMessage, error)
 
 	// SetMessages replaces existing messages in the store
-	SetMessages(messages []ChatMessage)
+	SetMessages(messages []ChatMessage) error
 }

--- a/schema/memory.go
+++ b/schema/memory.go
@@ -2,6 +2,8 @@ package schema
 
 // Memory is the interface for memory in chains.
 type Memory interface {
+	// GetMemoryKey getter for memory key.
+	GetMemoryKey() string
 	// MemoryVariables Input keys this memory class will load dynamically.
 	MemoryVariables() []string
 	// LoadMemoryVariables Return key-value pairs given the text input to the chain.


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

## Description
- this PR fixes the Conversational retrieval interface to accept `schema.Memory` instead of the `memory.Buffer`, by that we can in future pass in any memory that we need (for example Buffer, TokenBuffer or any other that we add).
- I've also renamed `Buffer` to be `ConversationBuffer` and `TokenBuffer` to be `ConversationTokenBuffer` so that we are closer to the langchain python implementation, so that it is easier on the eyes when we are comparing what is what.
- updated `ChatMessageHistory` schema to support errors, we need that when we port in psql, mongo or any other driven history, so that we don't swallow the errors when/if we have them