### PR TITLE
ollama: Add Support for Custom HTTP Headers in Client 🔐 

### DIFF
--- a/llms/ollama/internal/ollamaclient/ollamaclient.go
+++ b/llms/ollama/internal/ollamaclient/ollamaclient.go
@@ -112,14 +112,7 @@ func (c *Client) do(ctx context.Context, method, path string, reqData, respData 
 		return err
 	}
 
-	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Accept", "application/json")
-	request.Header.Set("User-Agent",
-		fmt.Sprintf("langchaingo/ (%s %s) Go/%s", runtime.GOARCH, runtime.GOOS, runtime.Version()))
-
-	for key, value := range c.additionalHeaders {
-		request.Header.Set(key, value)
-	}
+	setRequestHeaders(request, c.additionalHeaders)
 
 	respObj, err := c.http.Do(request)
 	if err != nil {
@@ -144,6 +137,17 @@ func (c *Client) do(ctx context.Context, method, path string, reqData, respData 
 	return nil
 }
 
+func setRequestHeaders(request *http.Request, additionalHeaders map[string]string) {
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("User-Agent",
+		fmt.Sprintf("langchaingo/ (%s %s) Go/%s", runtime.GOARCH, runtime.GOOS, runtime.Version()))
+
+	for key, value := range additionalHeaders {
+		request.Header.Set(key, value)
+	}
+}
+
 const maxBufferSize = 512 * 1000
 
 func (c *Client) stream(ctx context.Context, method, path string, data any, fn func([]byte) error) error {
@@ -163,14 +167,7 @@ func (c *Client) stream(ctx context.Context, method, path string, data any, fn f
 		return err
 	}
 
-	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Accept", "application/x-ndjson")
-	request.Header.Set("User-Agent",
-		fmt.Sprintf("langchaingo (%s %s) Go/%s", runtime.GOARCH, runtime.GOOS, runtime.Version()))
-
-	for key, value := range c.additionalHeaders {
-		request.Header.Set(key, value)
-	}
+	setRequestHeaders(request, c.additionalHeaders)
 
 	response, err := c.http.Do(request)
 	if err != nil {

--- a/llms/ollama/internal/ollamaclient/ollamaclient.go
+++ b/llms/ollama/internal/ollamaclient/ollamaclient.go
@@ -77,6 +77,8 @@ func NewClient(ourl *url.URL, ollamaAdditionalHeaders map[string]string) (*Clien
 	return &client, nil
 }
 
+const expectedKeyValuePairs = 2
+
 func parseHeaders(envString string) map[string]string {
 	headers := make(map[string]string)
 	if envString == "" {
@@ -84,8 +86,8 @@ func parseHeaders(envString string) map[string]string {
 	}
 	pairs := strings.Split(envString, ",")
 	for _, pair := range pairs {
-		kv := strings.SplitN(pair, ":", 2)
-		if len(kv) == 2 {
+		kv := strings.SplitN(pair, ":", expectedKeyValuePairs)
+		if len(kv) == expectedKeyValuePairs {
 			headers[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
 		}
 	}

--- a/llms/ollama/ollamallm.go
+++ b/llms/ollama/ollamallm.go
@@ -30,7 +30,7 @@ func New(opts ...Option) (*LLM, error) {
 		opt(&o)
 	}
 
-	client, err := ollamaclient.NewClient(o.ollamaServerURL)
+	client, err := ollamaclient.NewClient(o.ollamaServerURL, o.additionalHeaders)
 	if err != nil {
 		return nil, err
 	}

--- a/llms/ollama/ollamallm_chat.go
+++ b/llms/ollama/ollamallm_chat.go
@@ -27,7 +27,7 @@ func NewChat(opts ...Option) (*Chat, error) {
 		opt(&o)
 	}
 
-	client, err := ollamaclient.NewClient(o.ollamaServerURL)
+	client, err := ollamaclient.NewClient(o.ollamaServerURL, o.additionalHeaders)
 	if err != nil {
 		return nil, err
 	}

--- a/llms/ollama/options.go
+++ b/llms/ollama/options.go
@@ -9,6 +9,7 @@ import (
 
 type options struct {
 	ollamaServerURL     *url.URL
+	additionalHeaders   map[string]string
 	model               string
 	ollamaOptions       ollamaclient.Options
 	customModelTemplate string
@@ -49,6 +50,13 @@ func WithServerURL(rawURL string) Option {
 		if err != nil {
 			log.Fatal(err)
 		}
+	}
+}
+
+// WithAdditionalHeaders Set the additional Headers.
+func WithAdditionalHeaders(additionalHeaders map[string]string) Option {
+	return func(opts *options) {
+		opts.additionalHeaders = additionalHeaders
 	}
 }
 


### PR DESCRIPTION
Hello Team,

I've made an update to the `ollama` package to enhance the functionality of the `Client` struct. This update allows users to set custom HTTP headers when making requests to the Ollama server.

**Key Changes:**
- Added a new field `additionalHeaders` in the `Client` struct to store custom headers.
- Updated the `NewClient` function to accept custom headers as a parameter.
- Implemented the `parseHeaders` function to convert header strings to a map.
- Modified the `do` and `stream` methods of the `Client` struct to include custom headers in requests.

**Why This Change:**
Custom HTTP headers are crucial for various use cases, such as setting authentication tokens, customizing content types, or providing API keys. This flexibility is essential for users who need to interact with different types of HTTP-based services through the Ollama client.

**Additional Notes:**
This change is backward compatible as it adds a new feature without altering the existing functionalities. Users who don't need custom headers can continue to use the client as before.

I believe this enhancement will make the Ollama client more versatile and user-friendly. Looking forward to your feedback and suggestions.

Thank you for considering this contribution!

Best regards tuhochi!