### PR TITLE
weaviate: add option to deduplicate documents while adding

### DIFF
--- a/vectorstores/options.go
+++ b/vectorstores/options.go
@@ -1,6 +1,11 @@
 package vectorstores
 
-import "github.com/tmc/langchaingo/embeddings"
+import (
+	"context"
+
+	"github.com/tmc/langchaingo/embeddings"
+	"github.com/tmc/langchaingo/schema"
+)
 
 // Option is a function that configures an Options.
 type Option func(*Options)
@@ -11,6 +16,7 @@ type Options struct {
 	ScoreThreshold float32
 	Filters        any
 	Embedder       embeddings.Embedder
+	Deduplicater   func(context.Context, schema.Document) bool
 }
 
 // WithNameSpace returns an Option for setting the name space.
@@ -42,5 +48,14 @@ func WithFilters(filters any) Option {
 func WithEmbedder(embedder embeddings.Embedder) Option {
 	return func(o *Options) {
 		o.Embedder = embedder
+	}
+}
+
+// WithDeduplicater returns an Option for setting the deduplicater that could be used
+// when adding documents. This is useful to prevent wasting time on creating an embedding
+// when one already exists.
+func WithDeduplicater(fn func(ctx context.Context, doc schema.Document) bool) Option {
+	return func(o *Options) {
+		o.Deduplicater = fn
 	}
 }

--- a/vectorstores/weaviate/weaviate_test.go
+++ b/vectorstores/weaviate/weaviate_test.go
@@ -196,6 +196,49 @@ func TestMetadataSearch(t *testing.T) {
 	require.Equal(t, "city", docs[0].Metadata["type"])
 }
 
+func TestDeduplicater(t *testing.T) {
+	t.Parallel()
+
+	scheme, host := getValues(t)
+	llm, err := openai.New()
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	store, err := New(
+		WithScheme(scheme),
+		WithHost(host),
+		WithEmbedder(e),
+		WithNameSpace(uuid.New().String()),
+		WithIndexName(randomizedCamelCaseClass()),
+		WithQueryAttrs([]string{"type"}),
+	)
+	require.NoError(t, err)
+
+	err = createTestClass(context.Background(), store)
+	require.NoError(t, err)
+
+	_, err = store.AddDocuments(context.Background(), []schema.Document{
+		{PageContent: "tokyo", Metadata: map[string]any{
+			"type": "city",
+		}},
+		{PageContent: "potato", Metadata: map[string]any{
+			"type": "vegetable",
+		}},
+	}, vectorstores.WithDeduplicater(
+		func(ctx context.Context, doc schema.Document) bool {
+			return doc.PageContent == "tokyo"
+		},
+	))
+	require.NoError(t, err)
+
+	docs, err := store.MetadataSearch(context.Background(), 2)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.Equal(t, "potato", docs[0].PageContent)
+	require.Equal(t, "vegetable", docs[0].Metadata["type"])
+}
+
 func TestSimilaritySearchWithInvalidScoreThreshold(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### weaviate: add metadata search function in weaviate store

A new function, MetadataSearch, has been added to the Weaviate store. This
function allows for searching Weaviate based on metadata rather than on
similarity. The function takes a context, the number of documents to return,
and a set of options as parameters. It uses these to create a GraphQL query
which is then sent to the Weaviate server. The response is parsed and returned
as a slice of schema.Document.

In addition to the function itself, a test, TestMetadataSearch, has been added
to verify the functionality of the new MetadataSearch function. The test
creates a new Weaviate store, adds some documents to it, and then uses the
MetadataSearch function to retrieve documents based on their metadata. The
results are then checked to ensure they match the expected output.

The addition of this function allows for more flexible querying of Weaviate,
making it easier to find specific documents based on their metadata.


### weaviate: add deduplication functionality to weaviate

The changes introduce a deduplication function to the vectorstores
options. This function is used when adding documents to the store,
allowing the system to filter out duplicate documents before they
are added. This is particularly useful to prevent wasting time on
creating an embedding when one already exists.

The changes also include a test case for the new deduplication
functionality, ensuring that it works as expected. The test case
adds two documents to the store, one of which is a duplicate. The
test verifies that only the unique document is added to the store.

### PR Checklist

- [X] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [X] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [X] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [X] Describes the source of new concepts.
- [X] References existing implementations as appropriate.
- [X] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
