### PR TITLE
documentloaders: add notion directory loader

### DIFF
--- a/documentloaders/notion.go
+++ b/documentloaders/notion.go
@@ -1,0 +1,58 @@
+package documentloaders
+
+import (
+	"os"
+
+	"path/filepath"
+
+	"github.com/tmc/langchaingo/schema"
+)
+
+// NotionDirectoryLoader is a document loader that reads content from pages within a Notion Database.
+type NotionDirectoryLoader struct {
+	filePath string
+	encoding string
+}
+
+// NewNotionDirectory creates a new NotionDirectoryLoader with the given file path and encoding.
+func NewNotionDirectory(filePath string, encoding ...string) *NotionDirectoryLoader {
+	defaultEncoding := "utf-8"
+
+	if len(encoding) > 0 {
+		return &NotionDirectoryLoader{
+			filePath: filePath,
+			encoding: encoding[0],
+		}
+	}
+
+	return &NotionDirectoryLoader{
+		filePath: filePath,
+		encoding: defaultEncoding,
+	}
+}
+
+// Load retrieves data from a Notion directory and returns a list of schema.Document objects.
+func (n *NotionDirectoryLoader) Load() ([]schema.Document, error) {
+	files, err := os.ReadDir(n.filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var documents []schema.Document
+	for _, file := range files {
+		if file.IsDir() || filepath.Ext(file.Name()) != ".md" {
+			continue
+		}
+
+		filePath := filepath.Join(n.filePath, file.Name())
+		text, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, err
+		}
+
+		metadata := map[string]interface{}{"source": filePath}
+		documents = append(documents, schema.Document{PageContent: string(text), Metadata: metadata})
+	}
+
+	return documents, nil
+}

--- a/documentloaders/notion.go
+++ b/documentloaders/notion.go
@@ -2,7 +2,6 @@ package documentloaders
 
 import (
 	"os"
-
 	"path/filepath"
 
 	"github.com/tmc/langchaingo/schema"
@@ -38,7 +37,7 @@ func (n *NotionDirectoryLoader) Load() ([]schema.Document, error) {
 		return nil, err
 	}
 
-	var documents []schema.Document
+	documents := make([]schema.Document, 0, len(files))
 	for _, file := range files {
 		if file.IsDir() || filepath.Ext(file.Name()) != ".md" {
 			continue

--- a/documentloaders/notion_test.go
+++ b/documentloaders/notion_test.go
@@ -44,7 +44,7 @@ func TestNotionDirectoryLoader_Load(t *testing.T) {
 
 	for _, file := range testFiles {
 		filePath := filepath.Join(tempDir, file.name)
-		err := os.WriteFile(filePath, []byte(file.content), 0644)
+		err := os.WriteFile(filePath, []byte(file.content), 0o600)
 		require.NoError(t, err)
 	}
 

--- a/documentloaders/notion_test.go
+++ b/documentloaders/notion_test.go
@@ -1,0 +1,63 @@
+package documentloaders
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/schema"
+)
+
+func TestNotionDirectoryLoader_Load(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary test directory
+	tempDir, err := os.MkdirTemp("", "notion_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create sample Markdown files in the temporary directory
+	testFiles := []struct {
+		name     string
+		content  string
+		expected schema.Document
+	}{
+		{
+			name:    "test1.md",
+			content: "# Test Document 1\nThis is test document 1.",
+			expected: schema.Document{
+				PageContent: "# Test Document 1\nThis is test document 1.",
+				Metadata:    map[string]interface{}{"source": filepath.Join(tempDir, "test1.md")},
+			},
+		},
+		{
+			name:    "test2.md",
+			content: "# Test Document 2\nThis is test document 2.",
+			expected: schema.Document{
+				PageContent: "# Test Document 2\nThis is test document 2.",
+				Metadata:    map[string]interface{}{"source": filepath.Join(tempDir, "test2.md")},
+			},
+		},
+	}
+
+	for _, file := range testFiles {
+		filePath := filepath.Join(tempDir, file.name)
+		err := os.WriteFile(filePath, []byte(file.content), 0644)
+		require.NoError(t, err)
+	}
+
+	// Create a NotionDirectoryLoader instance
+	loader := NewNotionDirectory(tempDir)
+
+	// Load documents from the test directory
+	docs, err := loader.Load()
+	require.NoError(t, err)
+
+	// Verify the loaded documents match the expected ones
+	require.Len(t, docs, len(testFiles))
+	for i, expected := range testFiles {
+		assert.Equal(t, expected.expected, docs[i])
+	}
+}


### PR DESCRIPTION
This PR adds the NotionDirectoryLoader feature to Go, similar to its [Python counterpart](https://github.com/langchain-ai/langchain/blob/master/libs/langchain/langchain/document_loaders/notion.py). The loader manages fetching and arranging local Notion Markdown files from a specified directory.

### PR Checklist

- [X] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [X] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [X] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [X] Describes the source of new concepts.
- [X] References existing implementations as appropriate.
- [X] Contains test coverage for new functions.
- [X] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

