### PR TITLE
examples/ernie-completion-examples: make this example a separate module part 2

### DIFF
--- a/examples/ernie-completion-example/ernie_completion_example.go
+++ b/examples/ernie-completion-example/ernie_completion_example.go
@@ -1,35 +1,45 @@
 package main
 
+import (
+	"context"
+	"fmt"
+	"log"
+
+	ernieembedding "github.com/tmc/langchaingo/embeddings/ernie"
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/ernie"
+)
+
 func main() {
-	//llm, err := ernie.New(ernie.WithModelName(ernie.ModelNameERNIEBot))
+	llm, err := ernie.New(ernie.WithModelName(ernie.ModelNameERNIEBot))
 	// note:
 	// You would include ernie.WithAKSK(apiKey,secretKey) to use specific auth info.
 	// You would include ernie.WithModelName(ernie.ModelNameERNIEBot) to use the ERNIE-Bot model.
-	//if err != nil {
-	//log.Fatal(err)
-	//}
-	//ctx := context.Background()
-	//completion, err := llm.Call(ctx, "介绍一下你自己",
-	//llms.WithTemperature(0.8),
-	//llms.WithStreamingFunc(func(ctx context.Context, chunk []byte) error {
-	//log.Println(string(chunk))
-	//return nil
-	//}),
-	//)
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx := context.Background()
+	completion, err := llm.Call(ctx, "介绍一下你自己",
+		llms.WithTemperature(0.8),
+		llms.WithStreamingFunc(func(ctx context.Context, chunk []byte) error {
+			log.Println(string(chunk))
+			return nil
+		}),
+	)
 
-	//if err != nil {
-	//log.Fatal(err)
-	//}
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	//_ = completion
+	_ = completion
 
-	//// embedding
-	//embedding, _ := ernieembedding.NewErnie()
+	// embedding
+	embedding, _ := ernieembedding.NewErnie()
 
-	//emb, err := embedding.EmbedDocuments(ctx, []string{"你好"})
+	emb, err := embedding.EmbedDocuments(ctx, []string{"你好"})
 
-	//if err != nil {
-	//log.Fatal(err)
-	//}
-	//fmt.Println("Embedding-V1:", len(emb), len(emb[0]))
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("Embedding-V1:", len(emb), len(emb[0]))
 }

--- a/examples/ernie-completion-example/go.mod
+++ b/examples/ernie-completion-example/go.mod
@@ -1,3 +1,11 @@
 module github.com/tmc/langchaingo/examples/ernie-completion-example
 
 go 1.19
+
+require github.com/tmc/langchaingo v0.0.0-20231122191601-2eb6f5408849
+
+require (
+	github.com/dlclark/regexp2 v1.8.1 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/pkoukk/tiktoken-go v0.1.2 // indirect
+)

--- a/examples/ernie-completion-example/go.sum
+++ b/examples/ernie-completion-example/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/dlclark/regexp2 v1.8.1 h1:6Lcdwya6GjPUNsBct8Lg/yRPwMhABj269AAzdGSiR+0=
+github.com/dlclark/regexp2 v1.8.1/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pkoukk/tiktoken-go v0.1.2 h1:u7PCSBiWJ3nJYoTGShyM9iHXz4dNyYkurwwp+GHtyHY=
+github.com/pkoukk/tiktoken-go v0.1.2/go.mod h1:boMWvk9pQCOTx11pgu0DrIdrAKgQzzJKUP6vLXaz7Rw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/tmc/langchaingo v0.0.0-20231122191601-2eb6f5408849 h1:p0VIrm426HBxEoGal2oZU/1MUThZioXgqs8Kdyk0q/k=
+github.com/tmc/langchaingo v0.0.0-20231122191601-2eb6f5408849/go.mod h1:wwzKIaam0XFmiWfTlvSvdKwq7CkxE9Tz5rIkz1KKDws=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
This sets the go.mod to point to a newer version of the parent module, so now there's no conflict and everything builds and lints.

This is part 2, followup on #365
