### PR TITLE
Clear out GetNumTokens

### DIFF
--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -34,10 +34,6 @@ func (spv stringPromptValue) Messages() []schema.ChatMessage {
 	return nil
 }
 
-func (l *testLanguageModel) GetNumTokens(_ string) int {
-	return -1
-}
-
 func (l *testLanguageModel) Call(_ context.Context, prompt string, _ ...llms.CallOption) (string, error) {
 	l.recordedPrompt = []schema.PromptValue{
 		stringPromptValue{s: prompt},

--- a/llms/anthropic/anthropicllm.go
+++ b/llms/anthropic/anthropicllm.go
@@ -97,7 +97,3 @@ func (o *LLM) Generate(ctx context.Context, prompts []string, options ...llms.Ca
 	}
 	return generations, nil
 }
-
-func (o *LLM) GetNumTokens(text string) int {
-	return llms.CountTokens(o.client.Model, text)
-}

--- a/llms/cohere/coherellm.go
+++ b/llms/cohere/coherellm.go
@@ -70,10 +70,6 @@ func (o *LLM) Generate(ctx context.Context, prompts []string, options ...llms.Ca
 	return generations, nil
 }
 
-func (o *LLM) GetNumTokens(text string) int {
-	return o.client.GetNumTokens(text)
-}
-
 func New(opts ...Option) (*LLM, error) {
 	c, err := newClient(opts...)
 	return &LLM{

--- a/llms/cohere/internal/cohereclient/cohereclient.go
+++ b/llms/cohere/internal/cohereclient/cohereclient.go
@@ -137,8 +137,3 @@ func (c *Client) CreateGeneration(ctx context.Context, r *GenerationRequest) (*G
 
 	return &generation, nil
 }
-
-func (c *Client) GetNumTokens(text string) int {
-	encoded, _ := c.encoder.Encode(text)
-	return len(encoded)
-}

--- a/llms/ernie/ernie_chat.go
+++ b/llms/ernie/ernie_chat.go
@@ -123,10 +123,6 @@ func (o *Chat) Generate(ctx context.Context, messageSets [][]schema.ChatMessage,
 	return generations, nil
 }
 
-func (o *Chat) GetNumTokens(text string) int {
-	return llms.CountTokens(o.client.Model, text)
-}
-
 func getPromptsFromMessageSets(messageSets [][]schema.ChatMessage) []string {
 	prompts := make([]string, 0, len(messageSets))
 	for i := 0; i < len(messageSets); i++ {

--- a/llms/ernie/erniellm.go
+++ b/llms/ernie/erniellm.go
@@ -59,12 +59,6 @@ doc: https://cloud.baidu.com/doc/WENXINWORKSHOP/s/flfmc9do2`, ernieclient.ErrNot
 		ernieclient.WithAKSK(opts.apiKey, opts.secretKey))
 }
 
-func (o *LLM) GetNumTokens(_ string) int {
-	// todo: not provided yet
-	// see: https://cloud.baidu.com/doc/WENXINWORKSHOP/s/Nlks5zkzu
-	return -1
-}
-
 // Call implements llms.LLM.
 func (o *LLM) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
 	r, err := o.Generate(ctx, []string{prompt}, options...)

--- a/llms/huggingface/huggingfacellm.go
+++ b/llms/huggingface/huggingfacellm.go
@@ -72,10 +72,6 @@ func (o *LLM) Generate(ctx context.Context, prompts []string, options ...llms.Ca
 	return generations, nil
 }
 
-func (o *LLM) GetNumTokens(text string) int {
-	return llms.CountTokens("gpt2", text)
-}
-
 func New(opts ...Option) (*LLM, error) {
 	options := &options{
 		token: os.Getenv(tokenEnvVarName),

--- a/llms/llms.go
+++ b/llms/llms.go
@@ -10,10 +10,6 @@ import (
 type LLM interface {
 	Call(ctx context.Context, prompt string, options ...CallOption) (string, error)
 	Generate(ctx context.Context, prompts []string, options ...CallOption) ([]*Generation, error)
-
-	// Get the number of tokens present in the text. Returns -1 if this
-	// functionality is unavailable for the model.
-	GetNumTokens(text string) int
 }
 
 // ChatLLM is a langchaingo LLM that can be used for chatting.

--- a/llms/local/localllm.go
+++ b/llms/local/localllm.go
@@ -108,10 +108,6 @@ func (o *LLM) Generate(ctx context.Context, prompts []string, options ...llms.Ca
 	return generations, nil
 }
 
-func (o *LLM) GetNumTokens(text string) int {
-	return llms.CountTokens("gpt2", text)
-}
-
 // New creates a new local LLM implementation.
 func New(opts ...Option) (*LLM, error) {
 	options := &options{

--- a/llms/ollama/ollamallm.go
+++ b/llms/ollama/ollamallm.go
@@ -147,7 +147,3 @@ func (o *LLM) CreateEmbedding(ctx context.Context, inputTexts []string) ([][]flo
 
 	return embeddings, nil
 }
-
-func (o *LLM) GetNumTokens(text string) int {
-	return llms.CountTokens(o.options.model, text)
-}

--- a/llms/ollama/ollamallm_chat.go
+++ b/llms/ollama/ollamallm_chat.go
@@ -181,10 +181,6 @@ func (o *Chat) CreateEmbedding(ctx context.Context, inputTexts []string) ([][]fl
 	return embeddings, nil
 }
 
-func (o *Chat) GetNumTokens(text string) int {
-	return llms.CountTokens(o.options.model, text)
-}
-
 func (o Chat) getPromptsFromMessageSets(messageSets [][]schema.ChatMessage) []string {
 	prompts := make([]string, 0, len(messageSets))
 	for _, m := range messageSets {

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -81,10 +81,6 @@ func (o *LLM) Generate(ctx context.Context, prompts []string, options ...llms.Ca
 	return generations, nil
 }
 
-func (o *LLM) GetNumTokens(text string) int {
-	return llms.CountTokens(o.client.Model, text)
-}
-
 // CreateEmbedding creates embeddings for the given input texts.
 func (o *LLM) CreateEmbedding(ctx context.Context, inputTexts []string) ([][]float32, error) {
 	embeddings, err := o.client.CreateEmbedding(ctx, &openaiclient.EmbeddingRequest{

--- a/llms/openai/openaillm_chat.go
+++ b/llms/openai/openaillm_chat.go
@@ -169,10 +169,6 @@ func (o *Chat) Generate(ctx context.Context, messageSets [][]schema.ChatMessage,
 	return generations, nil
 }
 
-func (o *Chat) GetNumTokens(text string) int {
-	return llms.CountTokens(o.client.Model, text)
-}
-
 // CreateEmbedding creates embeddings for the given input texts.
 func (o *Chat) CreateEmbedding(ctx context.Context, inputTexts []string) ([][]float32, error) {
 	embeddings, err := o.client.CreateEmbedding(ctx, &openaiclient.EmbeddingRequest{

--- a/llms/vertexai/vertexai_palm_llm.go
+++ b/llms/vertexai/vertexai_palm_llm.go
@@ -89,10 +89,6 @@ func (o *LLM) CreateEmbedding(ctx context.Context, inputTexts []string) ([][]flo
 	return embeddings, nil
 }
 
-func (o *LLM) GetNumTokens(text string) int {
-	return llms.CountTokens(vertexaiclient.TextModelName, text)
-}
-
 // New returns a new VertexAI PaLM LLM.
 func New(opts ...Option) (*LLM, error) {
 	client, err := newClient(opts...)

--- a/llms/vertexai/vertexai_palm_llm_chat.go
+++ b/llms/vertexai/vertexai_palm_llm_chat.go
@@ -73,10 +73,6 @@ func (o *Chat) Generate(ctx context.Context, messageSets [][]schema.ChatMessage,
 	return generations, nil
 }
 
-func (o *Chat) GetNumTokens(text string) int {
-	return llms.CountTokens(vertexaiclient.TextModelName, text)
-}
-
 func toClientChatMessage(messages []schema.ChatMessage) []*vertexaiclient.ChatMessage {
 	msgs := make([]*vertexaiclient.ChatMessage, len(messages))
 

--- a/memory/token_buffer.go
+++ b/memory/token_buffer.go
@@ -105,5 +105,5 @@ func (tb *ConversationTokenBuffer) getNumTokensFromMessages(ctx context.Context)
 		return 0, err
 	}
 
-	return tb.LLM.GetNumTokens(bufferString), nil
+	return llms.CountTokens("", bufferString), nil
 }


### PR DESCRIPTION
It's not used and not implemented correctly for almost any model.

See #482 for details

If this is deemed useful, it will be more correct to expose a model name from the LLM (or cliena?) and then invoke a standalone function familiar with non-openai models.

