### PR TITLE
Added possiblity to add options to VertexAI client

### DIFF
--- a/llms/vertexai/vertexai_palm_llm_option.go
+++ b/llms/vertexai/vertexai_palm_llm_option.go
@@ -62,6 +62,18 @@ func WithCredentialsJSON(json []byte) Option {
 	return convertByteArrayOption(option.WithCredentialsJSON)(json)
 }
 
+func WithGRPCDialOption(opt grpc.DialOption) Option {
+	return func(opts *options) {
+		opts.clientOptions = append(opts.clientOptions, option.WithGRPCDialOption(opt))
+	}
+}
+
+func WithHTTPClient(client *http.Client) Option {
+	return func(opts *options) {
+		opts.clientOptions = append(opts.clientOptions, option.WithHTTPClient(client))
+	}
+}
+
 func convertStringOption(fopt func(string) option.ClientOption) func(string) Option {
 	return func(param string) Option {
 		return func(opts *options) {

--- a/llms/vertexai/vertexai_palm_llm_option.go
+++ b/llms/vertexai/vertexai_palm_llm_option.go
@@ -1,10 +1,12 @@
 package vertexai
 
 import (
+	"net/http"
 	"os"
 	"sync"
 
 	"google.golang.org/api/option"
+	"google.golang.org/grpc"
 )
 
 const (


### PR DESCRIPTION
This is a small PR that allows the user to pass options to the VertexAI client initalisation. 