### PR TITLE
weaviate: honor vectorstores.WithEmbedder

### DIFF
--- a/embeddings/embedding.go
+++ b/embeddings/embedding.go
@@ -35,6 +35,15 @@ type EmbedderClient interface {
 	CreateEmbedding(ctx context.Context, texts []string) ([][]float32, error)
 }
 
+// EmbedderClientFunc is an adapter to allow the use of ordinary functions as Embedder Clients. If
+// `f` is a function with the appropriate signature, `EmbedderClientFunc(f)` is an `EmbedderClient`
+// that calls `f`.
+type EmbedderClientFunc func(ctx context.Context, texts []string) ([][]float32, error)
+
+func (e EmbedderClientFunc) CreateEmbedding(ctx context.Context, texts []string) ([][]float32, error) {
+	return e(ctx, texts)
+}
+
 type EmbedderImpl struct {
 	client EmbedderClient
 

--- a/vectorstores/weaviate/weaviate.go
+++ b/vectorstores/weaviate/weaviate.go
@@ -101,7 +101,7 @@ func (s Store) AddDocuments(ctx context.Context,
 		texts = append(texts, doc.PageContent)
 	}
 
-	vectors, err := s.embedder.EmbedDocuments(ctx, texts)
+	vectors, err := opts.Embedder.EmbedDocuments(ctx, texts)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ func (s Store) SimilaritySearch(
 		return nil, err
 	}
 
-	vector, err := s.embedder.EmbedQuery(ctx, query)
+	vector, err := opts.Embedder.EmbedQuery(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +245,11 @@ func (s Store) getFilters(opts vectorstores.Options) any {
 }
 
 func (s Store) getOptions(options ...vectorstores.Option) vectorstores.Options {
-	opts := vectorstores.Options{}
+	// use the embedder from the store by default, this can be overwritten by passing
+	// an `vectorstores.WithEmbedder` option.
+	opts := vectorstores.Options{
+		Embedder: s.embedder,
+	}
 	for _, opt := range options {
 		opt(&opts)
 	}

--- a/vectorstores/weaviate/weaviate_test.go
+++ b/vectorstores/weaviate/weaviate_test.go
@@ -630,3 +630,58 @@ func TestWeaviateStoreAdditionalFieldsAdded(t *testing.T) {
 	require.NotEmpty(t, additional["certainty"], "expected the certainty to be present")
 	require.NotEmpty(t, additional["distance"], "expected the distance to be present")
 }
+
+// TestWeaviateWithOptionEmbedder ensures that the embedder provided as an option to either
+// `AddDocuments` or `SimilaritySearch` takes precedence over the one provided when creating
+// the `Store`.
+func TestWeaviateWithOptionEmbedder(t *testing.T) {
+	t.Parallel()
+
+	scheme, host := getValues(t)
+
+	llm, err := openai.New()
+	require.NoError(t, err)
+
+	notme, err := embeddings.NewEmbedder(
+		embeddings.EmbedderClientFunc(func(context.Context, []string) ([][]float32, error) {
+			require.FailNow(t, "wrong embedder was called")
+			return nil, nil
+		}),
+	)
+	require.NoError(t, err)
+
+	butme, err := embeddings.NewEmbedder(
+		embeddings.EmbedderClientFunc(func(ctx context.Context, texts []string) ([][]float32, error) {
+			return llm.CreateEmbedding(ctx, texts)
+		}),
+	)
+	require.NoError(t, err)
+
+	store, err := New(
+		WithScheme(scheme),
+		WithHost(host),
+		WithEmbedder(notme),
+		WithNameSpace(uuid.New().String()),
+		WithIndexName(randomizedCamelCaseClass()),
+		WithQueryAttrs([]string{"location"}),
+	)
+	require.NoError(t, err)
+
+	err = createTestClass(context.Background(), store)
+	require.NoError(t, err)
+
+	_, err = store.AddDocuments(context.Background(), []schema.Document{
+		{PageContent: "tokyo", Metadata: map[string]any{
+			"country": "japan",
+		}},
+		{PageContent: "potato"},
+	}, vectorstores.WithEmbedder(butme))
+	require.NoError(t, err)
+
+	docs, err := store.SimilaritySearch(context.Background(), "japan", 1,
+		vectorstores.WithEmbedder(butme))
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.Equal(t, "tokyo", docs[0].PageContent)
+	require.Equal(t, "japan", docs[0].Metadata["country"])
+}


### PR DESCRIPTION
### embeddings: add adapter for EmbedderClient interface

An adapter for the EmbedderClient interface has been added. This allows
the use of ordinary functions as Embedder Clients. This change provides
flexibility in implementing the EmbedderClient interface, as it allows
any function with the appropriate signature to be used as an
EmbedderClient.

### weaviate: allow embedder override in vectorstores options

The changes allow the embedder to be overridden in the vectorstores options.
This is done by changing the embedder calls in `AddDocuments` and `SimilaritySearch`
functions to use the embedder from the options instead of the store.

The default embedder is still the one from the store, but it can be overwritten
by passing a `vectorstores.WithEmbedder` option.

A new test case 'TestWeaviateWithOptionEmbedder' is added to ensure that the
embedder provided as an option to either `AddDocuments` or `SimilaritySearch` takes
precedence over the one provided when creating the Store.

This change provides more flexibility in choosing the embedder at runtime,
which can be useful in scenarios where the same store is used with
different embedders.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
