### PR TITLE
openai: allow creating llm with client with an explicitly specified model

### DIFF
--- a/embeddings/openai/openai.go
+++ b/embeddings/openai/openai.go
@@ -28,6 +28,19 @@ func NewOpenAI(opts ...Option) (OpenAI, error) {
 	return o, nil
 }
 
+func NewOpenAIWithClient(client *openai.LLM, opts ...Option) (OpenAI, error) {
+	o, err := NewOpenAI(opts...)
+	if err != nil {
+		return OpenAI{}, err
+	}
+
+	if client != nil {
+		o.client = client
+	}
+
+	return o, nil
+}
+
 // EmbedDocuments creates one vector embedding for each of the texts.
 func (e OpenAI) EmbedDocuments(ctx context.Context, texts []string) ([][]float64, error) {
 	batchedTexts := embeddings.BatchTexts(


### PR DESCRIPTION
Currently, the model used by the underlying client of the `LLM` struct in the `OpenAI` implementation is taken from the environment variable. Same applies to other settings applicable to the `OpenAI` client. This is inconvenient and should be allowed to be set explicitly.