### PR TITLE
examples/ernie-completion-examples: make this example a separate module

### DIFF
--- a/examples/ernie-completion-example/ernie_completion_example.go
+++ b/examples/ernie-completion-example/ernie_completion_example.go
@@ -1,45 +1,35 @@
 package main
 
-import (
-	"context"
-	"fmt"
-	"log"
-
-	ernieembedding "github.com/tmc/langchaingo/embeddings/ernie"
-	"github.com/tmc/langchaingo/llms"
-	"github.com/tmc/langchaingo/llms/ernie"
-)
-
 func main() {
-	llm, err := ernie.New(ernie.WithModelName(ernie.ModelNameERNIEBot))
+	//llm, err := ernie.New(ernie.WithModelName(ernie.ModelNameERNIEBot))
 	// note:
 	// You would include ernie.WithAKSK(apiKey,secretKey) to use specific auth info.
 	// You would include ernie.WithModelName(ernie.ModelNameERNIEBot) to use the ERNIE-Bot model.
-	if err != nil {
-		log.Fatal(err)
-	}
-	ctx := context.Background()
-	completion, err := llm.Call(ctx, "介绍一下你自己",
-		llms.WithTemperature(0.8),
-		llms.WithStreamingFunc(func(ctx context.Context, chunk []byte) error {
-			log.Println(string(chunk))
-			return nil
-		}),
-	)
+	//if err != nil {
+	//log.Fatal(err)
+	//}
+	//ctx := context.Background()
+	//completion, err := llm.Call(ctx, "介绍一下你自己",
+	//llms.WithTemperature(0.8),
+	//llms.WithStreamingFunc(func(ctx context.Context, chunk []byte) error {
+	//log.Println(string(chunk))
+	//return nil
+	//}),
+	//)
 
-	if err != nil {
-		log.Fatal(err)
-	}
+	//if err != nil {
+	//log.Fatal(err)
+	//}
 
-	_ = completion
+	//_ = completion
 
-	// embedding
-	embedding, _ := ernieembedding.NewErnie()
+	//// embedding
+	//embedding, _ := ernieembedding.NewErnie()
 
-	emb, err := embedding.EmbedDocuments(ctx, []string{"你好"})
+	//emb, err := embedding.EmbedDocuments(ctx, []string{"你好"})
 
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println("Embedding-V1:", len(emb), len(emb[0]))
+	//if err != nil {
+	//log.Fatal(err)
+	//}
+	//fmt.Println("Embedding-V1:", len(emb), len(emb[0]))
 }

--- a/examples/ernie-completion-example/go.mod
+++ b/examples/ernie-completion-example/go.mod
@@ -1,0 +1,10 @@
+module github.com/tmc/langchaingo/examples/ernie-completion-example
+
+go 1.19
+
+require (
+	github.com/dlclark/regexp2 v1.8.1 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/pkoukk/tiktoken-go v0.1.2 // indirect
+	github.com/tmc/langchaingo v0.0.0-20231121185739-386e1815ba71 // indirect
+)

--- a/examples/ernie-completion-example/go.mod
+++ b/examples/ernie-completion-example/go.mod
@@ -1,10 +1,3 @@
 module github.com/tmc/langchaingo/examples/ernie-completion-example
 
 go 1.19
-
-require (
-	github.com/dlclark/regexp2 v1.8.1 // indirect
-	github.com/google/uuid v1.3.0 // indirect
-	github.com/pkoukk/tiktoken-go v0.1.2 // indirect
-	github.com/tmc/langchaingo v0.0.0-20231121185739-386e1815ba71 // indirect
-)

--- a/examples/ernie-completion-example/go.sum
+++ b/examples/ernie-completion-example/go.sum
@@ -1,0 +1,8 @@
+github.com/dlclark/regexp2 v1.8.1 h1:6Lcdwya6GjPUNsBct8Lg/yRPwMhABj269AAzdGSiR+0=
+github.com/dlclark/regexp2 v1.8.1/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pkoukk/tiktoken-go v0.1.2 h1:u7PCSBiWJ3nJYoTGShyM9iHXz4dNyYkurwwp+GHtyHY=
+github.com/pkoukk/tiktoken-go v0.1.2/go.mod h1:boMWvk9pQCOTx11pgu0DrIdrAKgQzzJKUP6vLXaz7Rw=
+github.com/tmc/langchaingo v0.0.0-20231121185739-386e1815ba71 h1:q+winaFnpLPXy+2wNNpjh/02nEl2M9slDoOACkfLe9M=
+github.com/tmc/langchaingo v0.0.0-20231121185739-386e1815ba71/go.mod h1:wwzKIaam0XFmiWfTlvSvdKwq7CkxE9Tz5rIkz1KKDws=

--- a/examples/ernie-completion-example/go.sum
+++ b/examples/ernie-completion-example/go.sum
@@ -1,8 +1,0 @@
-github.com/dlclark/regexp2 v1.8.1 h1:6Lcdwya6GjPUNsBct8Lg/yRPwMhABj269AAzdGSiR+0=
-github.com/dlclark/regexp2 v1.8.1/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/pkoukk/tiktoken-go v0.1.2 h1:u7PCSBiWJ3nJYoTGShyM9iHXz4dNyYkurwwp+GHtyHY=
-github.com/pkoukk/tiktoken-go v0.1.2/go.mod h1:boMWvk9pQCOTx11pgu0DrIdrAKgQzzJKUP6vLXaz7Rw=
-github.com/tmc/langchaingo v0.0.0-20231121185739-386e1815ba71 h1:q+winaFnpLPXy+2wNNpjh/02nEl2M9slDoOACkfLe9M=
-github.com/tmc/langchaingo v0.0.0-20231121185739-386e1815ba71/go.mod h1:wwzKIaam0XFmiWfTlvSvdKwq7CkxE9Tz5rIkz1KKDws=


### PR DESCRIPTION
Right now it's in the main module, the only example of this kind.
Align it with the other examples.
    
This is a two step change, and this is step 1; step 2 will be updating
this example's go.mod to rely on a newer version of langchaingo that
no longer provides this package.

This change has to comment out the example's contents for the lint
to pass -- the issue is that both the main module and this new module
provide the package.

### PR Checklist

- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
