### PR TITLE
templates: Fix up gonja/jinja2 handling

### DIFF
--- a/prompts/templates.go
+++ b/prompts/templates.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/nikolalohinski/gonja"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 )
 
 // ErrInvalidTemplateFormat is the error when the template format is invalid and
@@ -21,8 +22,8 @@ type TemplateFormat string
 const (
 	// TemplateFormatGoTemplate is the format for go-template.
 	TemplateFormatGoTemplate TemplateFormat = "go-template"
-	// TemplateFormatJinjia2 is the format for jinjia2.
-	TemplateFormatJinjia2 TemplateFormat = "jinjia2"
+	// TemplateFormatJinjia2 is the format for jinja2.
+	TemplateFormatJinjia2 TemplateFormat = "jinja2"
 )
 
 // interpolator is the function that interpolates the given template with the given values.
@@ -31,7 +32,7 @@ type interpolator func(template string, values map[string]any) (string, error)
 // defaultFormatterMapping is the default mapping of TemplateFormat to interpolator.
 var defaultFormatterMapping = map[TemplateFormat]interpolator{ //nolint:gochecknoglobals
 	TemplateFormatGoTemplate: interpolateGoTemplate,
-	TemplateFormatJinjia2:    interpolateJinjia2,
+	TemplateFormatJinjia2:    interpolateJinja2,
 }
 
 // interpolateGoTemplate interpolates the given template with the given values by using
@@ -53,8 +54,8 @@ func interpolateGoTemplate(tmpl string, values map[string]any) (string, error) {
 }
 
 // interpolateJinjia2 interpolates the given template with the given values by using
-// jinjia2(impl by https://github.com/NikolaLohinski/gonja).
-func interpolateJinjia2(tmpl string, values map[string]any) (string, error) {
+// jinja2(impl by https://github.com/NikolaLohinski/gonja).
+func interpolateJinja2(tmpl string, values map[string]any) (string, error) {
 	tpl, err := gonja.FromString(tmpl)
 	if err != nil {
 		return "", err
@@ -67,10 +68,12 @@ func interpolateJinjia2(tmpl string, values map[string]any) (string, error) {
 }
 
 func newInvalidTemplateError(gotTemplateFormat TemplateFormat) error {
+	formats := maps.Keys(defaultFormatterMapping)
+	slices.Sort(formats)
 	return fmt.Errorf("%w, got: %s, should be one of %s",
 		ErrInvalidTemplateFormat,
 		gotTemplateFormat,
-		maps.Keys(defaultFormatterMapping),
+		formats,
 	)
 }
 

--- a/prompts/templates_test.go
+++ b/prompts/templates_test.go
@@ -59,10 +59,10 @@ func TestInterpolateGoTemplate(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tc.expected, actual)
 			})
-			t.Run("jinjia2", func(t *testing.T) {
+			t.Run("jinja2", func(t *testing.T) {
 				t.Parallel()
 
-				actual, err := interpolateJinjia2(strings.ReplaceAll(tc.template, "{{ .", "{{ "), tc.templateValues)
+				actual, err := interpolateJinja2(strings.ReplaceAll(tc.template, "{{ .", "{{ "), tc.templateValues)
 				require.NoError(t, err)
 				assert.Equal(t, tc.expected, actual)
 			})
@@ -105,7 +105,7 @@ func TestCheckValidTemplate(t *testing.T) {
 		err := CheckValidTemplate("Hello, {test}", "unknown", []string{"test"})
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrInvalidTemplateFormat)
-		require.EqualError(t, err, "invalid template format, got: unknown, should be one of [go-template jinjia2]")
+		require.EqualError(t, err, "invalid template format, got: unknown, should be one of [go-template jinja2]")
 	})
 
 	t.Run("TemplateErrored", func(t *testing.T) {


### PR DESCRIPTION
A recent unrelated CI failure https://github.com/tmc/langchaingo/actions/runs/7359418374/job/20034158813?pr=464#step:5:599 shows that we have an unstable comparison and "jinja2" isn't appropriately used everywhere.