### PR TITLE
fix unmarshalling of chatmessage

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -47,7 +47,7 @@ type ChatRequest struct {
 }
 
 // ChatMessage is a message in a chat request.
-type ChatMessage struct {
+type ChatMessage struct { //nolint:musttag
 	// The role of the author of this message. One of system, user, or assistant.
 	Role string
 	// The content of the message.
@@ -85,6 +85,22 @@ func (m ChatMessage) MarshalJSON() ([]byte, error) {
 		FunctionCall *FunctionCall      `json:"function_call,omitempty"`
 	}(m)
 	return json.Marshal(msg)
+}
+
+func (m *ChatMessage) UnmarshalJSON(data []byte) error {
+	msg := struct {
+		Role         string             `json:"role"`
+		Content      string             `json:"content"`
+		MultiContent []llms.ContentPart `json:"-"` // not expected in response
+		Name         string             `json:"name,omitempty"`
+		FunctionCall *FunctionCall      `json:"function_call,omitempty"`
+	}{}
+	err := json.Unmarshal(data, &msg)
+	if err != nil {
+		return err
+	}
+	*m = ChatMessage(msg)
+	return nil
 }
 
 // ChatChoice is a choice in a chat response.

--- a/llms/openai/internal/openaiclient/chat_test.go
+++ b/llms/openai/internal/openaiclient/chat_test.go
@@ -3,6 +3,7 @@ package openaiclient
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"testing"
@@ -30,4 +31,24 @@ func TestParseStreamingChatResponse_FinishReason(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, "stop", resp.Choices[0].FinishReason)
+}
+
+func TestChatMessage_MarshalUnmarshal(t *testing.T) {
+	t.Parallel()
+	msg := ChatMessage{
+		Role:    "assistant",
+		Content: "hello",
+		FunctionCall: &FunctionCall{
+			Name:      "test",
+			Arguments: "func",
+		},
+	}
+	text, err := json.Marshal(msg)
+	require.NoError(t, err)
+	require.Equal(t, `{"role":"assistant","content":"hello","function_call":{"name":"test","arguments":"func"}}`, string(text)) // nolint: lll
+
+	var msg2 ChatMessage
+	err = json.Unmarshal(text, &msg2)
+	require.NoError(t, err)
+	require.Equal(t, msg, msg2)
 }


### PR DESCRIPTION
### PR Checklist

- [x ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x ] Describes the source of new concepts.
- [ x] References existing implementations as appropriate.
- [x ] Contains test coverage for new functions.
- [ x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

I noticed after pulling the latest tag from 2 days ago that #480 removed struct tags from ChatMessage. A custom marshaller was implemented to retain compatibility, but there's no custom unmarshaller, so existing responses from OpenAI that contain a ChatMessage fail (for me, specifically when the StopReason is function_call, it doesn't fill in the FunctionCall properly).

So, I've added a corresponding Unmarshaller implementation & test. I'm not sure if MultiContent ever comes back in a response - if it does then there would be more work involved to detect the type and instantiate the correct implementation of llms.ContentPart.