### PR TITLE
prompts: use sprig.TxtFuncMap() as the template's function map

### DIFF
--- a/prompts/templates.go
+++ b/prompts/templates.go
@@ -35,7 +35,7 @@ var defaultformatterMapping = map[TemplateFormat]interpolator{ //nolint:gocheckn
 func interpolateGoTemplate(tmpl string, values map[string]any) (string, error) {
 	parsedTmpl, err := template.New("template").
 		Option("missingkey=error").
-		Funcs(sprig.FuncMap()).
+		Funcs(sprig.TxtFuncMap()).
 		Parse(tmpl)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

Fixes #287 

Currently, `prompts` package uses `sprig.FuncMap()` as the template's function map, which is an instance of the `html/template.FuncMap` type. However, the `interpolateGoTemplate` function uses `text/template` for template generation and requires a `text/template.FuncMap`. Although there is no significant distinction between the two in Go 1.19 and later versions, for versions prior to 1.19, the `interpolateGoTemplate` function will result in an error. This PR uses `sprig.TxtFuncMap()` as the template's function map.
