### PR TITLE
Extend Model / GenerateContent interface to support multi-content chats

### DIFF
--- a/llms/generatecontent.go
+++ b/llms/generatecontent.go
@@ -1,6 +1,20 @@
 package llms
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/tmc/langchaingo/schema"
+)
+
+// MessageContent is the content of a message sent to a LLM. It has a role and a
+// sequence of parts. For example, it can represent one message in a chat
+// session sent by the user, in which case Role will be
+// schema.ChatMessageTypeHuman and Parts will be the sequence of items sent in
+// this specific message.
+type MessageContent struct {
+	Role  schema.ChatMessageType
+	Parts []ContentPart
+}
 
 // ContentPart is an interface all parts of content have to implement.
 type ContentPart interface {

--- a/llms/googleai/googleai_llm_test.go
+++ b/llms/googleai/googleai_llm_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/schema"
 )
 
 func newClient(t *testing.T) *GoogleAI {
@@ -32,8 +33,14 @@ func TestMultiContentText(t *testing.T) {
 		llms.TextContent{Text: "I'm a pomeranian"},
 		llms.TextContent{Text: "What kind of mammal am I?"},
 	}
+	content := []llms.MessageContent{
+		{
+			Role:  schema.ChatMessageTypeHuman,
+			Parts: parts,
+		},
+	}
 
-	rsp, err := llm.GenerateContent(context.Background(), parts)
+	rsp, err := llm.GenerateContent(context.Background(), content)
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, rsp.Choices)
@@ -49,8 +56,14 @@ func TestMultiContentImage(t *testing.T) {
 		llms.ImageURLContent{URL: "https://github.com/tmc/langchaingo/blob/main/docs/static/img/parrot-icon.png?raw=true"},
 		llms.TextContent{Text: "describe this image in detail"},
 	}
+	content := []llms.MessageContent{
+		{
+			Role:  schema.ChatMessageTypeHuman,
+			Parts: parts,
+		},
+	}
 
-	rsp, err := llm.GenerateContent(context.Background(), parts, llms.WithModel("gemini-pro-vision"))
+	rsp, err := llm.GenerateContent(context.Background(), content, llms.WithModel("gemini-pro-vision"))
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, rsp.Choices)

--- a/llms/llms.go
+++ b/llms/llms.go
@@ -21,8 +21,10 @@ type ChatLLM interface {
 // Model is an interface multi-modal models implement.
 // Note: this is an experimental API.
 type Model interface {
-	// GenerateContent asks the model to generate content from parts.
-	GenerateContent(ctx context.Context, parts []ContentPart, options ...CallOption) (*ContentResponse, error)
+	// GenerateContent asks the model to generate content from a sequence of
+	// messages. It's the most general interface for LLMs that support chat-like
+	// interactions.
+	GenerateContent(ctx context.Context, parts []MessageContent, options ...CallOption) (*ContentResponse, error)
 }
 
 // Generation is a single generation from a langchaingo LLM.

--- a/llms/openai/multicontent_test.go
+++ b/llms/openai/multicontent_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/schema"
 )
 
 func newChatClient(t *testing.T, opts ...Option) *Chat {
@@ -33,8 +34,14 @@ func TestMultiContentText(t *testing.T) {
 		llms.TextContent{Text: "I'm a pomeranian"},
 		llms.TextContent{Text: "What kind of mammal am I?"},
 	}
+	content := []llms.MessageContent{
+		{
+			Role:  schema.ChatMessageTypeHuman,
+			Parts: parts,
+		},
+	}
 
-	rsp, err := llm.GenerateContent(context.Background(), parts)
+	rsp, err := llm.GenerateContent(context.Background(), content)
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, rsp.Choices)
@@ -51,8 +58,14 @@ func TestMultiContentImage(t *testing.T) {
 		llms.ImageURLContent{URL: "https://github.com/tmc/langchaingo/blob/main/docs/static/img/parrot-icon.png?raw=true"},
 		llms.TextContent{Text: "describe this image in detail"},
 	}
+	content := []llms.MessageContent{
+		{
+			Role:  schema.ChatMessageTypeHuman,
+			Parts: parts,
+		},
+	}
 
-	rsp, err := llm.GenerateContent(context.Background(), parts, llms.WithMaxTokens(300))
+	rsp, err := llm.GenerateContent(context.Background(), content, llms.WithMaxTokens(300))
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, rsp.Choices)

--- a/llms/openai/openaillm_chat.go
+++ b/llms/openai/openaillm_chat.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"github.com/tmc/langchaingo/callbacks"
@@ -56,6 +57,8 @@ func (o *Chat) GenerateContent(ctx context.Context, messages []llms.MessageConte
 			msg.Role = "user"
 		case schema.ChatMessageTypeGeneric:
 			msg.Role = "user"
+		default:
+			return nil, fmt.Errorf("role %v not supported", mc.Role)
 		}
 
 		chatMsgs = append(chatMsgs, msg)

--- a/llms/openai/openaillm_chat.go
+++ b/llms/openai/openaillm_chat.go
@@ -39,7 +39,8 @@ func NewChat(opts ...Option) (*Chat, error) {
 	}, err
 }
 
-func (o *Chat) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) { // nolint: lll
+//nolint:goerr113
+func (o *Chat) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) { // nolint: lll, cyclop
 	opts := llms.CallOptions{}
 	for _, opt := range options {
 		opt(&opts)
@@ -50,13 +51,15 @@ func (o *Chat) GenerateContent(ctx context.Context, messages []llms.MessageConte
 		msg := &ChatMessage{MultiContent: mc.Parts}
 		switch mc.Role {
 		case schema.ChatMessageTypeSystem:
-			msg.Role = "system"
+			msg.Role = RoleSystem
 		case schema.ChatMessageTypeAI:
-			msg.Role = "assistant"
+			msg.Role = RoleAssistant
 		case schema.ChatMessageTypeHuman:
-			msg.Role = "user"
+			msg.Role = RoleUser
 		case schema.ChatMessageTypeGeneric:
-			msg.Role = "user"
+			msg.Role = RoleUser
+		case schema.ChatMessageTypeFunction:
+			fallthrough
 		default:
 			return nil, fmt.Errorf("role %v not supported", mc.Role)
 		}


### PR DESCRIPTION
Generalizes the interface to enable chat interactions as well as single-message interactions

Re #410 and #465
