### PR TITLE
huggingface: allows to set custom inference endpoint

### DIFF
--- a/llms/huggingface/huggingfacellm.go
+++ b/llms/huggingface/huggingfacellm.go
@@ -76,6 +76,7 @@ func New(opts ...Option) (*LLM, error) {
 	options := &options{
 		token: os.Getenv(tokenEnvVarName),
 		model: defaultModel,
+		url:   defaultURL,
 	}
 
 	for _, opt := range opts {
@@ -86,7 +87,7 @@ func New(opts ...Option) (*LLM, error) {
 		return nil, ErrMissingToken
 	}
 
-	c, err := huggingfaceclient.New(options.token, options.model)
+	c, err := huggingfaceclient.New(options.token, options.model, options.url)
 	if err != nil {
 		return nil, err
 	}

--- a/llms/huggingface/huggingfacellm_option.go
+++ b/llms/huggingface/huggingfacellm_option.go
@@ -3,11 +3,13 @@ package huggingface
 const (
 	tokenEnvVarName = "HUGGINGFACEHUB_API_TOKEN"
 	defaultModel    = "gpt2"
+	defaultURL      = "https://api-inference.huggingface.co"
 )
 
 type options struct {
 	token string
 	model string
+	url   string
 }
 
 type Option func(*options)
@@ -25,5 +27,13 @@ func WithToken(token string) Option {
 func WithModel(model string) Option {
 	return func(opts *options) {
 		opts.model = model
+	}
+}
+
+// WithUrl passes the HuggingFace url to the client. If not set, then will be
+// used default url.
+func WithUrl(url string) Option {
+	return func(opts *options) {
+		opts.url = url
 	}
 }

--- a/llms/huggingface/huggingfacellm_option.go
+++ b/llms/huggingface/huggingfacellm_option.go
@@ -30,9 +30,9 @@ func WithModel(model string) Option {
 	}
 }
 
-// WithUrl passes the HuggingFace url to the client. If not set, then will be
+// WithURL passes the HuggingFace url to the client. If not set, then will be
 // used default url.
-func WithUrl(url string) Option {
+func WithURL(url string) Option {
 	return func(opts *options) {
 		opts.url = url
 	}

--- a/llms/huggingface/internal/huggingfaceclient/huggingfaceclient.go
+++ b/llms/huggingface/internal/huggingfaceclient/huggingfaceclient.go
@@ -11,22 +11,20 @@ var (
 	ErrEmptyResponse = errors.New("empty response")
 )
 
-const huggingfaceAPIBaseURL = "https://api-inference.huggingface.co"
-
 type Client struct {
 	Token string
 	Model string
 	url   string
 }
 
-func New(token string, model string) (*Client, error) {
+func New(token, model, url string) (*Client, error) {
 	if token == "" {
 		return nil, ErrInvalidToken
 	}
 	return &Client{
 		Token: token,
 		Model: model,
-		url:   huggingfaceAPIBaseURL,
+		url:   url,
 	}, nil
 }
 

--- a/llms/huggingface/internal/huggingfaceclient/huggingfaceclient_test.go
+++ b/llms/huggingface/internal/huggingfaceclient/huggingfaceclient_test.go
@@ -38,10 +38,8 @@ func TestRunInference(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			client, err := New("token", "model")
+			client, err := New("token", "model", server.URL)
 			require.NoError(t, err)
-			// Override the URL to point to our mock server.
-			client.url = server.URL
 
 			resp, err := client.RunInference(context.TODO(), tc.req)
 			assert.Equal(t, tc.expected, resp)


### PR DESCRIPTION
When using huggingface with bigger models we need to be able to set a custom inference endpoint. This PR allows to set this option.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
