### PR TITLE
bugfix: openai fix model option

### DIFF
--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -90,6 +90,7 @@ func (o *LLM) GetNumTokens(text string) int {
 func (o *LLM) CreateEmbedding(ctx context.Context, inputTexts []string) ([][]float32, error) {
 	embeddings, err := o.client.CreateEmbedding(ctx, &openaiclient.EmbeddingRequest{
 		Input: inputTexts,
+		Model: o.client.Model,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
openai.New(openai.WithModel("model_name")) not work, it will use defaultEmbeddingModel as "text-embedding-ada-002"