### PR TITLE
Added stop_sequences support to vertexai client

### DIFF
--- a/llms/vertexai/internal/vertexaiclient/palm_client.go
+++ b/llms/vertexai/internal/vertexaiclient/palm_client.go
@@ -245,12 +245,7 @@ func mergeParams(defaultParams, params map[string]interface{}) *structpb.Struct 
 				mergedParams[paramKey] = value
 			}
 		case []string:
-			new := make([]interface{}, len(value))
-			for i, v := range value {
-				new[i] = v
-			}
-			//mergedParams[paramKey], _ = structpb.NewList(new)*/
-			mergedParams[paramKey] = new
+			mergedParams[paramKey] = convertArray(value)
 		}
 	}
 	smergedParams, err := structpb.NewStruct(mergedParams)
@@ -259,6 +254,14 @@ func mergeParams(defaultParams, params map[string]interface{}) *structpb.Struct 
 		return smergedParams
 	}
 	return smergedParams
+}
+
+func convertArray(value []string) interface{} {
+	new := make([]interface{}, len(value))
+	for i, v := range value {
+		new[i] = v
+	}
+	return new
 }
 
 func (c *PaLMClient) batchPredict(ctx context.Context, model string, prompts []string, params map[string]interface{}) ([]*structpb.Value, error) { //nolint:lll

--- a/llms/vertexai/internal/vertexaiclient/palm_client.go
+++ b/llms/vertexai/internal/vertexaiclient/palm_client.go
@@ -95,7 +95,7 @@ func (c *PaLMClient) CreateCompletion(ctx context.Context, r *CompletionRequest)
 		"temperature":     r.Temperature,
 		"top_p":           r.TopP,
 		"top_k":           r.TopK,
-		"stopSequences":   r.StopSequences,
+		"stopSequences":   convertArray(r.StopSequences),
 	}
 	predictions, err := c.batchPredict(ctx, TextModelName, r.Prompts, params)
 	if err != nil {
@@ -244,8 +244,6 @@ func mergeParams(defaultParams, params map[string]interface{}) *structpb.Struct 
 			if value != 0 {
 				mergedParams[paramKey] = value
 			}
-		case []string:
-			mergedParams[paramKey] = convertArray(value)
 		}
 	}
 	smergedParams, err := structpb.NewStruct(mergedParams)
@@ -257,11 +255,11 @@ func mergeParams(defaultParams, params map[string]interface{}) *structpb.Struct 
 }
 
 func convertArray(value []string) interface{} {
-	new := make([]interface{}, len(value))
+	newArray := make([]interface{}, len(value))
 	for i, v := range value {
-		new[i] = v
+		newArray[i] = v
 	}
-	return new
+	return newArray
 }
 
 func (c *PaLMClient) batchPredict(ctx context.Context, model string, prompts []string, params map[string]interface{}) ([]*structpb.Value, error) { //nolint:lll

--- a/llms/vertexai/internal/vertexaiclient/palm_client.go
+++ b/llms/vertexai/internal/vertexaiclient/palm_client.go
@@ -75,11 +75,12 @@ var ErrEmptyResponse = errors.New("empty response")
 
 // CompletionRequest is a request to create a completion.
 type CompletionRequest struct {
-	Prompts     []string `json:"prompts"`
-	MaxTokens   int      `json:"max_tokens"`
-	Temperature float64  `json:"temperature,omitempty"`
-	TopP        int      `json:"top_p,omitempty"`
-	TopK        int      `json:"top_k,omitempty"`
+	Prompts       []string `json:"prompts"`
+	MaxTokens     int      `json:"max_tokens"`
+	Temperature   float64  `json:"temperature,omitempty"`
+	TopP          int      `json:"top_p,omitempty"`
+	TopK          int      `json:"top_k,omitempty"`
+	StopSequences []string `json:"stop_sequences"`
 }
 
 // Completion is a completion.
@@ -94,6 +95,7 @@ func (c *PaLMClient) CreateCompletion(ctx context.Context, r *CompletionRequest)
 		"temperature":     r.Temperature,
 		"top_p":           r.TopP,
 		"top_k":           r.TopK,
+		"stopSequences":   r.StopSequences,
 	}
 	predictions, err := c.batchPredict(ctx, TextModelName, r.Prompts, params)
 	if err != nil {
@@ -242,6 +244,13 @@ func mergeParams(defaultParams, params map[string]interface{}) *structpb.Struct 
 			if value != 0 {
 				mergedParams[paramKey] = value
 			}
+		case []string:
+			new := make([]interface{}, len(value))
+			for i, v := range value {
+				new[i] = v
+			}
+			//mergedParams[paramKey], _ = structpb.NewList(new)*/
+			mergedParams[paramKey] = new
 		}
 	}
 	smergedParams, err := structpb.NewStruct(mergedParams)

--- a/llms/vertexai/vertexai_palm_llm.go
+++ b/llms/vertexai/vertexai_palm_llm.go
@@ -49,9 +49,10 @@ func (o *LLM) Generate(ctx context.Context, prompts []string, options ...llms.Ca
 		opt(&opts)
 	}
 	results, err := o.client.CreateCompletion(ctx, &vertexaiclient.CompletionRequest{
-		Prompts:     prompts,
-		MaxTokens:   opts.MaxTokens,
-		Temperature: opts.Temperature,
+		Prompts:       prompts,
+		MaxTokens:     opts.MaxTokens,
+		Temperature:   opts.Temperature,
+		StopSequences: opts.StopWords,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
At the moment langchaingo's vertexai client doesn't include `stop_sequences`, this leads to problems with agents when the prediction doesn't stop at `Observation:` which then will include hallucinated tool output.