### PR TITLE
Add Ollama test and remove custom prompt for chat

### DIFF
--- a/llms/ollama/chatoptions.go
+++ b/llms/ollama/chatoptions.go
@@ -1,37 +1,10 @@
 package ollama
 
 type chatOptions struct {
-	chatTemplate string
 	options
 }
 
 type ChatOption func(*chatOptions)
-
-const (
-	// A default chat template for LLama2 from https://www.philschmid.de/llama-2#how-to-prompt-llama-2-chat.
-	// LLamacpp will add the BOS by default,
-	// See https://github.com/ggerganov/llama.cpp/tree/master/examples/server#api-endpoints for more details.
-	_defaultLLamaChatTemplate = `[INST] <<SYS>>
-{{.system}}
-<</SYS>>
-
-{{ range $m := .messagesPair }}
- {{- $u := index $m 0 }}
- {{- $a := index $m 1 }}
- {{- if $u }}
-   {{- $u }} [/INST]
- {{- end }}
- {{- if $a }}
- {{- " " }}{{- $a }}</s><s>[INST]{{" "}}
- {{- end }}
-{{- end }}`
-)
-
-func defaultChatOptions() chatOptions {
-	return chatOptions{
-		chatTemplate: _defaultLLamaChatTemplate,
-	}
-}
 
 // WithLLMOptions Set underlying LLM options.
 func WithLLMOptions(opts ...Option) ChatOption {
@@ -39,14 +12,5 @@ func WithLLMOptions(opts ...Option) ChatOption {
 		for _, opt := range opts {
 			opt(&copts.options)
 		}
-	}
-}
-
-// WithChatTemplate Set the chat go template to use (default: _defaultLLamaChatTemplate)
-// The chat template expects the inputs variables system as string and messagesPair as
-// a list of pair of string starting with user one.
-func WithChatTemplate(t string) ChatOption {
-	return func(opts *chatOptions) {
-		opts.chatTemplate = t
 	}
 }

--- a/llms/ollama/ollama_test.go
+++ b/llms/ollama/ollama_test.go
@@ -2,7 +2,6 @@ package ollama
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -25,6 +24,7 @@ func newChatClient(t *testing.T) *Chat {
 	return c
 }
 
+//nolint:all
 func TestChatBasic(t *testing.T) {
 	t.Parallel()
 
@@ -35,6 +35,5 @@ func TestChatBasic(t *testing.T) {
 		schema.HumanChatMessage{Content: "Write a very short poem about Donald Knuth"},
 	})
 	require.NoError(t, err)
-	fmt.Println(resp.Content)
 	assert.Regexp(t, "programa|comput|algoritm|libro", strings.ToLower(resp.Content))
 }

--- a/llms/ollama/ollama_test.go
+++ b/llms/ollama/ollama_test.go
@@ -1,0 +1,40 @@
+package ollama
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/schema"
+)
+
+func newChatClient(t *testing.T) *Chat {
+	t.Helper()
+	var ollamaModel string
+	if ollamaModel = os.Getenv("OLLAMA_TEST_MODEL"); ollamaModel == "" {
+		t.Skip("OLLAMA_TEST_MODEL not set")
+		return nil
+	}
+
+	c, err := NewChat(WithLLMOptions(WithModel(ollamaModel)))
+	require.NoError(t, err)
+	return c
+}
+
+func TestChatBasic(t *testing.T) {
+	t.Parallel()
+
+	llm := newChatClient(t)
+
+	resp, err := llm.Call(context.Background(), []schema.ChatMessage{
+		schema.SystemChatMessage{Content: "You are producing poems in Spanish."},
+		schema.HumanChatMessage{Content: "Write a very short poem about Donald Knuth"},
+	})
+	require.NoError(t, err)
+	fmt.Println(resp.Content)
+	assert.Regexp(t, "programa|comput|algoritm|libro", strings.ToLower(resp.Content))
+}


### PR DESCRIPTION
Following #405, the custom prompting is no longer needed since we now use the `/chat` endpoint of Ollama for chats.

This helps clean out a bunch of code!

Adding test for ollama that can be run locally by setting the `OLLAMA_TEST_MODEL` env var (otherwise skip).
