### PR TITLE
Deprecate the LLM interface

### DIFF
--- a/agents/conversational.go
+++ b/agents/conversational.go
@@ -40,7 +40,7 @@ type ConversationalAgent struct {
 
 var _ Agent = (*ConversationalAgent)(nil)
 
-func NewConversationalAgent(llm llms.LLM, tools []tools.Tool, opts ...CreationOption) *ConversationalAgent {
+func NewConversationalAgent(llm llms.Model, tools []tools.Tool, opts ...CreationOption) *ConversationalAgent {
 	options := conversationalDefaultOptions()
 	for _, opt := range opts {
 		opt(&options)

--- a/agents/initialize.go
+++ b/agents/initialize.go
@@ -23,7 +23,7 @@ const (
 // model, tools, agent type, and options. It returns an Executor or an error
 // if there is any issues during the creation process.
 func Initialize(
-	llm llms.LLM,
+	llm llms.Model,
 	tools []tools.Tool,
 	agentType AgentType,
 	opts ...CreationOption,

--- a/agents/mrkl.go
+++ b/agents/mrkl.go
@@ -41,7 +41,7 @@ var _ Agent = (*OneShotZeroAgent)(nil)
 // NewOneShotAgent creates a new OneShotZeroAgent with the given LLM model, tools,
 // and options. It returns a pointer to the created agent. The opts parameter
 // represents the options for the agent.
-func NewOneShotAgent(llm llms.LLM, tools []tools.Tool, opts ...CreationOption) *OneShotZeroAgent {
+func NewOneShotAgent(llm llms.Model, tools []tools.Tool, opts ...CreationOption) *OneShotZeroAgent {
 	options := mrklDefaultOptions()
 	for _, opt := range opts {
 		opt(&options)

--- a/chains/api.go
+++ b/chains/api.go
@@ -37,9 +37,9 @@ type APIChain struct {
 
 // NewAPIChain creates a new APIChain object.
 //
-// It takes a LanguageModel(llm) and an HTTPRequest(request) as parameters.
+// It takes a language model (llm) and an HTTPRequest (request) as parameters.
 // It returns an APIChain object.
-func NewAPIChain(llm llms.LLM, request HTTPRequest) APIChain {
+func NewAPIChain(llm llms.Model, request HTTPRequest) APIChain {
 	reqPrompt := prompts.NewPromptTemplate(_llmAPIURLPrompt, []string{"api_docs", "input"})
 	reqChain := NewLLMChain(llm, reqPrompt)
 

--- a/chains/chains_test.go
+++ b/chains/chains_test.go
@@ -58,7 +58,7 @@ func (l *testLanguageModel) GenerateContent(_ context.Context, _ []llms.MessageC
 	panic("not implemented")
 }
 
-var _ llms.LLM = &testLanguageModel{}
+var _ llms.Model = &testLanguageModel{}
 
 func TestApply(t *testing.T) {
 	t.Parallel()

--- a/chains/constitution/constitutional.go
+++ b/chains/constitution/constitutional.go
@@ -37,7 +37,7 @@ type Constitutional struct {
 	critiqueChain            chains.LLMChain
 	revisionChain            chains.LLMChain
 	constitutionalPrinciples []ConstitutionalPrinciple
-	llm                      llms.LLM
+	llm                      llms.Model
 	returnIntermediateSteps  bool
 	memory                   schema.Memory
 }
@@ -58,7 +58,7 @@ func NewConstitutionalPrinciple(critique, revision string, names ...string) Cons
 }
 
 // NewConstitutional creates a new Constitutional chain.
-func NewConstitutional(llm llms.LLM, chain chains.LLMChain,
+func NewConstitutional(llm llms.Model, chain chains.LLMChain,
 	constitutionalPrinciples []ConstitutionalPrinciple, options map[string]*prompts.FewShotPrompt,
 ) *Constitutional {
 	CritiquePrompt, RevisionPrompt := initCritiqueRevision()

--- a/chains/constitutional.go
+++ b/chains/constitutional.go
@@ -375,7 +375,7 @@ type Constitutional struct {
 	critiqueChain            LLMChain
 	revisionChain            LLMChain
 	constitutionalPrinciples []ConstitutionalPrinciple
-	llm                      llms.LLM
+	llm                      llms.Model
 	returnIntermediateSteps  bool
 	memory                   schema.Memory
 }
@@ -557,7 +557,7 @@ func NewConstitutionalPrinciple(critique, revision string, names ...string) Cons
 }
 
 // NewConstitutional creates a new Constitutional chain.
-func NewConstitutional(llm llms.LLM, chain LLMChain, constitutionalPrinciples []ConstitutionalPrinciple,
+func NewConstitutional(llm llms.Model, chain LLMChain, constitutionalPrinciples []ConstitutionalPrinciple,
 	options map[string]*prompts.FewShotPrompt,
 ) *Constitutional {
 	CritiquePrompt, RevisionPrompt := initCritiqueRevision()

--- a/chains/conversation.go
+++ b/chains/conversation.go
@@ -15,7 +15,7 @@ Current conversation:
 Human: {{.input}}
 AI:`
 
-func NewConversation(llm llms.LLM, memory schema.Memory) LLMChain {
+func NewConversation(llm llms.Model, memory schema.Memory) LLMChain {
 	return LLMChain{
 		Prompt: prompts.NewPromptTemplate(
 			_conversationTemplate,

--- a/chains/conversational_retrieval_qa.go
+++ b/chains/conversational_retrieval_qa.go
@@ -74,7 +74,7 @@ func NewConversationalRetrievalQA(
 }
 
 func NewConversationalRetrievalQAFromLLM(
-	llm llms.LLM,
+	llm llms.Model,
 	retriever schema.Retriever,
 	memory schema.Memory,
 ) ConversationalRetrievalQA {

--- a/chains/llm.go
+++ b/chains/llm.go
@@ -15,7 +15,7 @@ const _llmChainDefaultOutputKey = "text"
 
 type LLMChain struct {
 	Prompt           prompts.FormatPrompter
-	LLM              llms.LLM
+	LLM              llms.Model
 	Memory           schema.Memory
 	CallbacksHandler callbacks.Handler
 	OutputParser     schema.OutputParser[any]
@@ -29,7 +29,7 @@ var (
 )
 
 // NewLLMChain creates a new LLMChain with an LLM and a prompt.
-func NewLLMChain(llm llms.LLM, prompt prompts.FormatPrompter, opts ...ChainCallOption) *LLMChain {
+func NewLLMChain(llm llms.Model, prompt prompts.FormatPrompter, opts ...ChainCallOption) *LLMChain {
 	opt := &chainCallOption{}
 	for _, o := range opts {
 		o(opt)

--- a/chains/llm_math.go
+++ b/chains/llm_math.go
@@ -25,7 +25,7 @@ type LLMMathChain struct {
 
 var _ Chain = LLMMathChain{}
 
-func NewLLMMathChain(llm llms.LLM) LLMMathChain {
+func NewLLMMathChain(llm llms.Model) LLMMathChain {
 	p := prompts.NewPromptTemplate(_llmMathPrompt, []string{"question"})
 	c := NewLLMChain(llm, p)
 	return LLMMathChain{

--- a/chains/prompt_selector.go
+++ b/chains/prompt_selector.go
@@ -8,7 +8,7 @@ import (
 // PromptSelector is the interface for selecting a formatter depending on the
 // LLM given.
 type PromptSelector interface {
-	GetPrompt(llm llms.LLM) prompts.PromptTemplate
+	GetPrompt(llm llms.Model) prompts.PromptTemplate
 }
 
 // ConditionalPromptSelector is a formatter selector that selects a prompt
@@ -16,14 +16,14 @@ type PromptSelector interface {
 type ConditionalPromptSelector struct {
 	DefaultPrompt prompts.PromptTemplate
 	Conditionals  []struct {
-		Condition func(llms.LLM) bool
+		Condition func(llms.Model) bool
 		Prompt    prompts.PromptTemplate
 	}
 }
 
 var _ PromptSelector = ConditionalPromptSelector{}
 
-func (s ConditionalPromptSelector) GetPrompt(llm llms.LLM) prompts.PromptTemplate {
+func (s ConditionalPromptSelector) GetPrompt(llm llms.Model) prompts.PromptTemplate {
 	for _, conditional := range s.Conditionals {
 		if conditional.Condition(llm) {
 			return conditional.Prompt

--- a/chains/question_answering.go
+++ b/chains/question_answering.go
@@ -92,7 +92,7 @@ Follow Up Input: {{.question}}
 Standalone question:`
 
 // LoadCondenseQuestionGenerator chain is used to generate a new question for the sake of retrieval.
-func LoadCondenseQuestionGenerator(llm llms.LLM) *LLMChain {
+func LoadCondenseQuestionGenerator(llm llms.Model) *LLMChain {
 	condenseQuestionPromptTemplate := prompts.NewPromptTemplate(
 		_defaultCondenseQuestionTemplate,
 		[]string{"chat_history", "question"},
@@ -101,7 +101,7 @@ func LoadCondenseQuestionGenerator(llm llms.LLM) *LLMChain {
 }
 
 // LoadStuffQA loads a StuffDocuments chain with default prompts for the llm chain.
-func LoadStuffQA(llm llms.LLM) StuffDocuments {
+func LoadStuffQA(llm llms.Model) StuffDocuments {
 	defaultQAPromptTemplate := prompts.NewPromptTemplate(
 		_defaultStuffQATemplate,
 		[]string{"context", "question"},
@@ -118,7 +118,7 @@ func LoadStuffQA(llm llms.LLM) StuffDocuments {
 
 // LoadRefineQA loads a refine documents chain for question answering. Inputs are
 // "question" and "input_documents".
-func LoadRefineQA(llm llms.LLM) RefineDocuments {
+func LoadRefineQA(llm llms.Model) RefineDocuments {
 	questionPrompt := prompts.NewPromptTemplate(
 		_defaultStuffQATemplate,
 		[]string{"context", "question"},
@@ -136,7 +136,7 @@ func LoadRefineQA(llm llms.LLM) RefineDocuments {
 
 // LoadMapReduceQA loads a refine documents chain for question answering. Inputs are
 // "question" and "input_documents".
-func LoadMapReduceQA(llm llms.LLM) MapReduceDocuments {
+func LoadMapReduceQA(llm llms.Model) MapReduceDocuments {
 	getInfoPrompt := prompts.NewPromptTemplate(
 		_defaultMapReduceGetInformationQATemplate,
 		[]string{"question", "context"},
@@ -156,7 +156,7 @@ func LoadMapReduceQA(llm llms.LLM) MapReduceDocuments {
 
 // LoadMapRerankQA loads a map rerank documents chain for question answering. Inputs are
 // "question" and "input_documents".
-func LoadMapRerankQA(llm llms.LLM) MapRerankDocuments {
+func LoadMapRerankQA(llm llms.Model) MapRerankDocuments {
 	mapRerankPrompt := prompts.NewPromptTemplate(
 		_defaultMapRerankTemplate,
 		[]string{"context", "question"},

--- a/chains/retrieval_qa.go
+++ b/chains/retrieval_qa.go
@@ -50,7 +50,7 @@ func NewRetrievalQA(combineDocumentsChain Chain, retriever schema.Retriever) Ret
 
 // NewRetrievalQAFromLLM loads a question answering combine documents chain
 // from the llm and creates a new retrievalQA chain.
-func NewRetrievalQAFromLLM(llm llms.LLM, retriever schema.Retriever) RetrievalQA {
+func NewRetrievalQAFromLLM(llm llms.Model, retriever schema.Retriever) RetrievalQA {
 	return NewRetrievalQA(
 		LoadStuffQA(llm),
 		retriever,

--- a/chains/sql_database.go
+++ b/chains/sql_database.go
@@ -50,7 +50,7 @@ type SQLDatabaseChain struct {
 
 // NewSQLDatabaseChain creates a new SQLDatabaseChain.
 // The topK is the max number of results to return.
-func NewSQLDatabaseChain(llm llms.LLM, topK int, database *sqldatabase.SQLDatabase) *SQLDatabaseChain {
+func NewSQLDatabaseChain(llm llms.Model, topK int, database *sqldatabase.SQLDatabase) *SQLDatabaseChain {
 	p := prompts.NewPromptTemplate(_defaultSQLTemplate+_defaultSQLSuffix,
 		[]string{"dialect", "top_k", "table_info", "input"})
 	c := NewLLMChain(llm, p)

--- a/chains/summarization.go
+++ b/chains/summarization.go
@@ -28,7 +28,7 @@ REFINED SUMMARY:`
 
 // LoadStuffSummarization loads a summarization chain that stuffs all documents
 // given into the prompt.
-func LoadStuffSummarization(llm llms.LLM) StuffDocuments {
+func LoadStuffSummarization(llm llms.Model) StuffDocuments {
 	llmChain := NewLLMChain(llm, prompts.NewPromptTemplate(
 		_stuffSummarizationTemplate, []string{"context"},
 	))
@@ -38,7 +38,7 @@ func LoadStuffSummarization(llm llms.LLM) StuffDocuments {
 
 // LoadRefineSummarization loads a refine documents chain for summarization of
 // documents.
-func LoadRefineSummarization(llm llms.LLM) RefineDocuments {
+func LoadRefineSummarization(llm llms.Model) RefineDocuments {
 	llmChain := NewLLMChain(llm, prompts.NewPromptTemplate(
 		_stuffSummarizationTemplate, []string{"context"},
 	))
@@ -51,7 +51,7 @@ func LoadRefineSummarization(llm llms.LLM) RefineDocuments {
 
 // LoadMapReduceSummarization loads a map reduce documents chain for
 // summarization of documents.
-func LoadMapReduceSummarization(llm llms.LLM) MapReduceDocuments {
+func LoadMapReduceSummarization(llm llms.Model) MapReduceDocuments {
 	mapChain := NewLLMChain(llm, prompts.NewPromptTemplate(
 		_stuffSummarizationTemplate, []string{"context"},
 	))

--- a/llms/anthropic/anthropicllm.go
+++ b/llms/anthropic/anthropicllm.go
@@ -22,7 +22,7 @@ type LLM struct {
 	client           *anthropicclient.Client
 }
 
-var _ llms.LLM = (*LLM)(nil)
+var _ llms.Model = (*LLM)(nil)
 
 // New returns a new Anthropic LLM.
 func New(opts ...Option) (*LLM, error) {

--- a/llms/cohere/coherellm.go
+++ b/llms/cohere/coherellm.go
@@ -22,7 +22,7 @@ type LLM struct {
 	client           *cohereclient.Client
 }
 
-var _ llms.LLM = (*LLM)(nil)
+var _ llms.Model = (*LLM)(nil)
 
 func (o *LLM) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
 	return llms.CallLLM(ctx, o, prompt, options...)

--- a/llms/ernie/erniellm.go
+++ b/llms/ernie/erniellm.go
@@ -22,7 +22,7 @@ type LLM struct {
 	CallbacksHandler callbacks.Handler
 }
 
-var _ llms.LLM = (*LLM)(nil)
+var _ llms.Model = (*LLM)(nil)
 
 // New returns a new Anthropic LLM.
 func New(opts ...Option) (*LLM, error) {
@@ -59,7 +59,6 @@ doc: https://cloud.baidu.com/doc/WENXINWORKSHOP/s/flfmc9do2`, ernieclient.ErrNot
 		ernieclient.WithAKSK(opts.apiKey, opts.secretKey))
 }
 
-// Call implements llms.LLM.
 func (o *LLM) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
 	return llms.CallLLM(ctx, o, prompt, options...)
 }

--- a/llms/huggingface/huggingfacellm.go
+++ b/llms/huggingface/huggingfacellm.go
@@ -21,7 +21,7 @@ type LLM struct {
 	client           *huggingfaceclient.Client
 }
 
-var _ llms.LLM = (*LLM)(nil)
+var _ llms.Model = (*LLM)(nil)
 
 // Call implements the LLM interface.
 func (o *LLM) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {

--- a/llms/llms.go
+++ b/llms/llms.go
@@ -9,7 +9,7 @@ import (
 
 // LLM is an alias for model, for backwards compatibility.
 //
-// This alias may be removed in the future; please use Model
+// Deprecated: This alias may be removed in the future; please use Model
 // instead.
 type LLM = Model
 

--- a/llms/local/localllm.go
+++ b/llms/local/localllm.go
@@ -26,10 +26,7 @@ type LLM struct {
 	client           *localclient.Client
 }
 
-// _ ensures that LLM implements the llms.LLM and language model interface.
-var (
-	_ llms.LLM = (*LLM)(nil)
-)
+var _ llms.Model = (*LLM)(nil)
 
 // Call calls the local LLM binary with the given prompt.
 func (o *LLM) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {

--- a/llms/ollama/ollamallm.go
+++ b/llms/ollama/ollamallm.go
@@ -22,7 +22,7 @@ type LLM struct {
 	options          options
 }
 
-var _ llms.LLM = (*LLM)(nil)
+var _ llms.Model = (*LLM)(nil)
 
 // New creates a new ollama LLM implementation.
 func New(opts ...Option) (*LLM, error) {

--- a/llms/openai/multicontent_test.go
+++ b/llms/openai/multicontent_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tmc/langchaingo/schema"
 )
 
-func newTestClient(t *testing.T, opts ...Option) *LLM {
+func newTestClient(t *testing.T, opts ...Option) llms.Model {
 	t.Helper()
 	if openaiKey := os.Getenv("OPENAI_API_KEY"); openaiKey == "" {
 		t.Skip("OPENAI_API_KEY not set")

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -24,7 +24,7 @@ const (
 	RoleFunction  = "function"
 )
 
-var _ llms.LLM = (*LLM)(nil)
+var _ llms.Model = (*LLM)(nil)
 
 // New returns a new OpenAI LLM.
 func New(opts ...Option) (*LLM, error) {

--- a/llms/options.go
+++ b/llms/options.go
@@ -5,7 +5,7 @@ import "context"
 // CallOption is a function that configures a CallOptions.
 type CallOption func(*CallOptions)
 
-// CallOptions is a set of options for LLM.Call.
+// CallOptions is a set of options for calling models.
 type CallOptions struct {
 	// Model is the model to use.
 	Model string `json:"model"`
@@ -66,42 +66,43 @@ const (
 	FunctionCallBehaviorAuto FunctionCallBehavior = "auto"
 )
 
-// WithModel is an option for LLM.Call.
+// WithModel specifies which model name to use.
 func WithModel(model string) CallOption {
 	return func(o *CallOptions) {
 		o.Model = model
 	}
 }
 
-// WithMaxTokens is an option for LLM.Call.
+// WithMaxTokens specifies the max number of tokens to generate.
 func WithMaxTokens(maxTokens int) CallOption {
 	return func(o *CallOptions) {
 		o.MaxTokens = maxTokens
 	}
 }
 
-// WithTemperature is an option for LLM.Call.
+// WithTemperature specifies the model temperature, a hyperparameter that
+// regulates the randomness, or creativity, of the AI's responses.
 func WithTemperature(temperature float64) CallOption {
 	return func(o *CallOptions) {
 		o.Temperature = temperature
 	}
 }
 
-// WithStopWords is an option for LLM.Call.
+// WithStopWords specifies a list of words to stop generation on.
 func WithStopWords(stopWords []string) CallOption {
 	return func(o *CallOptions) {
 		o.StopWords = stopWords
 	}
 }
 
-// WithOptions is an option for LLM.Call.
+// WithOptions specifies options.
 func WithOptions(options CallOptions) CallOption {
 	return func(o *CallOptions) {
 		(*o) = options
 	}
 }
 
-// WithStreamingFunc is an option for LLM.Call that allows streaming responses.
+// WithStreamingFunc specifies the streaming function to use.
 func WithStreamingFunc(streamingFunc func(ctx context.Context, chunk []byte) error) CallOption {
 	return func(o *CallOptions) {
 		o.StreamingFunc = streamingFunc

--- a/llms/vertexai/vertexai_palm_llm.go
+++ b/llms/vertexai/vertexai_palm_llm.go
@@ -21,7 +21,7 @@ type LLM struct {
 	client           *vertexaiclient.PaLMClient
 }
 
-var _ llms.LLM = (*LLM)(nil)
+var _ llms.Model = (*LLM)(nil)
 
 // Call requests a completion for the given prompt.
 func (o *LLM) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {

--- a/memory/token_buffer.go
+++ b/memory/token_buffer.go
@@ -10,7 +10,7 @@ import (
 // ConversationTokenBuffer for storing conversation memory.
 type ConversationTokenBuffer struct {
 	ConversationBuffer
-	LLM           llms.LLM
+	LLM           llms.Model
 	MaxTokenLimit int
 }
 
@@ -19,7 +19,7 @@ var _ schema.Memory = &ConversationTokenBuffer{}
 
 // NewConversationTokenBuffer is a function for crating a new token buffer memory.
 func NewConversationTokenBuffer(
-	llm llms.LLM,
+	llm llms.Model,
 	maxTokenLimit int,
 	options ...ConversationBufferOption,
 ) *ConversationTokenBuffer {


### PR DESCRIPTION
It's just an alias for Model now

Deprecating it means lint will complain when someone uses it directly. 

This completes and fixes #465 
