### PR TITLE
ci: Pin golangci-lint to 1.55

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3.7.0
         with:
           args: --timeout=4m
-          version: v1.54.2
+          version: v1.55.1
   build-examples:
     runs-on: ubuntu-latest
     steps:

--- a/chains/api.go
+++ b/chains/api.go
@@ -50,7 +50,7 @@ const (
 
 // HTTPRequest http requester interface.
 type HTTPRequest interface {
-	Do(*http.Request) (*http.Response, error)
+	Do(req *http.Request) (*http.Response, error)
 }
 
 type APIChain struct {

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -2,7 +2,7 @@ package chains
 
 import (
 	"context"
-	"fmt"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -55,7 +55,7 @@ func TestApply(t *testing.T) {
 	inputs := make([]map[string]any, numInputs)
 	for i := 0; i < len(inputs); i++ {
 		inputs[i] = map[string]any{
-			"text": fmt.Sprint(i),
+			"text": strconv.Itoa(i),
 		}
 	}
 

--- a/chains/constitution/constitutional_test.go
+++ b/chains/constitution/constitutional_test.go
@@ -31,7 +31,7 @@ func TestConstitutionCritiqueParsing(t *testing.T) {
 
 	for _, rawCritique := range []string{textOne, textTwo, textThree} {
 		critique := parseCritique(rawCritique)
-		require.Equal(t, strings.TrimSpace(critique), "This text is bad.",
+		require.Equal(t, "This text is bad.", strings.TrimSpace(critique),
 			fmt.Sprintf("Failed on %s with %s", rawCritique, critique))
 	}
 }

--- a/chains/constitutional_test.go
+++ b/chains/constitutional_test.go
@@ -30,7 +30,7 @@ func TestConstitutionCritiqueParsing(t *testing.T) {
 
 	for _, rawCritique := range []string{textOne, textTwo, textThree} {
 		critique := parseCritique(rawCritique)
-		require.Equal(t, strings.TrimSpace(critique), "This text is bad.",
+		require.Equal(t, "This text is bad.", strings.TrimSpace(critique),
 			fmt.Sprintf("Failed on %s with %s", rawCritique, critique))
 	}
 }

--- a/chains/llm_math.go
+++ b/chains/llm_math.go
@@ -15,20 +15,21 @@ import (
 )
 
 const (
+	quote          = "```"
 	_llmMathPrompt = `Translate a math problem into a expression that can be evaluated as Starlark.
 Use the output of running this code to answer the question.
 
 ---
 Question: (Question with math problem.)
-` + "```" + `starlark
+` + quote + `starlark
 $(single line expression that solves the problem)
-` + "```" + `
+` + quote + `
 
 ---
 Question: What is 37593 * 67?
-` + "```" + `starlark
+` + quote + `starlark
 37593 * 67
-` + "```" + `
+` + quote + `
 
 ---
 Question: {{.question}}

--- a/chains/map_reduce_test.go
+++ b/chains/map_reduce_test.go
@@ -28,7 +28,7 @@ func TestMapReduceInputVariables(t *testing.T) {
 
 	inputKeys := c.GetInputKeys()
 	expectedLength := 3
-	require.Equal(t, expectedLength, len(inputKeys))
+	require.Len(t, inputKeys, expectedLength)
 }
 
 func TestMapReduce(t *testing.T) {

--- a/chains/map_rerank_documents_test.go
+++ b/chains/map_rerank_documents_test.go
@@ -26,7 +26,7 @@ func TestMapRerankInputVariables(t *testing.T) {
 
 	inputKeys := c.GetInputKeys()
 	expectedLength := 3
-	require.Equal(t, expectedLength, len(inputKeys))
+	require.Len(t, inputKeys, expectedLength)
 }
 
 func TestMapRerankDocumentsCall(t *testing.T) {

--- a/chains/prompt_selector.go
+++ b/chains/prompt_selector.go
@@ -8,7 +8,7 @@ import (
 // PromptSelector is the interface for selecting a formatter depending on the
 // LLM given.
 type PromptSelector interface {
-	GetPrompt(llms.LanguageModel) prompts.PromptTemplate
+	GetPrompt(llm llms.LanguageModel) prompts.PromptTemplate
 }
 
 // ConditionalPromptSelector is a formatter selector that selects a prompt

--- a/chains/sequential_test.go
+++ b/chains/sequential_test.go
@@ -71,11 +71,11 @@ func TestSimpleSequentialErrors(t *testing.T) {
 			t.Parallel()
 			c, err := NewSimpleSequentialChain([]Chain{tc.chain})
 			if tc.initErr != nil {
-				assert.ErrorIs(t, err, tc.initErr)
+				require.ErrorIs(t, err, tc.initErr)
 			} else {
 				require.NoError(t, err)
 				_, err := Run(context.Background(), c, "Do something")
-				assert.ErrorIs(t, err, tc.execErr)
+				require.ErrorIs(t, err, tc.execErr)
 			}
 		})
 	}
@@ -184,11 +184,11 @@ func TestSequentialChainErrors(t *testing.T) {
 			t.Parallel()
 			c, err := NewSequentialChain(tc.chains, []string{"input1", "input2"}, []string{"output"}, tc.seqChainOpts...)
 			if tc.initErr != nil {
-				assert.ErrorIs(t, err, tc.initErr)
+				require.ErrorIs(t, err, tc.initErr)
 			} else {
 				require.NoError(t, err)
 				_, err := Call(context.Background(), c, map[string]any{"input1": "foo", "input2": "bar"})
-				assert.ErrorIs(t, err, tc.execErr)
+				require.ErrorIs(t, err, tc.execErr)
 			}
 		})
 	}

--- a/chains/sql_database_test.go
+++ b/chains/sql_database_test.go
@@ -41,7 +41,7 @@ func TestSQLDatabaseChain_Call(t *testing.T) {
 
 	ret, ok := result["result"].(string)
 	require.True(t, ok)
-	require.Greater(t, len(ret), 0)
+	require.NotEmpty(t, ret)
 
 	t.Log(ret)
 }

--- a/documentloaders/csv_test.go
+++ b/documentloaders/csv_test.go
@@ -12,7 +12,7 @@ import (
 func TestCSVLoader(t *testing.T) {
 	t.Parallel()
 	file, err := os.Open("./testdata/test.csv")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loader := NewCSV(file)
 
@@ -33,7 +33,7 @@ country: United Kingdom`
 func TestCSVLoaderWithFilteringColumns(t *testing.T) {
 	t.Parallel()
 	file, err := os.Open("./testdata/test.csv")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loader := NewCSV(file, "city")
 

--- a/documentloaders/documentloaders.go
+++ b/documentloaders/documentloaders.go
@@ -10,7 +10,7 @@ import (
 // Loader is the interface for loading and splitting documents from a source.
 type Loader interface {
 	// Loads loads from a source and returns documents.
-	Load(context.Context) ([]schema.Document, error)
+	Load(ctx context.Context) ([]schema.Document, error)
 	// LoadAndSplit loads from a source and splits the documents using a text splitter.
-	LoadAndSplit(context.Context, textsplitter.TextSplitter) ([]schema.Document, error)
+	LoadAndSplit(ctx context.Context, splitter textsplitter.TextSplitter) ([]schema.Document, error)
 }

--- a/documentloaders/html_test.go
+++ b/documentloaders/html_test.go
@@ -12,7 +12,7 @@ import (
 func TestHTMLLoader(t *testing.T) {
 	t.Parallel()
 	file, err := os.Open("./testdata/test.html")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loader := NewHTML(file)
 
@@ -46,5 +46,5 @@ func TestHTMLLoader(t *testing.T) {
 	assert.NotContains(t, content, notexpected[5])
 
 	expectedMetadata := map[string]any{}
-	assert.Equal(t, docs[0].Metadata, expectedMetadata)
+	assert.Equal(t, expectedMetadata, docs[0].Metadata)
 }

--- a/documentloaders/pdf_test.go
+++ b/documentloaders/pdf_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ledongthuc/pdf"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/textsplitter"
 )
 
@@ -38,13 +39,13 @@ func TestPDFLoader(t *testing.T) {
 	t.Run("PDFLoad", func(t *testing.T) {
 		t.Parallel()
 		f, err := os.Open("./testdata/sample.pdf")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		defer f.Close()
 		finfo, err := f.Stat()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		p := NewPDF(f, finfo.Size())
 		docs, err := p.Load(context.Background())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Len(t, docs, 2)
 
@@ -57,13 +58,13 @@ func TestPDFLoader(t *testing.T) {
 	t.Run("PDFLoadPassword", func(t *testing.T) {
 		t.Parallel()
 		f, err := os.Open("./testdata/sample_password.pdf")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		defer f.Close()
 		finfo, err := f.Stat()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		p := NewPDF(f, finfo.Size(), WithPassword("password"))
 		docs, err := p.Load(context.Background())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Len(t, docs, 2)
 
@@ -76,15 +77,15 @@ func TestPDFLoader(t *testing.T) {
 	t.Run("PDFLoadPasswordWrong", func(t *testing.T) {
 		t.Parallel()
 		f, err := os.Open("./testdata/sample_password.pdf")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		defer f.Close()
 		finfo, err := f.Stat()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		p := NewPDF(f, finfo.Size(), WithPassword("password1"))
 		docs, err := p.Load(context.Background())
-		assert.Errorf(t, err, pdf.ErrInvalidPassword.Error())
+		require.Errorf(t, err, pdf.ErrInvalidPassword.Error())
 
-		assert.Len(t, docs, 0)
+		assert.Empty(t, docs)
 	})
 }
 
@@ -118,16 +119,16 @@ func TestPDFTextSplit(t *testing.T) {
 	t.Run("PDFTextSplit", func(t *testing.T) {
 		t.Parallel()
 		f, err := os.Open("./testdata/sample.pdf")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		defer f.Close()
 		finfo, err := f.Stat()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		p := NewPDF(f, finfo.Size())
 		split := textsplitter.NewRecursiveCharacter()
 		split.ChunkSize = 300
 		split.ChunkOverlap = 30
 		docs, err := p.LoadAndSplit(context.Background(), split)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Len(t, docs, 4)
 

--- a/documentloaders/text_test.go
+++ b/documentloaders/text_test.go
@@ -12,7 +12,7 @@ import (
 func TestTextLoader(t *testing.T) {
 	t.Parallel()
 	file, err := os.Open("./testdata/test.txt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loader := NewText(file)
 
@@ -21,8 +21,8 @@ func TestTextLoader(t *testing.T) {
 	require.Len(t, docs, 1)
 
 	expectedPageContent := "Foo Bar Baz"
-	assert.Equal(t, docs[0].PageContent, expectedPageContent)
+	assert.Equal(t, expectedPageContent, docs[0].PageContent)
 
 	expectedMetadata := map[string]any{}
-	assert.Equal(t, docs[0].Metadata, expectedMetadata)
+	assert.Equal(t, expectedMetadata, docs[0].Metadata)
 }

--- a/embeddings/openai/openai_test.go
+++ b/embeddings/openai/openai_test.go
@@ -67,7 +67,7 @@ func TestOpenaiEmbeddingsWithAzureAPI(t *testing.T) {
 		// Azure deployment that uses embeddings model, the name depends on what we define in the Azure deployment section
 		openai.WithEmbeddingModel("model-embedding"),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	e, err := NewOpenAI(WithClient(*client), WithBatchSize(1), WithStripNewLines(false))
 	require.NoError(t, err)

--- a/embeddings/vector_math_test.go
+++ b/embeddings/vector_math_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCombineVectors(t *testing.T) {
@@ -23,7 +24,7 @@ func TestCombineVectors(t *testing.T) {
 
 	for _, tc := range cases {
 		combined, err := CombineVectors(tc.vectors, tc.weights)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, tc.expected, combined)
 	}
 }
@@ -55,7 +56,7 @@ func TestGetAverage(t *testing.T) {
 
 	for _, tc := range cases {
 		average, err := getAverage(tc.vectors, tc.weights)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, tc.expected, average)
 	}
 }
@@ -78,6 +79,6 @@ func TestGetNorm(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		assert.Equal(t, tc.expected, getNorm(tc.vector))
+		assert.InEpsilon(t, tc.expected, getNorm(tc.vector), 0.0001)
 	}
 }

--- a/jsonschema/json_test.go
+++ b/jsonschema/json_test.go
@@ -5,29 +5,29 @@ import (
 	"reflect"
 	"testing"
 
-	. "github.com/tmc/langchaingo/jsonschema"
+	"github.com/tmc/langchaingo/jsonschema"
 )
 
 func TestDefinition_MarshalJSON(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	tests := []struct {
 		name string
-		def  Definition
+		def  jsonschema.Definition
 		want string
 	}{
 		{
 			name: "Test with empty Definition",
-			def:  Definition{},
+			def:  jsonschema.Definition{},
 			want: `{"properties":{}}`,
 		},
 		{
 			name: "Test with Definition properties set",
-			def: Definition{
-				Type:        String,
+			def: jsonschema.Definition{
+				Type:        jsonschema.String,
 				Description: "A string type",
-				Properties: map[string]Definition{
+				Properties: map[string]jsonschema.Definition{
 					"name": {
-						Type: String,
+						Type: jsonschema.String,
 					},
 				},
 			},
@@ -44,17 +44,17 @@ func TestDefinition_MarshalJSON(t *testing.T) { //nolint:funlen
 		},
 		{
 			name: "Test with nested Definition properties",
-			def: Definition{
-				Type: Object,
-				Properties: map[string]Definition{
+			def: jsonschema.Definition{
+				Type: jsonschema.Object,
+				Properties: map[string]jsonschema.Definition{
 					"user": {
-						Type: Object,
-						Properties: map[string]Definition{
+						Type: jsonschema.Object,
+						Properties: map[string]jsonschema.Definition{
 							"name": {
-								Type: String,
+								Type: jsonschema.String,
 							},
 							"age": {
-								Type: Integer,
+								Type: jsonschema.Integer,
 							},
 						},
 					},
@@ -81,26 +81,26 @@ func TestDefinition_MarshalJSON(t *testing.T) { //nolint:funlen
 		},
 		{
 			name: "Test with complex nested Definition",
-			def: Definition{
-				Type: Object,
-				Properties: map[string]Definition{
+			def: jsonschema.Definition{
+				Type: jsonschema.Object,
+				Properties: map[string]jsonschema.Definition{
 					"user": {
-						Type: Object,
-						Properties: map[string]Definition{
+						Type: jsonschema.Object,
+						Properties: map[string]jsonschema.Definition{
 							"name": {
-								Type: String,
+								Type: jsonschema.String,
 							},
 							"age": {
-								Type: Integer,
+								Type: jsonschema.Integer,
 							},
 							"address": {
-								Type: Object,
-								Properties: map[string]Definition{
+								Type: jsonschema.Object,
+								Properties: map[string]jsonschema.Definition{
 									"city": {
-										Type: String,
+										Type: jsonschema.String,
 									},
 									"country": {
-										Type: String,
+										Type: jsonschema.String,
 									},
 								},
 							},
@@ -142,14 +142,14 @@ func TestDefinition_MarshalJSON(t *testing.T) { //nolint:funlen
 		},
 		{
 			name: "Test with Array type Definition",
-			def: Definition{
-				Type: Array,
-				Items: &Definition{
-					Type: String,
+			def: jsonschema.Definition{
+				Type: jsonschema.Array,
+				Items: &jsonschema.Definition{
+					Type: jsonschema.String,
 				},
-				Properties: map[string]Definition{
+				Properties: map[string]jsonschema.Definition{
 					"name": {
-						Type: String,
+						Type: jsonschema.String,
 					},
 				},
 			},

--- a/llms/huggingface/internal/huggingfaceclient/huggingfaceclient_test.go
+++ b/llms/huggingface/internal/huggingfaceclient/huggingfaceclient_test.go
@@ -46,7 +46,7 @@ func TestRunInference(t *testing.T) {
 			resp, err := client.RunInference(context.TODO(), tc.req)
 			assert.Equal(t, tc.expected, resp)
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			}
 		})
 	}

--- a/llms/openai/internal/openaiclient/chat_test.go
+++ b/llms/openai/internal/openaiclient/chat_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseStreamingChatResponse_FinishReason(t *testing.T) {
@@ -26,7 +27,7 @@ func TestParseStreamingChatResponse_FinishReason(t *testing.T) {
 
 	resp, err := parseStreamingChatResponse(context.Background(), r, req)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, "stop", resp.Choices[0].FinishReason)
 }

--- a/llms/vertexai/internal/vertexaiclient/palm_client.go
+++ b/llms/vertexai/internal/vertexaiclient/palm_client.go
@@ -294,10 +294,10 @@ func (c *PaLMClient) batchPredict(ctx context.Context, model string, prompts []s
 	if err != nil {
 		return nil, err
 	}
-	if len(resp.Predictions) == 0 {
+	if len(resp.GetPredictions()) == 0 {
 		return nil, ErrEmptyResponse
 	}
-	return resp.Predictions, nil
+	return resp.GetPredictions(), nil
 }
 
 func (c *PaLMClient) chat(ctx context.Context, r *ChatRequest) ([]*structpb.Value, error) {
@@ -333,10 +333,10 @@ func (c *PaLMClient) chat(ctx context.Context, r *ChatRequest) ([]*structpb.Valu
 	if err != nil {
 		return nil, err
 	}
-	if len(resp.Predictions) == 0 {
+	if len(resp.GetPredictions()) == 0 {
 		return nil, ErrEmptyResponse
 	}
-	return resp.Predictions, nil
+	return resp.GetPredictions(), nil
 }
 
 func (c *PaLMClient) projectLocationPublisherModelPath(projectID, location, publisher, model string) string {

--- a/memory/buffer_test.go
+++ b/memory/buffer_test.go
@@ -52,7 +52,7 @@ func TestBufferMemoryReturnMessage(t *testing.T) {
 	)
 
 	messages, err := expectedChatHistory.Messages(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expected2 := map[string]any{"history": messages}
 	assert.Equal(t, expected2, result2)
 }

--- a/memory/chat_test.go
+++ b/memory/chat_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/schema"
 )
 
@@ -13,12 +14,12 @@ func TestChatMessageHistory(t *testing.T) {
 
 	h := NewChatMessageHistory()
 	err := h.AddAIMessage(context.Background(), "foo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = h.AddUserMessage(context.Background(), "bar")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	messages, err := h.Messages(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, []schema.ChatMessage{
 		schema.AIChatMessage{Content: "foo"},
@@ -32,10 +33,10 @@ func TestChatMessageHistory(t *testing.T) {
 		}),
 	)
 	err = h.AddUserMessage(context.Background(), "zoo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	messages, err = h.Messages(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, []schema.ChatMessage{
 		schema.AIChatMessage{Content: "foo"},

--- a/outputparser/comma_seperated_list_test.go
+++ b/outputparser/comma_seperated_list_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/outputparser"
 )
 
@@ -32,7 +33,7 @@ func TestCommaSeparatedList(t *testing.T) {
 
 	for _, tc := range testCases {
 		output, err := parser.Parse(tc.input)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, tc.expected, output)
 	}
 }

--- a/prompts/chat_prompt_template_test.go
+++ b/prompts/chat_prompt_template_test.go
@@ -3,7 +3,6 @@ package prompts
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/schema"
 )
@@ -26,7 +25,7 @@ func TestChatPromptTemplate(t *testing.T) {
 		"outputLang": "Chinese",
 		"input":      "I love programming",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expectedMessages := []schema.ChatMessage{
 		schema.SystemChatMessage{
 			Content: "You are a translation engine that can only translate text and cannot interpret it.",
@@ -41,5 +40,5 @@ func TestChatPromptTemplate(t *testing.T) {
 		"inputLang":  "English",
 		"outputLang": "Chinese",
 	})
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/prompts/few_shot_test.go
+++ b/prompts/few_shot_test.go
@@ -1,7 +1,6 @@
 package prompts
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -132,11 +131,10 @@ func TestFewShotPrompt_Format(t *testing.T) {
 				checkError(t, err, tc.expected)
 				return
 			}
-			fp, err := p.Format(tc.input)
+			got, err := p.Format(tc.input)
 			if checkError(t, err, "") {
 				return
 			}
-			got := fmt.Sprint(fp)
 			if diff := cmp.Diff(tc.expected, got); diff != "" {
 				t.Errorf("unexpected prompt output (-want +got):\n%s", diff)
 			}

--- a/prompts/templates_test.go
+++ b/prompts/templates_test.go
@@ -81,7 +81,7 @@ func TestInterpolateGoTemplate(t *testing.T) {
 
 			_, err := interpolateGoTemplate(tc.template, map[string]any{})
 			require.Error(t, err)
-			assert.EqualError(t, err, tc.errValue)
+			require.EqualError(t, err, tc.errValue)
 		})
 	}
 }
@@ -94,8 +94,8 @@ func TestCheckValidTemplate(t *testing.T) {
 
 		err := CheckValidTemplate("Hello, {test}", "unknown", []string{"test"})
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrInvalidTemplateFormat)
-		assert.EqualError(t, err, "invalid template format, got: unknown, should be one of [go-template]")
+		require.ErrorIs(t, err, ErrInvalidTemplateFormat)
+		require.EqualError(t, err, "invalid template format, got: unknown, should be one of [go-template]")
 	})
 
 	t.Run("TemplateErrored", func(t *testing.T) {
@@ -103,7 +103,7 @@ func TestCheckValidTemplate(t *testing.T) {
 
 		err := CheckValidTemplate("Hello, {{{ test }}", TemplateFormatGoTemplate, []string{"test"})
 		require.Error(t, err)
-		assert.EqualError(t, err, "template: template:1: unexpected \"{\" in command")
+		require.EqualError(t, err, "template: template:1: unexpected \"{\" in command")
 	})
 
 	t.Run("TemplateValid", func(t *testing.T) {
@@ -142,6 +142,6 @@ func TestRenderTemplate(t *testing.T) {
 			},
 		)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrInvalidTemplateFormat)
+		require.ErrorIs(t, err, ErrInvalidTemplateFormat)
 	})
 }

--- a/textsplitter/markdown_splitter.go
+++ b/textsplitter/markdown_splitter.go
@@ -53,9 +53,9 @@ type MarkdownTextSplitter struct {
 }
 
 // SplitText splits a text into multiple text.
-func (sp MarkdownTextSplitter) SplitText(s string) ([]string, error) {
+func (sp MarkdownTextSplitter) SplitText(text string) ([]string, error) {
 	mdParser := markdown.New(markdown.XHTMLOutput(true))
-	tokens := mdParser.Parse([]byte(s))
+	tokens := mdParser.Parse([]byte(text))
 
 	mc := &markdownContext{
 		startAt:        0,

--- a/textsplitter/markdown_splitter_test.go
+++ b/textsplitter/markdown_splitter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/schema"
 )
 
@@ -55,7 +56,7 @@ func TestMarkdownHeaderTextSplitter_SplitText(t *testing.T) {
 	splitter := NewMarkdownTextSplitter(WithChunkSize(64), WithChunkOverlap(32))
 	for _, tc := range testCases {
 		docs, err := CreateDocuments(splitter, []string{tc.markdown}, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, tc.expectedDocs, docs)
 	}
 }
@@ -93,12 +94,12 @@ func TestMarkdownHeaderTextSplitter_Table(t *testing.T) {
 	for _, tc := range testCases {
 		splitter := NewMarkdownTextSplitter(WithChunkSize(64), WithChunkOverlap(32))
 		docs, err := CreateDocuments(splitter, []string{tc.markdown}, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, tc.expectedDocs, docs)
 
 		splitter = NewMarkdownTextSplitter(WithChunkSize(512), WithChunkOverlap(64))
 		docs, err = CreateDocuments(splitter, []string{tc.markdown}, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, tc.expectedDocs, docs)
 	}
 }
@@ -187,7 +188,7 @@ func TestMarkdownHeaderTextSplitter_BulletList(t *testing.T) {
 	for _, tc := range testCases {
 		splitter := NewMarkdownTextSplitter(WithChunkSize(512), WithChunkOverlap(64))
 		docs, err := CreateDocuments(splitter, []string{tc.markdown}, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, tc.expectedDocs, docs)
 	}
 }
@@ -247,7 +248,7 @@ for a review.`, Metadata: map[string]any{},
 	for _, tc := range testCases {
 		splitter := NewMarkdownTextSplitter(WithChunkSize(512), WithChunkOverlap(64))
 		docs, err := CreateDocuments(splitter, []string{tc.markdown}, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, tc.expectedDocs, docs)
 	}
 }

--- a/textsplitter/recursive_character_test.go
+++ b/textsplitter/recursive_character_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/schema"
 )
 
@@ -96,7 +97,7 @@ Bye!
 		splitter.ChunkSize = tc.chunkSize
 
 		docs, err := CreateDocuments(splitter, []string{tc.text}, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, tc.expectedDocs, docs)
 	}
 }

--- a/textsplitter/text_spliter.go
+++ b/textsplitter/text_spliter.go
@@ -2,5 +2,5 @@ package textsplitter
 
 // TextSplitter is the standard interface for splitting texts.
 type TextSplitter interface {
-	SplitText(string) ([]string, error)
+	SplitText(text string) ([]string, error)
 }

--- a/textsplitter/token_splitter_test.go
+++ b/textsplitter/token_splitter_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/schema"
 )
 
@@ -81,7 +82,7 @@ Bye!
 		splitter.ChunkSize = tc.chunkSize
 
 		docs, err := CreateDocuments(splitter, []string{tc.text}, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, tc.expectedDocs, docs)
 	}
 }

--- a/tools/sqldatabase/mysql/mysql_test.go
+++ b/tools/sqldatabase/mysql/mysql_test.go
@@ -25,7 +25,7 @@ func Test(t *testing.T) {
 	require.NoError(t, err)
 
 	tbs := db.TableNames()
-	require.Greater(t, len(tbs), 0)
+	require.NotEmpty(t, tbs)
 
 	desc, err := db.TableInfo(context.Background(), tbs)
 	require.NoError(t, err)

--- a/tools/sqldatabase/postgresql/postgresql_test.go
+++ b/tools/sqldatabase/postgresql/postgresql_test.go
@@ -24,7 +24,7 @@ func Test(t *testing.T) {
 	require.NoError(t, err)
 
 	tbs := db.TableNames()
-	require.Greater(t, len(tbs), 0)
+	require.NotEmpty(t, tbs)
 
 	desc, err := db.TableInfo(context.Background(), tbs)
 	require.NoError(t, err)

--- a/tools/sqldatabase/sqlite3/sqlite3_test.go
+++ b/tools/sqldatabase/sqlite3/sqlite3_test.go
@@ -38,16 +38,16 @@ func Test(t *testing.T) {
 	defer db.Close()
 
 	tbs := db.TableNames()
-	require.Equal(t, len(tbs), 3)
+	require.Len(t, tbs, 3)
 
 	desc, err := db.TableInfo(context.Background(), tbs)
 	require.NoError(t, err)
 
 	desc = strings.TrimSpace(desc)
-	require.True(t, 0 == strings.Index(desc, "CREATE TABLE")) //nolint:stylecheck
-	require.True(t, strings.Contains(desc, "Activity"))       //nolint:stylecheck
-	require.True(t, strings.Contains(desc, "Activity1"))      //nolint:stylecheck
-	require.True(t, strings.Contains(desc, "Activity2"))      //nolint:stylecheck
+	require.Equal(t, 0, strings.Index(desc, "CREATE TABLE")) //nolint:stylecheck
+	require.True(t, strings.Contains(desc, "Activity"))      //nolint:stylecheck
+	require.True(t, strings.Contains(desc, "Activity1"))     //nolint:stylecheck
+	require.True(t, strings.Contains(desc, "Activity2"))     //nolint:stylecheck
 
 	for _, tableName := range tbs {
 		_, err = db.Query(context.Background(), fmt.Sprintf("SELECT * from %s LIMIT 1", tableName))

--- a/tools/tool.go
+++ b/tools/tool.go
@@ -6,5 +6,5 @@ import "context"
 type Tool interface {
 	Name() string
 	Description() string
-	Call(context.Context, string) (string, error)
+	Call(ctx context.Context, input string) (string, error)
 }

--- a/tools/wikipedia/client.go
+++ b/tools/wikipedia/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -39,7 +40,7 @@ func search(
 	params.Add("action", "query")
 	params.Add("list", "search")
 	params.Add("srsearch", query)
-	params.Add("srlimit", fmt.Sprintf("%v", limit))
+	params.Add("srlimit", strconv.Itoa(limit))
 
 	reqURL := fmt.Sprintf("%s?%s", fmt.Sprintf(_baseURL, languageCode), params.Encode())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
@@ -83,7 +84,7 @@ func getPage(ctx context.Context, pageID int, languageCode, userAgent string) (p
 	params.Add("format", "json")
 	params.Add("action", "query")
 	params.Add("prop", "extracts")
-	params.Add("pageids", fmt.Sprintf("%v", (pageID)))
+	params.Add("pageids", strconv.Itoa(pageID))
 
 	reqURL := fmt.Sprintf("%s?%s", fmt.Sprintf(_baseURL, languageCode), params.Encode())
 

--- a/tools/wikipedia/wikipedia.go
+++ b/tools/wikipedia/wikipedia.go
@@ -3,7 +3,7 @@ package wikipedia
 import (
 	"context"
 	"errors"
-	"fmt"
+	"strconv"
 
 	"github.com/tmc/langchaingo/callbacks"
 	"github.com/tmc/langchaingo/tools"
@@ -80,7 +80,7 @@ func (t Tool) Call(ctx context.Context, input string) (string, error) {
 			return "", err
 		}
 
-		page, ok := getPageResult.Query.Pages[fmt.Sprintf("%v", search.PageID)]
+		page, ok := getPageResult.Query.Pages[strconv.Itoa(search.PageID)]
 		if !ok {
 			return "", ErrUnexpectedAPIResult
 		}

--- a/tools/wikipedia/wikipedia_test.go
+++ b/tools/wikipedia/wikipedia_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const _userAgent = "langchaingo test (https://github.com/tmc/langchaingo)"
@@ -14,5 +14,5 @@ func TestWikipedia(t *testing.T) {
 
 	tool := New(_userAgent)
 	_, err := tool.Call(context.Background(), "america")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/tools/zapier/zapier_test.go
+++ b/tools/zapier/zapier_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateDescription(t *testing.T) {
@@ -17,7 +18,7 @@ func TestCreateDescription(t *testing.T) {
 			"Param2": "Param2 Description",
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	desc := tool.Description()
 	assert.Contains(t, desc, "Test Tool")

--- a/vectorstores/chroma/chroma_test.go
+++ b/vectorstores/chroma/chroma_test.go
@@ -57,13 +57,13 @@ func TestChromaGoStoreRest(t *testing.T) {
 	docs, err := s.SimilaritySearch(context.Background(), "japan", 1)
 	require.NoError(t, err)
 	require.Len(t, docs, 1)
-	require.Equal(t, docs[0].PageContent, "tokyo")
+	require.Equal(t, "tokyo", docs[0].PageContent)
 
 	rawCountry := fmt.Sprintf("%s", docs[0].Metadata["country"])
 	// TODO (noodnik2): why is the metadata (apparently being) surrounded by quotes??
 	country, err := strconv.Unquote(rawCountry)
 	require.NoError(t, err)
-	require.Equal(t, country, "japan")
+	require.Equal(t, "japan", country)
 
 	// if the following fails, please revisit the stripping of the quotes (above)
 	require.NotEqual(t, rawCountry, country)

--- a/vectorstores/pinecone/grpcapi.go
+++ b/vectorstores/pinecone/grpcapi.go
@@ -94,13 +94,13 @@ func (s Store) grpcQuery(
 		return nil, err
 	}
 
-	if len(queryResult.Results) == 0 {
+	if len(queryResult.GetResults()) == 0 {
 		return nil, ErrEmptyResponse
 	}
 
 	resultDocuments := make([]schema.Document, 0)
-	for _, match := range queryResult.Results[0].Matches {
-		metadata := match.Metadata.AsMap()
+	for _, match := range queryResult.GetResults()[0].GetMatches() {
+		metadata := match.GetMetadata().AsMap()
 
 		pageContent, ok := metadata[s.textKey].(string)
 		if !ok {

--- a/vectorstores/pinecone/pinecone_test.go
+++ b/vectorstores/pinecone/pinecone_test.go
@@ -104,7 +104,7 @@ func TestPineconeStoreRest(t *testing.T) {
 	docs, err := storer.SimilaritySearch(context.Background(), "japan", 1)
 	require.NoError(t, err)
 	require.Len(t, docs, 1)
-	require.Equal(t, docs[0].PageContent, "tokyo")
+	require.Equal(t, "tokyo", docs[0].PageContent)
 }
 
 func TestPineconeStoreRestWithScoreThreshold(t *testing.T) {

--- a/vectorstores/vectorstores.go
+++ b/vectorstores/vectorstores.go
@@ -10,7 +10,7 @@ import (
 // VectorStore is the interface for saving and querying documents in the
 // form of vector embeddings.
 type VectorStore interface {
-	AddDocuments(context.Context, []schema.Document, ...Option) error
+	AddDocuments(ctx context.Context, docs []schema.Document, options ...Option) error
 	SimilaritySearch(ctx context.Context, query string, numDocuments int, options ...Option) ([]schema.Document, error) //nolint:lll
 }
 

--- a/vectorstores/weaviate/weaviate_test.go
+++ b/vectorstores/weaviate/weaviate_test.go
@@ -93,8 +93,8 @@ func TestWeaviateStoreRest(t *testing.T) {
 	docs, err := store.SimilaritySearch(context.Background(), "japan", 1)
 	require.NoError(t, err)
 	require.Len(t, docs, 1)
-	require.Equal(t, docs[0].PageContent, "tokyo")
-	require.Equal(t, docs[0].Metadata["country"], "japan")
+	require.Equal(t, "tokyo", docs[0].PageContent)
+	require.Equal(t, "japan", docs[0].Metadata["country"])
 }
 
 func TestWeaviateStoreRestWithScoreThreshold(t *testing.T) {


### PR DESCRIPTION
Fix [#341](https://github.com/tmc/langchaingo/issues/341)