### PR TITLE
memory: add ConversationWindowBuffer

### DIFF
--- a/memory/window_buffer.go
+++ b/memory/window_buffer.go
@@ -1,0 +1,97 @@
+package memory
+
+import (
+	"context"
+
+	"github.com/tmc/langchaingo/schema"
+)
+
+// defaultConversationWindowSize is the default number of previous conversation.
+const defaultConversationWindowSize = 5
+
+// ConversationWindowBuffer for storing conversation memory.
+type ConversationWindowBuffer struct {
+	ConversationBuffer
+	ConversationWindowSize int
+}
+
+// Statically assert that ConversationWindowBuffer implement the memory interface.
+var _ schema.Memory = &ConversationWindowBuffer{}
+
+// NewConversationWindowBuffer is a function for crating a new window buffer memory.
+func NewConversationWindowBuffer(
+	conversationWindowSize int,
+	options ...ConversationBufferOption,
+) *ConversationWindowBuffer {
+	if conversationWindowSize <= 0 {
+		conversationWindowSize = defaultConversationWindowSize
+	}
+	tb := &ConversationWindowBuffer{
+		ConversationWindowSize: conversationWindowSize,
+		ConversationBuffer:     *applyBufferOptions(options...),
+	}
+
+	return tb
+}
+
+// MemoryVariables uses ConversationBuffer method for memory variables.
+func (wb *ConversationWindowBuffer) MemoryVariables(ctx context.Context) []string {
+	return wb.ConversationBuffer.MemoryVariables(ctx)
+}
+
+// LoadMemoryVariables uses ConversationBuffer method for loading memory variables.
+func (wb *ConversationWindowBuffer) LoadMemoryVariables(ctx context.Context, _ map[string]any) (map[string]any, error) {
+	messages, err := wb.ChatHistory.Messages(ctx)
+	if err != nil {
+		return nil, err
+	}
+	messages, _ = wb.cutMessages(messages)
+
+	if wb.ReturnMessages {
+		return map[string]any{
+			wb.MemoryKey: messages,
+		}, nil
+	}
+
+	bufferString, err := schema.GetBufferString(messages, wb.HumanPrefix, wb.AIPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		wb.MemoryKey: bufferString,
+	}, nil
+}
+
+// SaveContext uses ConversationBuffer method for saving context and prunes memory buffer if needed.
+func (wb *ConversationWindowBuffer) SaveContext(
+	ctx context.Context, inputValues map[string]any, outputValues map[string]any,
+) error {
+	err := wb.ConversationBuffer.SaveContext(ctx, inputValues, outputValues)
+	if err != nil {
+		return err
+	}
+	messages, err := wb.ConversationBuffer.ChatHistory.Messages(ctx)
+	if err != nil {
+		return err
+	}
+	if messages, ok := wb.cutMessages(messages); ok {
+		err := wb.ConversationBuffer.ChatHistory.SetMessages(ctx, messages)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (wb *ConversationWindowBuffer) cutMessages(message []schema.ChatMessage) ([]schema.ChatMessage, bool) {
+	if len(message) > wb.ConversationWindowSize {
+		return message[len(message)-wb.ConversationWindowSize*2:], true
+	}
+	return message, false
+}
+
+// Clear uses ConversationBuffer method for clearing buffer memory.
+func (wb *ConversationWindowBuffer) Clear(ctx context.Context) error {
+	return wb.ConversationBuffer.Clear(ctx)
+}

--- a/memory/window_buffer_test.go
+++ b/memory/window_buffer_test.go
@@ -1,0 +1,99 @@
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/schema"
+)
+
+func TestWindowBufferMemory(t *testing.T) {
+	t.Parallel()
+
+	m := NewConversationWindowBuffer(2)
+
+	result1, err := m.LoadMemoryVariables(context.Background(), map[string]any{})
+	require.NoError(t, err)
+	expected1 := map[string]any{"history": ""}
+	assert.Equal(t, expected1, result1)
+
+	err = m.SaveContext(context.Background(), map[string]any{"foo": "bar1"}, map[string]any{"bar": "foo1"})
+	require.NoError(t, err)
+
+	result2, err := m.LoadMemoryVariables(context.Background(), map[string]any{})
+	require.NoError(t, err)
+
+	expected2 := map[string]any{"history": "Human: bar1\nAI: foo1"}
+	assert.Equal(t, expected2, result2)
+
+	err = m.SaveContext(context.Background(), map[string]any{"foo": "bar2"}, map[string]any{"bar": "foo2"})
+	require.NoError(t, err)
+
+	result3, err := m.LoadMemoryVariables(context.Background(), map[string]any{})
+	require.NoError(t, err)
+
+	expected3 := map[string]any{"history": "Human: bar1\nAI: foo1\nHuman: bar2\nAI: foo2"}
+	assert.Equal(t, expected3, result3)
+
+	err = m.SaveContext(context.Background(), map[string]any{"foo": "bar3"}, map[string]any{"bar": "foo3"})
+	require.NoError(t, err)
+
+	result4, err := m.LoadMemoryVariables(context.Background(), map[string]any{})
+	require.NoError(t, err)
+
+	expected4 := map[string]any{"history": "Human: bar2\nAI: foo2\nHuman: bar3\nAI: foo3"}
+	assert.Equal(t, expected4, result4)
+}
+
+func TestWindowBufferMemoryReturnMessage(t *testing.T) {
+	t.Parallel()
+	m := NewConversationWindowBuffer(2, WithReturnMessages(true))
+
+	err := m.SaveContext(context.Background(), map[string]any{"foo": "bar1"}, map[string]any{"bar": "foo1"})
+	require.NoError(t, err)
+
+	err = m.SaveContext(context.Background(), map[string]any{"foo": "bar2"}, map[string]any{"bar": "foo2"})
+	require.NoError(t, err)
+
+	err = m.SaveContext(context.Background(), map[string]any{"foo": "bar3"}, map[string]any{"bar": "foo3"})
+	require.NoError(t, err)
+
+	result, err := m.LoadMemoryVariables(context.Background(), map[string]any{})
+	require.NoError(t, err)
+
+	expectedChatHistory := NewChatMessageHistory(
+		WithPreviousMessages([]schema.ChatMessage{
+			schema.HumanChatMessage{Content: "bar2"},
+			schema.AIChatMessage{Content: "foo2"},
+			schema.HumanChatMessage{Content: "bar3"},
+			schema.AIChatMessage{Content: "foo3"},
+		}),
+	)
+
+	messages, err := expectedChatHistory.Messages(context.Background())
+	require.NoError(t, err)
+	expected := map[string]any{"history": messages}
+	assert.Equal(t, expected, result)
+}
+
+func TestWindowBufferMemoryWithPreLoadedHistory(t *testing.T) {
+	t.Parallel()
+
+	m := NewConversationWindowBuffer(2, WithChatHistory(NewChatMessageHistory(
+		WithPreviousMessages([]schema.ChatMessage{
+			schema.HumanChatMessage{Content: "bar1"},
+			schema.AIChatMessage{Content: "foo1"},
+			schema.HumanChatMessage{Content: "bar2"},
+			schema.AIChatMessage{Content: "foo2"},
+			schema.HumanChatMessage{Content: "bar3"},
+			schema.AIChatMessage{Content: "foo3"},
+		}),
+	)))
+
+	result, err := m.LoadMemoryVariables(context.Background(), map[string]any{})
+	require.NoError(t, err)
+	expected := map[string]any{"history": "Human: bar2\nAI: foo2\nHuman: bar3\nAI: foo3"}
+	assert.Equal(t, expected, result)
+}


### PR DESCRIPTION
Port the [ConversationBufferWindowMemory](https://python.langchain.com/docs/modules/memory/types/buffer_window) class from [langchain python](https://github.com/langchain-ai/langchain/blob/master/libs/langchain/langchain/memory/buffer_window.py) in langchaingo


### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
