### PR TITLE
Add multi-turn tests for new GenerateContent capabilities

### DIFF
--- a/llms/googleai/googleai_llm_test.go
+++ b/llms/googleai/googleai_llm_test.go
@@ -48,6 +48,33 @@ func TestMultiContentText(t *testing.T) {
 	assert.Regexp(t, "dog|canid|canine", strings.ToLower(c1.Content))
 }
 
+func TestMultiContentTextChatSequence(t *testing.T) {
+	t.Parallel()
+	llm := newClient(t)
+
+	content := []llms.MessageContent{
+		{
+			Role:  schema.ChatMessageTypeHuman,
+			Parts: []llms.ContentPart{llms.TextContent{Text: "Name some countries"}},
+		},
+		{
+			Role:  schema.ChatMessageTypeAI,
+			Parts: []llms.ContentPart{llms.TextContent{Text: "Spain and Lesotho"}},
+		},
+		{
+			Role:  schema.ChatMessageTypeHuman,
+			Parts: []llms.ContentPart{llms.TextContent{Text: "Which if these is larger?"}},
+		},
+	}
+
+	rsp, err := llm.GenerateContent(context.Background(), content, llms.WithModel("gemini-pro"))
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, rsp.Choices)
+	c1 := rsp.Choices[0]
+	assert.Regexp(t, "spain.*larger", strings.ToLower(c1.Content))
+}
+
 func TestMultiContentImage(t *testing.T) {
 	t.Parallel()
 	llm := newClient(t)

--- a/llms/openai/multicontent_test.go
+++ b/llms/openai/multicontent_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -47,6 +48,34 @@ func TestMultiContentText(t *testing.T) {
 	assert.NotEmpty(t, rsp.Choices)
 	c1 := rsp.Choices[0]
 	assert.Regexp(t, "dog|canid", strings.ToLower(c1.Content))
+}
+
+func TestMultiContentTextChatSequence(t *testing.T) {
+	t.Parallel()
+	llm := newChatClient(t)
+
+	content := []llms.MessageContent{
+		{
+			Role:  schema.ChatMessageTypeHuman,
+			Parts: []llms.ContentPart{llms.TextContent{Text: "Name some countries"}},
+		},
+		{
+			Role:  schema.ChatMessageTypeAI,
+			Parts: []llms.ContentPart{llms.TextContent{Text: "Spain and Lesotho"}},
+		},
+		{
+			Role:  schema.ChatMessageTypeHuman,
+			Parts: []llms.ContentPart{llms.TextContent{Text: "Which if these is larger?"}},
+		},
+	}
+
+	rsp, err := llm.GenerateContent(context.Background(), content)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, rsp.Choices)
+	c1 := rsp.Choices[0]
+	fmt.Println(c1)
+	assert.Regexp(t, "spain.*larger.*lesotho", strings.ToLower(c1.Content))
 }
 
 func TestMultiContentImage(t *testing.T) {

--- a/llms/openai/multicontent_test.go
+++ b/llms/openai/multicontent_test.go
@@ -3,7 +3,6 @@ package openai
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -74,8 +73,7 @@ func TestMultiContentTextChatSequence(t *testing.T) {
 
 	assert.NotEmpty(t, rsp.Choices)
 	c1 := rsp.Choices[0]
-	fmt.Println(c1)
-	assert.Regexp(t, "spain.*larger.*lesotho", strings.ToLower(c1.Content))
+	assert.Regexp(t, "spain.*larger", strings.ToLower(c1.Content))
 }
 
 func TestMultiContentImage(t *testing.T) {


### PR DESCRIPTION
Add multi-turn tests for new GenerateContent capabilities
    
For both openai and googleai providers
