### PR TITLE
feat: read OPENAI_API_BASE env to compatible with langchain

### DIFF
--- a/llms/openai/llm.go
+++ b/llms/openai/llm.go
@@ -21,7 +21,7 @@ func newClient(opts ...Option) (*openaiclient.Client, error) {
 	options := &options{
 		token:        os.Getenv(tokenEnvVarName),
 		model:        os.Getenv(modelEnvVarName),
-		baseURL:      os.Getenv(baseURLEnvVarName),
+		baseURL:      getEnvs(baseURLEnvVarName, baseAPIBaseEnvVarName),
 		organization: os.Getenv(organizationEnvVarName),
 		apiType:      APIType(openaiclient.APITypeOpenAI),
 		httpClient:   http.DefaultClient,
@@ -45,4 +45,14 @@ func newClient(opts ...Option) (*openaiclient.Client, error) {
 
 	return openaiclient.New(options.token, options.model, options.baseURL, options.organization,
 		openaiclient.APIType(options.apiType), options.apiVersion, options.httpClient, options.embeddingModel)
+}
+
+func getEnvs(keys ...string) string {
+	for _, key := range keys {
+		val, ok := os.LookupEnv(key)
+		if ok {
+			return val
+		}
+	}
+	return ""
 }

--- a/llms/openai/openaillm_option.go
+++ b/llms/openai/openaillm_option.go
@@ -6,6 +6,7 @@ const (
 	tokenEnvVarName        = "OPENAI_API_KEY"      //nolint:gosec
 	modelEnvVarName        = "OPENAI_MODEL"        //nolint:gosec
 	baseURLEnvVarName      = "OPENAI_BASE_URL"     //nolint:gosec
+	baseAPIBaseEnvVarName  = "OPENAI_API_BASE"     //nolint:gosec
 	organizationEnvVarName = "OPENAI_ORGANIZATION" //nolint:gosec
 )
 


### PR DESCRIPTION
there are many code in langchain use env `OPENAI_API_BASE`:
https://github.com/search?q=repo%3Alangchain-ai%2Flangchain%20OPENAI_API_BASE&type=code

such as: https://github.com/langchain-ai/langchain/blob/583696732cbaa3d1cf3a3a9375539a7e8785850c/libs/community/langchain_community/embeddings/azure_openai.py#L62

just add code to read backup env name `OPENAI_API_BASE` to campatible with langchain