### PR TITLE
Fixed OpenAI APITypeAzureAD header authentication field error

### DIFF
--- a/llms/openai/internal/openaiclient/openaiclient.go
+++ b/llms/openai/internal/openaiclient/openaiclient.go
@@ -150,10 +150,10 @@ func IsAzure(apiType APIType) bool {
 
 func (c *Client) setHeaders(req *http.Request) {
 	req.Header.Set("Content-Type", "application/json")
-	if IsAzure(c.apiType) {
-		req.Header.Set("api-key", c.token)
-	} else {
+	if c.apiType == APITypeOpenAI || c.apiType == APITypeAzureAD {
 		req.Header.Set("Authorization", "Bearer "+c.token)
+	} else {
+		req.Header.Set("api-key", c.token)
 	}
 	if c.organization != "" {
 		req.Header.Set("OpenAI-Organization", c.organization)


### PR DESCRIPTION
When using the openai API with the `AZURE_AD` type, I found that there was an error when making the API call. After debugging, I discovered that the authentication field in the header was incorrectly set to `api-key` instead of `Authorization`.

```go
if IsAzure(c.apiType) {
	req.Header.Set("api-key", c.token)
} else {
	req.Header.Set("Authorization", "Bearer "+c.token)
}
```

change to :
```go
if c.apiType == APITypeOpenAI || c.apiType == APITypeAzureAD {
	req.Header.Set("Authorization", "Bearer "+c.token)
} else {
	req.Header.Set("api-key", c.token)
}
```

Please refer to the implementation in the Python OpenAI library:
https://github.com/openai/openai-python/blob/9d559b064cda09d56c1ebf756be4a1f73d5a275a/openai/util.py#L21C1-L25C2

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
