### PR TITLE
Chains/api chain CRUD support upgrade

### DIFF
--- a/chains/api.go
+++ b/chains/api.go
@@ -169,10 +169,10 @@ func (a APIChain) runRequest(
 
 	defer resp.Body.Close()
 
-	b, err := io.ReadAll(resp.Body)
+	resBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
 
-	return string(b), nil
+	return string(resBody), nil
 }

--- a/chains/api.go
+++ b/chains/api.go
@@ -48,7 +48,7 @@ const (
 	Summary:`
 )
 
-// HTTPRequester http requester interface.
+// HTTPRequest http requester interface.
 type HTTPRequest interface {
 	Do(*http.Request) (*http.Response, error)
 }
@@ -59,6 +59,10 @@ type APIChain struct {
 	Request      HTTPRequest
 }
 
+// NewAPIChain creates a new APIChain object.
+//
+// It takes a LanguageModel(llm) and an HTTPRequest(request) as parameters.
+// It returns an APIChain object.
 func NewAPIChain(llm llms.LanguageModel, request HTTPRequest) APIChain {
 	reqPrompt := prompts.NewPromptTemplate(_llmAPIURLPrompt, []string{"api_docs", "input"})
 	reqChain := NewLLMChain(llm, reqPrompt)
@@ -73,6 +77,10 @@ func NewAPIChain(llm llms.LanguageModel, request HTTPRequest) APIChain {
 	}
 }
 
+// Call executes the APIChain and returns the result.
+//
+// It takes a context.Context object, a map[string]any values, and optional ChainCallOption
+// values as input parameters. It returns a map[string]any and an error as output.
 func (a APIChain) Call(ctx context.Context, values map[string]any, opts ...ChainCallOption) (map[string]any, error) {
 	reqChainTmp := 0.0
 	opts = append(opts, WithTemperature(reqChainTmp))
@@ -121,14 +129,26 @@ func (a APIChain) Call(ctx context.Context, values map[string]any, opts ...Chain
 	return map[string]any{"answer": answer["text"]}, err
 }
 
+// GetMemory returns the memory of the APIChain.
+//
+// This function does not take any parameters.
+// It returns a schema.Memory object.
 func (a APIChain) GetMemory() schema.Memory { //nolint:ireturn
 	return memory.NewSimple()
 }
 
+// GetInputKeys returns the input keys of the APIChain.
+//
+// No parameters.
+// Returns a slice of strings, which contains the output keys.
 func (a APIChain) GetInputKeys() []string {
 	return []string{"api_docs", "input"}
 }
 
+// GetOutputKeys returns the output keys of the APIChain.
+//
+// It does not take any parameters.
+// It returns a slice of strings, which contains the output keys.
 func (a APIChain) GetOutputKeys() []string {
 	return []string{"answer"}
 }


### PR DESCRIPTION
Current api chain supports only `HTTP GET`, this PR upgrades the chain with the ability to perform `PUT`, `POST`, `DELETE`. 

The `reqChain` is updated to build and return a json string representing the request based on the provided API docs. The temp for request chain is set to 0.0 to ensure consistent json formatting.  The `HTTPRequester` interface is changed to support full CRUD capabilities. 

Once the request is performed the answer chain will summarise and inform about the API response, will handle success and various errors. 

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
