### PR TITLE
embeddings: Fix BatchTexts function

### DIFF
--- a/embeddings/embedding.go
+++ b/embeddings/embedding.go
@@ -3,6 +3,8 @@ package embeddings
 import (
 	"context"
 	"strings"
+
+	"github.com/tmc/langchaingo/internal/util"
 )
 
 // NewEmbedder creates a new Embedder from the given EmbedderClient, with
@@ -74,18 +76,10 @@ func MaybeRemoveNewLines(texts []string, removeNewLines bool) []string {
 
 // BatchTexts splits strings by the length batchSize.
 func BatchTexts(texts []string, batchSize int) [][]string {
-	batchedTexts := make([][]string, len(texts))
-	for i, text := range texts {
-		runeText := []rune(text)
+	batchedTexts := make([][]string, 0, len(texts)/batchSize+1)
 
-		for j := 0; j < len(runeText); j += batchSize {
-			if j+batchSize >= len(runeText) {
-				batchedTexts[i] = append(batchedTexts[i], string(runeText[j:]))
-				break
-			}
-
-			batchedTexts[i] = append(batchedTexts[i], string(runeText[j:j+batchSize]))
-		}
+	for i := 0; i < len(texts); i += batchSize {
+		batchedTexts = append(batchedTexts, texts[i:util.MinInt([]int{i + batchSize, len(texts)})])
 	}
 
 	return batchedTexts

--- a/embeddings/embedding_test.go
+++ b/embeddings/embedding_test.go
@@ -15,14 +15,44 @@ func TestBatchTexts(t *testing.T) {
 		expected  [][]string
 	}{
 		{
+			texts:     []string{},
+			batchSize: 1,
+			expected:  [][]string{},
+		},
+		{
 			texts:     []string{"foo bar zoo"},
 			batchSize: 4,
-			expected:  [][]string{{"foo ", "bar ", "zoo"}},
+			expected:  [][]string{{"foo bar zoo"}},
 		},
 		{
 			texts:     []string{"foo bar zoo", "foo"},
 			batchSize: 7,
-			expected:  [][]string{{"foo bar", " zoo"}, {"foo"}},
+			expected:  [][]string{{"foo bar zoo", "foo"}},
+		},
+		{
+			texts:     []string{"foo", "bar", "zoo"},
+			batchSize: 2,
+			expected:  [][]string{{"foo", "bar"}, {"zoo"}},
+		},
+		{
+			texts:     []string{"foo", "bar", "zoo", "baz", "qux"},
+			batchSize: 2,
+			expected:  [][]string{{"foo", "bar"}, {"zoo", "baz"}, {"qux"}},
+		},
+		{
+			texts:     []string{"foo", "bar", "zoo", "baz"},
+			batchSize: 2,
+			expected:  [][]string{{"foo", "bar"}, {"zoo", "baz"}},
+		},
+		{
+			texts:     []string{"foo", "bar", "zoo", "baz", "qux"},
+			batchSize: 3,
+			expected:  [][]string{{"foo", "bar", "zoo"}, {"baz", "qux"}},
+		},
+		{
+			texts:     []string{"foo", "bar", "zoo", "baz", "qux"},
+			batchSize: 6,
+			expected:  [][]string{{"foo", "bar", "zoo", "baz", "qux"}},
 		},
 	}
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -39,3 +39,20 @@ func ListKeys[T any](m map[string]T) []string {
 	}
 	return keys
 }
+
+// MinInt returns the minimum value in nums.
+// If nums is empty, it returns 0.
+func MinInt(nums []int) int {
+	var min int
+	for idx := 0; idx < len(nums); idx++ {
+		item := nums[idx]
+		if idx == 0 {
+			min = item
+			continue
+		}
+		if item < min {
+			min = item
+		}
+	}
+	return min
+}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMinInt(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		nums     []int
+		expected int
+	}{
+		{
+			nums:     []int{1, 2, 3, 23, 34},
+			expected: 1,
+		},
+		{
+			nums:     []int{3, 2, 1, 34, 2213},
+			expected: 1,
+		},
+		{
+			nums:     nil,
+			expected: 0,
+		},
+		{
+			nums:     []int{},
+			expected: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		assert.Equal(t, tc.expected, MinInt(tc.nums))
+	}
+}


### PR DESCRIPTION
Fixes #322 

This is how it's done in langchain js package https://github.com/langchain-ai/langchainjs/blob/4e9e23137de8d2bc61dfbcf05e8e35a8f1e89ef5/langchain/src/embeddings/openai.ts#L154

Current implementation batches the []texts by taking each text and **dividing** them into _batchSize_ chars instead of **grouping** the texts into _batchSize_ elements

If texts are ["abcd", "efgh", "ijkl", "mnop"] and batchSize is 2, current implementation breaks it into [ ["ab", "cd"], ["ef", "gh"], ... ] instead of [ ["abcd", "efgh" ], ["ijkl", "mnop"] ]

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
