### PR TITLE
Clean up GeneratePrompt -- unused code, and simplify caller

### DIFF
--- a/chains/llm.go
+++ b/chains/llm.go
@@ -56,17 +56,12 @@ func (c LLMChain) Call(ctx context.Context, values map[string]any, options ...Ch
 		return nil, err
 	}
 
-	result, err := llms.GeneratePrompt(
-		ctx,
-		c.LLM,
-		[]schema.PromptValue{promptValue},
-		getLLMCallOptions(options...)...,
-	)
+	result, err := c.LLM.Call(ctx, promptValue.String(), getLLMCallOptions(options...)...)
 	if err != nil {
 		return nil, err
 	}
 
-	finalOutput, err := c.OutputParser.ParseWithPrompt(result.Generations[0][0].Text, promptValue)
+	finalOutput, err := c.OutputParser.ParseWithPrompt(result, promptValue)
 	if err != nil {
 		return nil, err
 	}

--- a/llms/llms.go
+++ b/llms/llms.go
@@ -42,25 +42,3 @@ type LLMResult struct {
 	Generations [][]*Generation
 	LLMOutput   map[string]any
 }
-
-func GeneratePrompt(ctx context.Context, l LLM, promptValues []schema.PromptValue, options ...CallOption) (LLMResult, error) { //nolint:lll
-	prompts := make([]string, 0, len(promptValues))
-	for _, promptValue := range promptValues {
-		prompts = append(prompts, promptValue.String())
-	}
-	generations, err := l.Generate(ctx, prompts, options...)
-	return LLMResult{
-		Generations: [][]*Generation{generations},
-	}, err
-}
-
-func GenerateChatPrompt(ctx context.Context, l ChatLLM, promptValues []schema.PromptValue, options ...CallOption) (LLMResult, error) { //nolint:lll
-	messages := make([][]schema.ChatMessage, 0, len(promptValues))
-	for _, promptValue := range promptValues {
-		messages = append(messages, promptValue.Messages())
-	}
-	generations, err := l.Generate(ctx, messages, options...)
-	return LLMResult{
-		Generations: [][]*Generation{generations},
-	}, err
-}


### PR DESCRIPTION
`GeneratePrompt` is an undocumented top-level function in llms - it's unused except in one place which has to work hard to adapt to it instead of just using `llm.Call` more simply -- update the single caller and simplify the code

`GenerateChatPrompt` is completely unused, so remove it.

re #465 