### PR TITLE
examples: move go.work creation to root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,8 @@ clean-lint-cache:
 build-examples:
 	for example in $(shell find ./examples -mindepth 1 -maxdepth 1 -type d); do \
 		(cd $$example; echo Build $$example; go mod tidy; go build -o /dev/null) || exit 1; done
+
+.PHONY: add-go-work
+add-go-work:
+	go work init .
+	go work use -r .

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -4,14 +4,6 @@ SYNC_REF?=main
 sync: ## Sync all go.mod files
 	@sh .update-all-to-latest.sh ${SYNC_REF}
 
-.PHONY: add-go-work-files
-add-go-work-files: ## Add go work files to all examples
-	find . -name go.mod -execdir sh -c 'go work init && go work use . && go work use ../..' \;
-
-.PHONY: rm-go-work-files
-rm-go-work-files: ## Add go work files to all examples
-	rm -f ./*/go.work*
-
 .PHONY: install-all
 install-all: ## Add go work files to all examples
 	@find . -name go.mod -execdir go install \;


### PR DESCRIPTION
We only need a single go.work file in the reposotory, and `go work use -r .` can recursively add all sub-modules to it, without requiring bash iteration.

Moves the creation of go.work into the root Makefile go.work is still in .gitignore so it won't be committed

Fixes #375


### PR Checklist

- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
