### PR TITLE
locallms: Split arguments with spaces in & remove quote around prompt

### DIFF
--- a/llms/local/internal/localclient/completions.go
+++ b/llms/local/internal/localclient/completions.go
@@ -3,7 +3,6 @@ package localclient
 import (
 	"context"
 	"os/exec"
-	"strconv"
 )
 
 type completionPayload struct {
@@ -16,7 +15,7 @@ type completionResponsePayload struct {
 
 func (c *Client) createCompletion(ctx context.Context, payload *completionPayload) (*completionResponsePayload, error) {
 	// Append the prompt to the args
-	c.Args = append(c.Args, strconv.Quote(payload.Prompt))
+	c.Args = append(c.Args, payload.Prompt)
 
 	// #nosec G204
 	out, err := exec.CommandContext(ctx, c.BinPath, c.Args...).Output()

--- a/llms/local/localllm.go
+++ b/llms/local/localllm.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/local/internal/localclient"
@@ -92,7 +93,11 @@ func (o *LLM) Generate(ctx context.Context, prompts []string, options ...llms.Ca
 	}, nil
 }
 
-func (o *LLM) GeneratePrompt(ctx context.Context, prompts []schema.PromptValue, options ...llms.CallOption) (llms.LLMResult, error) { //nolint:lll
+func (o *LLM) GeneratePrompt(
+	ctx context.Context,
+	prompts []schema.PromptValue,
+	options ...llms.CallOption,
+) (llms.LLMResult, error) { //nolint:lll
 	return llms.GeneratePrompt(ctx, o, prompts, options...)
 }
 
@@ -116,7 +121,7 @@ func New(opts ...Option) (*LLM, error) {
 		return nil, errors.Join(ErrMissingBin, err)
 	}
 
-	c, err := localclient.New(path, options.globalAsArgs, options.args)
+	c, err := localclient.New(path, options.globalAsArgs, strings.Split(options.args, " ")...)
 	return &LLM{
 		client: c,
 	}, err


### PR DESCRIPTION
I attempted to use Llama with LangChainGo utilizing the "local" LLM, but encountered some issues when I tried to send arguments (specifically the model path) to the binary.

I faced an error when I tried using local.WithArgs("-m <path_to_the_model> -p"). It seemed as if the list of arguments was being sent to exec.CommandContext as a single argument.

Once I got it up and running, I noticed that extra quotes were added to the prompt.

To me, it seems like it was designed to be parsed by Bash, but it doesn't appear to be so.

I'm not entirely sure if this is actually a bug, or perhaps I used it incorrectly. If it's supposed to work like this, feel free to close this PR.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
