### PR TITLE
bug fix: openai_functions_agent not compatible with the new llms.Model interface

### DIFF
--- a/agents/executor_test.go
+++ b/agents/executor_test.go
@@ -111,7 +111,7 @@ func TestExecutorWithOpenAIFunctionAgent(t *testing.T) {
 		t.Skip("SERPAPI_API_KEY not set")
 	}
 
-	llm, err := openai.NewChat()
+	llm, err := openai.New()
 	require.NoError(t, err)
 
 	searchTool, err := serpapi.New()

--- a/llms/llms.go
+++ b/llms/llms.go
@@ -48,14 +48,3 @@ func CallLLM(ctx context.Context, llm Model, prompt string, options ...CallOptio
 	c1 := choices[0]
 	return c1.Content, nil
 }
-
-func GenerateChatPrompt(ctx context.Context, l ChatLLM, promptValues []schema.PromptValue, options ...CallOption) (LLMResult, error) { //nolint:lll
-	messages := make([][]schema.ChatMessage, 0, len(promptValues))
-	for _, promptValue := range promptValues {
-		messages = append(messages, promptValue.Messages())
-	}
-	generations, err := l.Generate(ctx, messages, options...)
-	return LLMResult{
-		Generations: [][]*Generation{generations},
-	}, err
-}


### PR DESCRIPTION
sync the newest main branch today find that openai_functions_agent.go still use old llms.Chat Generate function and can't compile

### PR Checklist

- [x]  Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x]  Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x]  Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x]  Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x]  Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x]  Describes the source of new concepts.
- [x]  References existing implementations as appropriate.
- [x]  Contains test coverage for new functions.
- [x]  Passes all [`golangci-lint`](https://golangci-lint.run/) checks.