### PR TITLE
vectorstores: Weaviate make additional fields configurable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[langchaingo Code of Conduct](/CODE_OF_CONDUCT.md).
+[langchaingo Code of Conduct](CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to <travis.cline@gmail.com>.
 

--- a/vectorstores/weaviate/options.go
+++ b/vectorstores/weaviate/options.go
@@ -105,6 +105,13 @@ func WithQueryAttrs(queryAttrs []string) Option {
 	}
 }
 
+// WithAdditionalFields is an option for setting additional fields query attributes of the weaviate server.
+func WithAdditionalFields(additionalFields []string) Option {
+	return func(p *Store) {
+		p.additionalFields = additionalFields
+	}
+}
+
 func applyClientOptions(opts ...Option) (Store, error) {
 	o := &Store{
 		textKey:      _defaultTextKey,
@@ -143,5 +150,31 @@ func applyClientOptions(opts ...Option) (Store, error) {
 		o.queryAttrs = append(o.queryAttrs, o.nameSpaceKey)
 	}
 
+	// add additional fields
+	defaultAdditionalFields := []string{"certainty"}
+
+	if o.additionalFields == nil {
+		o.additionalFields = defaultAdditionalFields
+	} else {
+		o.additionalFields = mergeValuesAsUnique(defaultAdditionalFields, o.additionalFields)
+	}
+
 	return *o, nil
+}
+
+func mergeValuesAsUnique(collections ...[]string) []string {
+	valueMap := make(map[string]bool)
+
+	for _, collection := range collections {
+		for _, value := range collection {
+			valueMap[value] = true
+		}
+	}
+
+	uniqueValues := make([]string, 0, len(valueMap))
+	for k := range valueMap {
+		uniqueValues = append(uniqueValues, k)
+	}
+
+	return uniqueValues
 }

--- a/vectorstores/weaviate/weaviate.go
+++ b/vectorstores/weaviate/weaviate.go
@@ -57,7 +57,8 @@ type Store struct {
 	connectionClient *http.Client
 
 	// optional
-	queryAttrs []string
+	queryAttrs       []string
+	additionalFields []string
 }
 
 var _ vectorstores.VectorStore = Store{}
@@ -273,11 +274,18 @@ func (s Store) createFields() []graphql.Field {
 			Name: attr,
 		})
 	}
+
+	additionalFields := make([]graphql.Field, 0, len(s.additionalFields))
+	for _, attr := range s.additionalFields {
+		additionalFields = append(additionalFields, graphql.Field{
+			Name: attr,
+		})
+	}
+
 	fields = append(fields, graphql.Field{
-		Name: "_additional",
-		Fields: []graphql.Field{
-			{Name: "certainty"},
-		},
+		Name:   "_additional",
+		Fields: additionalFields,
 	})
+
 	return fields
 }


### PR DESCRIPTION
Via `queryAttrs` you can specify fields to be returned with a similarity search. In Weaviate you can retrieve [additional properties](https://weaviate.io/developers/weaviate/api/graphql/additional-properties#available-additional-properties) via the `_additional` field. With the current setup it is not possible to add additional fields (like the id) to the the `_additional` field due to the [manual mapping](https://github.com/tmc/langchaingo/blob/main/vectorstores/weaviate/weaviate.go#L276-L281) in 'createFields' function.

This adds a new `WithAdditionalFields` optional to give the user control over which additional fields to return.

### PR Checklist

- [X] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [X] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [X] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [X] Describes the source of new concepts.
- [X] References existing implementations as appropriate.
- [X] Contains test coverage for new functions.
- [X] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
