### PR TITLE
ci: Pin golangci-lint to 1.54

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,10 @@ jobs:
           cache: false
       - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.6.0
+        uses: golangci/golangci-lint-action@v3.7.0
         with:
           args: --timeout=4m
+          version: v1.54.2
   build-examples:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fixes #339