### PR TITLE
pgvector: support postgres schema

### DIFF
--- a/vectorstores/pgvector/options.go
+++ b/vectorstores/pgvector/options.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/tmc/langchaingo/embeddings"
@@ -53,14 +54,14 @@ func WithCollectionName(name string) Option {
 // WithEmbeddingTableName is an option for specifying the embedding table name.
 func WithEmbeddingTableName(name string) Option {
 	return func(p *Store) {
-		p.embeddingTableName = pgx.Identifier{name}.Sanitize()
+		p.embeddingTableName = tableName(name)
 	}
 }
 
 // WithCollectionTableName is an option for specifying the collection table name.
 func WithCollectionTableName(name string) Option {
 	return func(p *Store) {
-		p.collectionTableName = pgx.Identifier{name}.Sanitize()
+		p.collectionTableName = tableName(name)
 	}
 }
 
@@ -89,4 +90,11 @@ func applyClientOptions(opts ...Option) (Store, error) {
 	}
 
 	return *o, nil
+}
+
+// tableName returns the table name with the schema sanitized.
+func tableName(name string) string {
+	nameParts := strings.Split(name, ".")
+
+	return pgx.Identifier(nameParts).Sanitize()
 }


### PR DESCRIPTION
Added support for Postgres Schemas. 

The table is named `"mySchema"."myTable"` instead `"mySchema.myTable"`.
