### PR TITLE
GenerateContent - initial experimental API with OpenAI implementation

### DIFF
--- a/llms/generatecontent.go
+++ b/llms/generatecontent.go
@@ -47,10 +47,13 @@ type BinaryContent struct {
 
 func (BinaryContent) isPart() {}
 
+// ContentResponse is the response returned by a GenerateContent call.
+// It can potentially return multiple response choices.
 type ContentResponse struct {
 	Choices []*ContentChoice
 }
 
+// ContentChoice is one of the response choices returned by GenerateModel calls.
 type ContentChoice struct {
 	Content        string
 	StopReason     string

--- a/llms/generatecontent.go
+++ b/llms/generatecontent.go
@@ -1,0 +1,54 @@
+package llms
+
+import "encoding/json"
+
+type ContentPart interface {
+	isPart()
+}
+
+type TextContent struct {
+	Text string
+}
+
+func (tc TextContent) MarshalJSON() ([]byte, error) {
+	m := map[string]string{
+		"type": "text",
+		"text": tc.Text,
+	}
+	return json.Marshal(m)
+}
+
+func (_ TextContent) isPart() {}
+
+type ImageURLContent struct {
+	URL string
+}
+
+func (iuc ImageURLContent) MarshalJSON() ([]byte, error) {
+	m := map[string]any{
+		"type": "image_url",
+		"image_url": map[string]string{
+			"url": iuc.URL,
+		},
+	}
+	return json.Marshal(m)
+}
+
+func (_ ImageURLContent) isPart() {}
+
+type BinaryContent struct {
+	MIMEType string
+	Data     []byte
+}
+
+func (_ BinaryContent) isPart() {}
+
+type ContentResponse struct {
+	Choices []*ContentChoice
+}
+
+type ContentChoice struct {
+	Content        string
+	StopReason     string
+	GenerationInfo map[string]any
+}

--- a/llms/generatecontent.go
+++ b/llms/generatecontent.go
@@ -20,7 +20,7 @@ func (tc TextContent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
-func (_ TextContent) isPart() {}
+func (TextContent) isPart() {}
 
 // ImageURLContent is content with an URL pointing to an image.
 type ImageURLContent struct {
@@ -37,14 +37,15 @@ func (iuc ImageURLContent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
-func (_ ImageURLContent) isPart() {}
+func (ImageURLContent) isPart() {}
 
+// BinaryContent is content holding some binary data with a MIME type.
 type BinaryContent struct {
 	MIMEType string
 	Data     []byte
 }
 
-func (_ BinaryContent) isPart() {}
+func (BinaryContent) isPart() {}
 
 type ContentResponse struct {
 	Choices []*ContentChoice

--- a/llms/generatecontent.go
+++ b/llms/generatecontent.go
@@ -2,10 +2,12 @@ package llms
 
 import "encoding/json"
 
+// ContentPart is an interface all parts of content have to implement.
 type ContentPart interface {
 	isPart()
 }
 
+// TextContent is content with some text.
 type TextContent struct {
 	Text string
 }
@@ -20,6 +22,7 @@ func (tc TextContent) MarshalJSON() ([]byte, error) {
 
 func (_ TextContent) isPart() {}
 
+// ImageURLContent is content with an URL pointing to an image.
 type ImageURLContent struct {
 	URL string
 }

--- a/llms/llms.go
+++ b/llms/llms.go
@@ -23,7 +23,9 @@ type ChatLLM interface {
 }
 
 // Model is an interface multi-modal models implement.
+// Note: this is an experimental API.
 type Model interface {
+	// GenerateContent asks the model to generate content from parts.
 	GenerateContent(ctx context.Context, parts []ContentPart, options ...CallOption) (*ContentResponse, error)
 }
 

--- a/llms/llms.go
+++ b/llms/llms.go
@@ -22,6 +22,11 @@ type ChatLLM interface {
 	Generate(ctx context.Context, messages [][]schema.ChatMessage, options ...CallOption) ([]*Generation, error)
 }
 
+// Model is an interface multi-modal models implement.
+type Model interface {
+	GenerateContent(ctx context.Context, parts []ContentPart, options ...CallOption) (*ContentResponse, error)
+}
+
 // Generation is a single generation from a langchaingo LLM.
 type Generation struct {
 	// Text is the generated text.

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -18,6 +18,8 @@ const (
 	defaultChatModel = "gpt-3.5-turbo"
 )
 
+var ErrContentExclusive = errors.New("only one of Content / MultiContent allowed in message")
+
 // ChatRequest is a request to complete a chat completion..
 type ChatRequest struct {
 	Model            string         `json:"model"`
@@ -63,7 +65,7 @@ type ChatMessage struct {
 
 func (m ChatMessage) MarshalJSON() ([]byte, error) {
 	if m.Content != "" && m.MultiContent != nil {
-		return nil, errors.New("only one of Content / MultiContent allowed in message")
+		return nil, ErrContentExclusive
 	}
 	if len(m.MultiContent) > 0 {
 		msg := struct {

--- a/llms/openai/multicontent_test.go
+++ b/llms/openai/multicontent_test.go
@@ -30,16 +30,16 @@ func TestMultiContentText(t *testing.T) {
 	llm := newChatClient(t)
 
 	parts := []llms.ContentPart{
-		llms.TextContent{"I'm a pomeranian"},
-		llms.TextContent{"What kind of mammal am I?"},
+		llms.TextContent{Text: "I'm a pomeranian"},
+		llms.TextContent{Text: "What kind of mammal am I?"},
 	}
 
 	rsp, err := llm.GenerateContent(context.Background(), parts)
 	require.NoError(t, err)
 
-	assert.GreaterOrEqual(t, len(rsp.Choices), 1)
+	assert.NotEmpty(t, rsp.Choices)
 	c1 := rsp.Choices[0]
-	assert.Regexp(t, "dog", strings.ToLower(c1.Content))
+	assert.Regexp(t, "dog|canid", strings.ToLower(c1.Content))
 }
 
 func TestMultiContentImage(t *testing.T) {
@@ -48,27 +48,22 @@ func TestMultiContentImage(t *testing.T) {
 	llm := newChatClient(t, WithModel("gpt-4-vision-preview"))
 
 	parts := []llms.ContentPart{
-		llms.ImageURLContent{"https://github.com/tmc/langchaingo/blob/main/docs/static/img/parrot-icon.png?raw=true"},
-		llms.TextContent{"describe this image in detail"},
+		llms.ImageURLContent{URL: "https://github.com/tmc/langchaingo/blob/main/docs/static/img/parrot-icon.png?raw=true"},
+		llms.TextContent{Text: "describe this image in detail"},
 	}
 
 	rsp, err := llm.GenerateContent(context.Background(), parts, llms.WithMaxTokens(300))
 	require.NoError(t, err)
 
-	assert.GreaterOrEqual(t, len(rsp.Choices), 1)
+	assert.NotEmpty(t, rsp.Choices)
 	c1 := rsp.Choices[0]
 	assert.Regexp(t, "parrot", strings.ToLower(c1.Content))
 }
 
-func showResponse(rsp any) string {
+func showResponse(rsp any) string { //nolint:golint,unused
 	b, err := json.MarshalIndent(rsp, "", "  ")
 	if err != nil {
 		panic(err)
 	}
 	return string(b)
 }
-
-// TODO: add test for image URL, for stability use some image on our own
-// site? maybe parrot-icon.png?
-// then add documentation all around and send
-// initial PR.

--- a/llms/openai/multicontent_test.go
+++ b/llms/openai/multicontent_test.go
@@ -1,0 +1,47 @@
+package openai
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/llms"
+)
+
+func newChatClient(t *testing.T, opts ...Option) *Chat {
+	t.Helper()
+	if openaiKey := os.Getenv("OPENAI_API_KEY"); openaiKey == "" {
+		t.Skip("OPENAI_API_KEY not set")
+		return nil
+	}
+
+	llm, err := NewChat(opts...)
+	require.NoError(t, err)
+	return llm
+}
+
+func TestMultiContentText(t *testing.T) {
+	t.Parallel()
+
+	llm := newChatClient(t)
+
+	parts := []llms.ContentPart{
+		llms.TextContent{"I'm a pomeranian"},
+		llms.TextContent{"What kind of mammal am I?"},
+	}
+
+	rsp, err := llm.GenerateContent(context.Background(), parts)
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, len(rsp.Choices), 1)
+	c1 := rsp.Choices[0]
+	assert.Regexp(t, "dog", strings.ToLower(c1.Content))
+}
+
+// TODO: add test for image URL, for stability use some image on our own
+// site? maybe parrot-icon.png?
+// then add documentation all around and send
+// initial PR.

--- a/llms/openai/multicontent_test.go
+++ b/llms/openai/multicontent_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -39,6 +40,32 @@ func TestMultiContentText(t *testing.T) {
 	assert.GreaterOrEqual(t, len(rsp.Choices), 1)
 	c1 := rsp.Choices[0]
 	assert.Regexp(t, "dog", strings.ToLower(c1.Content))
+}
+
+func TestMultiContentImage(t *testing.T) {
+	t.Parallel()
+
+	llm := newChatClient(t, WithModel("gpt-4-vision-preview"))
+
+	parts := []llms.ContentPart{
+		llms.ImageURLContent{"https://github.com/tmc/langchaingo/blob/main/docs/static/img/parrot-icon.png?raw=true"},
+		llms.TextContent{"describe this image in detail"},
+	}
+
+	rsp, err := llm.GenerateContent(context.Background(), parts, llms.WithMaxTokens(300))
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, len(rsp.Choices), 1)
+	c1 := rsp.Choices[0]
+	assert.Regexp(t, "parrot", strings.ToLower(c1.Content))
+}
+
+func showResponse(rsp any) string {
+	b, err := json.MarshalIndent(rsp, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
 }
 
 // TODO: add test for image URL, for stability use some image on our own

--- a/llms/openai/openaillm_chat.go
+++ b/llms/openai/openaillm_chat.go
@@ -87,7 +87,7 @@ func (o *Chat) GenerateContent(ctx context.Context, parts []llms.ContentPart, op
 		}
 	}
 
-	return &llms.ContentResponse{choices}, nil
+	return &llms.ContentResponse{Choices: choices}, nil
 }
 
 // Call requests a chat response for the given messages.

--- a/llms/openai/openaillm_chat.go
+++ b/llms/openai/openaillm_chat.go
@@ -38,6 +38,58 @@ func NewChat(opts ...Option) (*Chat, error) {
 	}, err
 }
 
+func (o *Chat) GenerateContent(ctx context.Context, parts []llms.ContentPart, options ...llms.CallOption) (*llms.ContentResponse, error) { // nolint: lll
+	opts := llms.CallOptions{}
+	for _, opt := range options {
+		opt(&opts)
+	}
+
+	msgs := []*ChatMessage{
+		{
+			Role:         "user",
+			MultiContent: parts,
+		},
+	}
+
+	req := &openaiclient.ChatRequest{
+		Model:                opts.Model,
+		StopWords:            opts.StopWords,
+		Messages:             msgs,
+		StreamingFunc:        opts.StreamingFunc,
+		Temperature:          opts.Temperature,
+		MaxTokens:            opts.MaxTokens,
+		N:                    opts.N,
+		FrequencyPenalty:     opts.FrequencyPenalty,
+		PresencePenalty:      opts.PresencePenalty,
+		FunctionCallBehavior: openaiclient.FunctionCallBehavior(opts.FunctionCallBehavior),
+	}
+
+	for _, fn := range opts.Functions {
+		req.Functions = append(req.Functions, openaiclient.FunctionDefinition{
+			Name:        fn.Name,
+			Description: fn.Description,
+			Parameters:  fn.Parameters,
+		})
+	}
+	result, err := o.client.CreateChat(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if len(result.Choices) == 0 {
+		return nil, ErrEmptyResponse
+	}
+
+	choices := make([]*llms.ContentChoice, len(result.Choices))
+	for i, c := range result.Choices {
+		choices[i] = &llms.ContentChoice{
+			Content:    c.Message.Content,
+			StopReason: c.FinishReason,
+		}
+	}
+
+	return &llms.ContentResponse{choices}, nil
+}
+
 // Call requests a chat response for the given messages.
 func (o *Chat) Call(ctx context.Context, messages []schema.ChatMessage, options ...llms.CallOption) (*schema.AIChatMessage, error) { // nolint: lll
 	r, err := o.Generate(ctx, [][]schema.ChatMessage{messages}, options...)


### PR DESCRIPTION
First sketch for #465, including an OpenAI implementation.

Also adding real tests that require API key to be set.

I'm marking this API as experimental so we can work on it without disrupting other code, initially.