### PR TITLE
vectorstore/options: Extending Vectorstore options to accept optional embedder

### DIFF
--- a/vectorstores/options.go
+++ b/vectorstores/options.go
@@ -1,5 +1,7 @@
 package vectorstores
 
+import "github.com/tmc/langchaingo/embeddings"
+
 // Option is a function that configures an Options.
 type Option func(*Options)
 
@@ -8,6 +10,7 @@ type Options struct {
 	NameSpace      string
 	ScoreThreshold float64
 	Filters        any
+	Embedder       embeddings.Embedder
 }
 
 // WithNameSpace returns an Option for setting the name space.
@@ -30,5 +33,14 @@ func WithScoreThreshold(scoreThreshold float64) Option {
 func WithFilters(filters any) Option {
 	return func(o *Options) {
 		o.Filters = filters
+	}
+}
+
+// WithEmbedder returns an Option for setting the embedder that could be used when
+// adding documents or doing similarity search (instead the embedder from the Store context)
+// this is useful when we are using multiple LLMs with single vectorstore.
+func WithEmbedder(embedder embeddings.Embedder) Option {
+	return func(o *Options) {
+		o.Embedder = embedder
 	}
 }


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

## Description
- this option allows us to use different embedders, if we have single vectorstore (like posgresql) which can handle (storing/using) multiple embeddings.

### Usage example:
```
....
        // dummy list of embedders
        embedders := map[string]embedder.Embedder{
		"openai": openaiEmbedder,
		"huggingface": huggingfaceEmbedder,
		"vertexai": vertexaiEmbedder,
		"someother": someotherEmbedder,
	}
        emd := embedders["openai"] // dummy example pulling the embedders from the list of supported embedders

 	result, err := chains.Run(
		context.TODO(),
		chains.NewRetrievalQAFromLLM(
			llm,
			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(id), vectorstore.WithEmbedder(emb)),
		),
		"What colors is each piece of furniture next to the desk?",
	)
....
```
from this point on, our `store` when the `AddDocuments` or `SimilaritySearch` methods are called from the vectorstore interface, we can actually use the needed embedder and not be tied to only one.

for example
```
// Store is a wrapper around the pinecone rest API and grpc client.
type Store struct {
	some store configuration where we could have or not have embedder
}

funct (s Store) AddDocuments(ctx context.Context, docs []schema.Document, options ...vectorstores.Option) error {
     opts := v.getOptions(options...)
     vectors, err := options.Embeder.EmbedDocuments(ctx, texts)
   ....
}
````