### PR TITLE
bugfix: sql null column error

### DIFF
--- a/tools/sqldatabase/mysql/mysql.go
+++ b/tools/sqldatabase/mysql/mysql.go
@@ -66,8 +66,8 @@ func (m MySQL) Query(ctx context.Context, query string, args ...any) ([]string, 
 		if err != nil {
 			return nil, nil, err
 		}
-		for _, v := range rowNullable {
-			row = append(row, v.String)
+		for i := range rowNullable {
+			row[i] = rowNullable[i].String
 		}
 		results = append(results, row)
 	}

--- a/tools/sqldatabase/mysql/mysql.go
+++ b/tools/sqldatabase/mysql/mysql.go
@@ -57,13 +57,17 @@ func (m MySQL) Query(ctx context.Context, query string, args ...any) ([]string, 
 	results := make([][]string, 0)
 	for rows.Next() {
 		row := make([]string, len(cols))
+		rowNullable := make([]sql.NullString, len(cols))
 		rowPtrs := make([]interface{}, len(cols))
 		for i := range row {
-			rowPtrs[i] = &row[i]
+			rowPtrs[i] = &rowNullable[i]
 		}
 		err = rows.Scan(rowPtrs...)
 		if err != nil {
 			return nil, nil, err
+		}
+		for _, v := range rowNullable {
+			row = append(row, v.String)
 		}
 		results = append(results, row)
 	}

--- a/tools/sqldatabase/mysql/mysql_test.go
+++ b/tools/sqldatabase/mysql/mysql_test.go
@@ -3,6 +3,7 @@ package mysql_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -35,7 +36,7 @@ func Test(t *testing.T) {
 		_, err = db.Query(context.Background(), fmt.Sprintf("SELECT * from %s LIMIT 1", tableName))
 		/* exclude no row error,
 		since we only need to check if db.Query function can perform query correctly*/
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			continue
 		}
 		require.NoError(t, err)

--- a/tools/sqldatabase/mysql/mysql_test.go
+++ b/tools/sqldatabase/mysql/mysql_test.go
@@ -33,7 +33,9 @@ func Test(t *testing.T) {
 
 	for _, tableName := range tbs {
 		_, err = db.Query(context.Background(), fmt.Sprintf("SELECT * from %s LIMIT 1", tableName))
-		if err == sql.ErrNoRows { // exclude no row error, since we only need to check if db.Query function can perform query correctly
+		/* exclude no row error,
+		since we only need to check if db.Query function can perform query correctly*/
+		if err == sql.ErrNoRows {
 			continue
 		}
 		require.NoError(t, err)

--- a/tools/sqldatabase/mysql/mysql_test.go
+++ b/tools/sqldatabase/mysql/mysql_test.go
@@ -2,6 +2,8 @@ package mysql_test
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"os"
 	"testing"
 
@@ -28,4 +30,12 @@ func Test(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log(desc)
+
+	for _, tableName := range tbs {
+		_, err = db.Query(context.Background(), fmt.Sprintf("SELECT * from %s LIMIT 1", tableName))
+		if err == sql.ErrNoRows { // exclude no row error, since we only need to check if db.Query function can perform query correctly
+			continue
+		}
+		require.NoError(t, err)
+	}
 }

--- a/tools/sqldatabase/postgresql/postgresql.go
+++ b/tools/sqldatabase/postgresql/postgresql.go
@@ -73,8 +73,8 @@ func (p PostgreSQL) Query(ctx context.Context, query string, args ...any) ([]str
 		if err != nil {
 			return nil, nil, err
 		}
-		for _, v := range rowNullable {
-			row = append(row, v.String)
+		for i := range rowNullable {
+			row[i] = rowNullable[i].String
 		}
 		results = append(results, row)
 	}

--- a/tools/sqldatabase/postgresql/postgresql.go
+++ b/tools/sqldatabase/postgresql/postgresql.go
@@ -64,13 +64,17 @@ func (p PostgreSQL) Query(ctx context.Context, query string, args ...any) ([]str
 	results := make([][]string, 0)
 	for rows.Next() {
 		row := make([]string, len(cols))
+		rowNullable := make([]sql.NullString, len(cols))
 		rowPtrs := make([]interface{}, len(cols))
 		for i := range row {
-			rowPtrs[i] = &row[i]
+			rowPtrs[i] = &rowNullable[i]
 		}
 		err = rows.Scan(rowPtrs...)
 		if err != nil {
 			return nil, nil, err
+		}
+		for _, v := range rowNullable {
+			row = append(row, v.String)
 		}
 		results = append(results, row)
 	}

--- a/tools/sqldatabase/postgresql/postgresql_test.go
+++ b/tools/sqldatabase/postgresql/postgresql_test.go
@@ -3,6 +3,7 @@ package postgresql_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -34,7 +35,7 @@ func Test(t *testing.T) {
 		_, err = db.Query(context.Background(), fmt.Sprintf("SELECT * from %s LIMIT 1", tableName))
 		/* exclude no row error,
 		since we only need to check if db.Query function can perform query correctly*/
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			continue
 		}
 		require.NoError(t, err)

--- a/tools/sqldatabase/postgresql/postgresql_test.go
+++ b/tools/sqldatabase/postgresql/postgresql_test.go
@@ -32,7 +32,9 @@ func Test(t *testing.T) {
 
 	for _, tableName := range tbs {
 		_, err = db.Query(context.Background(), fmt.Sprintf("SELECT * from %s LIMIT 1", tableName))
-		if err == sql.ErrNoRows { // exclude no row error, since we only need to check if db.Query function can perform query correctly
+		/* exclude no row error,
+		since we only need to check if db.Query function can perform query correctly*/
+		if err == sql.ErrNoRows {
 			continue
 		}
 		require.NoError(t, err)

--- a/tools/sqldatabase/postgresql/postgresql_test.go
+++ b/tools/sqldatabase/postgresql/postgresql_test.go
@@ -40,5 +40,4 @@ func Test(t *testing.T) {
 		}
 		require.NoError(t, err)
 	}
-
 }

--- a/tools/sqldatabase/postgresql/postgresql_test.go
+++ b/tools/sqldatabase/postgresql/postgresql_test.go
@@ -2,6 +2,8 @@ package postgresql_test
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"os"
 	"testing"
 
@@ -27,4 +29,13 @@ func Test(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log(desc)
+
+	for _, tableName := range tbs {
+		_, err = db.Query(context.Background(), fmt.Sprintf("SELECT * from %s LIMIT 1", tableName))
+		if err == sql.ErrNoRows { // exclude no row error, since we only need to check if db.Query function can perform query correctly
+			continue
+		}
+		require.NoError(t, err)
+	}
+
 }

--- a/tools/sqldatabase/sqlite3/sqlite3.go
+++ b/tools/sqldatabase/sqlite3/sqlite3.go
@@ -56,13 +56,17 @@ func (m SQLite3) Query(ctx context.Context, query string, args ...any) ([]string
 	results := make([][]string, 0)
 	for rows.Next() {
 		row := make([]string, len(cols))
+		rowNullable := make([]sql.NullString, len(cols))
 		rowPtrs := make([]interface{}, len(cols))
 		for i := range row {
-			rowPtrs[i] = &row[i]
+			rowPtrs[i] = &rowNullable[i]
 		}
 		err = rows.Scan(rowPtrs...)
 		if err != nil {
 			return nil, nil, err
+		}
+		for _, v := range rowNullable {
+			row = append(row, v.String)
 		}
 		results = append(results, row)
 	}

--- a/tools/sqldatabase/sqlite3/sqlite3.go
+++ b/tools/sqldatabase/sqlite3/sqlite3.go
@@ -65,8 +65,8 @@ func (m SQLite3) Query(ctx context.Context, query string, args ...any) ([]string
 		if err != nil {
 			return nil, nil, err
 		}
-		for _, v := range rowNullable {
-			row = append(row, v.String)
+		for i := range rowNullable {
+			row[i] = rowNullable[i].String
 		}
 		results = append(results, row)
 	}

--- a/tools/sqldatabase/sqlite3/sqlite3_test.go
+++ b/tools/sqldatabase/sqlite3/sqlite3_test.go
@@ -3,6 +3,7 @@ package sqlite3_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -52,7 +53,7 @@ func Test(t *testing.T) {
 		_, err = db.Query(context.Background(), fmt.Sprintf("SELECT * from %s LIMIT 1", tableName))
 		/* exclude no row error,
 		since we only need to check if db.Query function can perform query correctly*/
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			continue
 		}
 		require.NoError(t, err)

--- a/tools/sqldatabase/sqlite3/sqlite3_test.go
+++ b/tools/sqldatabase/sqlite3/sqlite3_test.go
@@ -3,6 +3,7 @@ package sqlite3_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -46,4 +47,12 @@ func Test(t *testing.T) {
 	require.True(t, strings.Contains(desc, "Activity"))       //nolint:stylecheck
 	require.True(t, strings.Contains(desc, "Activity1"))      //nolint:stylecheck
 	require.True(t, strings.Contains(desc, "Activity2"))      //nolint:stylecheck
+
+	for _, tableName := range tbs {
+		_, err = db.Query(context.Background(), fmt.Sprintf("SELECT * from %s LIMIT 1", tableName))
+		if err == sql.ErrNoRows { // exclude no row error, since we only need to check if db.Query function can perform query correctly
+			continue
+		}
+		require.NoError(t, err)
+	}
 }

--- a/tools/sqldatabase/sqlite3/sqlite3_test.go
+++ b/tools/sqldatabase/sqlite3/sqlite3_test.go
@@ -50,7 +50,9 @@ func Test(t *testing.T) {
 
 	for _, tableName := range tbs {
 		_, err = db.Query(context.Background(), fmt.Sprintf("SELECT * from %s LIMIT 1", tableName))
-		if err == sql.ErrNoRows { // exclude no row error, since we only need to check if db.Query function can perform query correctly
+		/* exclude no row error,
+		since we only need to check if db.Query function can perform query correctly*/
+		if err == sql.ErrNoRows {
 			continue
 		}
 		require.NoError(t, err)


### PR DESCRIPTION
Currently when using sql chain on tables with nullable columns, it will return converting null to string error is not supported. To mitigate this issue, I'm suggesting to use sql.NullString to handle null values.
Fixes https://github.com/tmc/langchaingo/issues/235

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
