### PR TITLE
textsplitter: render code blocks and reference links

### DIFF
--- a/textsplitter/markdown_splitter.go
+++ b/textsplitter/markdown_splitter.go
@@ -121,6 +121,8 @@ type markdownContext struct {
 }
 
 // splitText splits Markdown text.
+//
+//nolint:cyclop
 func (mc *markdownContext) splitText() []string {
 	for idx := mc.startAt; idx < mc.endAt; {
 		token := mc.tokens[idx]
@@ -500,10 +502,10 @@ func (mc *markdownContext) onTableBody() [][]string {
 	}
 }
 
-// onMDCodeBlock splits indented code block
+// onMDCodeBlock splits indented code block.
 func (mc *markdownContext) onMDCodeBlock() {
 	defer func() {
-		mc.startAt += 1
+		mc.startAt++
 	}()
 
 	if !mc.renderCodeBlocks {
@@ -515,6 +517,12 @@ func (mc *markdownContext) onMDCodeBlock() {
 		return
 	}
 
+	// CommonMark Spec 4.4: Indented Code Blocks
+	// An indented code block is composed of one or more indented chunks
+	// separated by blank lines. An indented chunk is a sequence of
+	// non-blank lines, each preceded by four or more spaces of indentation.
+
+	//nolint:gomnd
 	codeblockMD := "\n" + formatWithIndent(codeblock.Content, strings.Repeat(" ", 4))
 
 	// adding this as a single snippet means that long codeblocks will be split
@@ -523,10 +531,10 @@ func (mc *markdownContext) onMDCodeBlock() {
 	mc.joinSnippet(codeblockMD)
 }
 
-// onMDFence splits fenced code block
+// onMDFence splits fenced code block.
 func (mc *markdownContext) onMDFence() {
 	defer func() {
-		mc.startAt += 1
+		mc.startAt++
 	}()
 
 	if !mc.renderCodeBlocks {
@@ -546,10 +554,10 @@ func (mc *markdownContext) onMDFence() {
 	mc.joinSnippet(fenceMD)
 }
 
-// onMDHr splits thematic break
+// onMDHr splits thematic break.
 func (mc *markdownContext) onMDHr() {
 	defer func() {
-		mc.startAt += 1
+		mc.startAt++
 	}()
 
 	if _, ok := mc.tokens[mc.startAt].(*markdown.Hr); !ok {
@@ -616,6 +624,8 @@ func (mc *markdownContext) applyToChunks() {
 // splitInline splits inline
 //
 // format: Link/Image/Text
+//
+//nolint:funlen,cyclop
 func (mc *markdownContext) splitInline(inline *markdown.Inline) string {
 	if len(inline.Children) == 0 || mc.useInlineContent {
 		return inline.Content
@@ -626,7 +636,6 @@ func (mc *markdownContext) splitInline(inline *markdown.Inline) string {
 	var currentLink *markdown.LinkOpen
 
 	// CommonMark Spec 6: Inlines
-	// Inlines include:
 	// - Soft linebreaks
 	// - Hard linebreaks
 	// - Emphasis and strong emphasis
@@ -661,7 +670,7 @@ func (mc *markdownContext) splitInline(inline *markdown.Inline) string {
 				content += fmt.Sprintf("`%s`", token.Content)
 			case *markdown.LinkOpen:
 				content += "["
-				// CommonMark Spec 6.3: Links
+				// CommonMark Spec 6.3:
 				// Links may not contain other links, at any level of nesting.
 				// If multiple otherwise valid link definitions appear nested
 				// inside each other, the inner-most definition is used.

--- a/textsplitter/options.go
+++ b/textsplitter/options.go
@@ -10,6 +10,8 @@ type Options struct {
 	AllowedSpecial    []string
 	DisallowedSpecial []string
 	SecondSplitter    TextSplitter
+	CodeBlocks        bool
+	ReferenceLinks    bool
 }
 
 // DefaultOptions returns the default options for all text splitter.
@@ -82,5 +84,26 @@ func WithDisallowedSpecial(disallowedSpecial []string) Option {
 func WithSecondSplitter(secondSplitter TextSplitter) Option {
 	return func(o *Options) {
 		o.SecondSplitter = secondSplitter
+	}
+}
+
+// WithCodeBlocks sets whether indented and fenced codeblocks should be included
+// in the output.
+func WithCodeBlocks(renderCode bool) Option {
+	return func(o *Options) {
+		o.CodeBlocks = renderCode
+	}
+}
+
+// WithReferenceLinks sets whether reference links (i.e. `[text][label]`)
+// should be patched with the url and title from their definition. Note that
+// by default reference definitions are dropped from the output.
+//
+// Caution: this also affects how other inline elements are rendered, e.g. all
+// emphasis will use `*` even when another character (e.g. `_`) was used in the
+// input.
+func WithReferenceLinks(referenceLinks bool) Option {
+	return func(o *Options) {
+		o.ReferenceLinks = referenceLinks
 	}
 }


### PR DESCRIPTION
### textsplitter: render code block, fence, and hr in markdown_splitter
Enhance markdown text splitting functionality by adding handlers for
markdown code blocks, fences, and horizontal rules. This change allows
the markdown splitter to properly process and format these elements,
improving the accuracy of the text splitting process.  However, long
code blocks and fenced blocks will be split as text and won't be
properly wrapped, which is a known limitation that aligns with the
current behavior of the python langchain.

### textsplitter: support reference links in markdown_splitter
The markdown splitter function 'splitInline' has been significantly
enhanced to handle a variety of inline elements as per the CommonMark
specification. Previously, it simply returned the content of the inline
element. Now, it checks for the presence of children in the inline
element and processes them accordingly.

This change was necessary to support reference links, which have the
following format:

```markdown
[foo][bar]

[bar]: /url "title"
```

When this gets parsed, the URL and title from the definition are
added to each reference link and the definition is dropped from the
document. This means when the document is rendered we end up with
incomplete links.

With this change, we render full links instead of references, so the
example above ends up looking like:

```markdown
[foo](/url "title")
```

### textsplitter: add options for rendering code blocks and reference links
The changes introduce two new options in the MarkdownTextSplitter struct:
CodeBlocks and ReferenceLinks. These options allow users to specify
whether they want to render code blocks and reference links when
splitting a markdown text.

The CodeBlocks option determines whether indented and fenced code
blocks should be rendered. If set to false, these blocks are ignored
during the splitting process.

The ReferenceLinks option determines whether reference links should be
patched with the URL and title from their definition. By default,
reference definitions are dropped from the output.

These changes provide users with more control over how their markdown
text is split, allowing them to include or exclude specific elements
as needed.

### textsplitter: enhance markdown splitter tests
Extend the test coverage for the Markdown splitter. The changes include
new tests for code splitting, inline elements, and handling of different
markdown features such as fenced code blocks, hard breaks, emphasis,
strikethrough, images, and links. The changes aim to ensure the robustness
of the Markdown splitter and its ability to handle a variety of markdown
syntaxes.

### textsplitter: refactor splitInline in markdown_splitter

Extracted the logic for handling link closure and image processing into
separate functions. This reduces the complexity of the `splitInline` function,
improving readability and maintainability. Removed unnecessary comments and
linting directives.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
