### PR TITLE
cleanup: remove unused msg conversion - openaillm_chat

### DIFF
--- a/llms/openai/openaillm_chat.go
+++ b/llms/openai/openaillm_chat.go
@@ -61,35 +61,6 @@ func (o *Chat) Generate(ctx context.Context, messageSets [][]schema.ChatMessage,
 	}
 	generations := make([]*llms.Generation, 0, len(messageSets))
 	for _, messageSet := range messageSets {
-		msgs := make([]*openaiclient.ChatMessage, len(messageSet))
-		for i, m := range messageSet {
-			msg := &openaiclient.ChatMessage{
-				Content: m.GetContent(),
-			}
-			typ := m.GetType()
-			switch typ {
-			case schema.ChatMessageTypeSystem:
-				msg.Role = RoleSystem
-			case schema.ChatMessageTypeAI:
-				msg.Role = RoleAssistant
-				if aiChatMsg, ok := m.(schema.AIChatMessage); ok && aiChatMsg.FunctionCall != nil {
-					msg.FunctionCall = &openaiclient.FunctionCall{
-						Name:      aiChatMsg.FunctionCall.Name,
-						Arguments: aiChatMsg.FunctionCall.Arguments,
-					}
-				}
-			case schema.ChatMessageTypeHuman:
-				msg.Role = RoleUser
-			case schema.ChatMessageTypeGeneric:
-				msg.Role = RoleUser
-			case schema.ChatMessageTypeFunction:
-				msg.Role = RoleFunction
-			}
-			if n, ok := m.(schema.Named); ok {
-				msg.Name = n.GetName()
-			}
-			msgs[i] = msg
-		}
 		req := &openaiclient.ChatRequest{
 			Model:            opts.Model,
 			StopWords:        opts.StopWords,


### PR DESCRIPTION
Conversion of messages from `schema.Message*` to openai client messages seems have been moved to a dedicated function but the old code was still there.

Question for maintainers: 

This case
```
case schema.ChatMessageTypeAI:
    msg.Role = RoleAssistant
    if aiChatMsg, ok := m.(schema.AIChatMessage); ok && aiChatMsg.FunctionCall != nil {
	    msg.FunctionCall = &openaiclient.FunctionCall{
		    Name:      aiChatMsg.FunctionCall.Name,
		    Arguments: aiChatMsg.FunctionCall.Arguments,
	    }
    }
```
isn't handled by `messagesToClientMessages` here: https://github.com/urjitbhatia/langchaingo/blob/main/llms/openai/openaillm_chat.go#L156

is that on purpose or an accidental omission?


### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

