### PR TITLE
vectorstores: Added an option to PGVector to set the collection metadata

### DIFF
--- a/vectorstores/pgvector/options.go
+++ b/vectorstores/pgvector/options.go
@@ -74,6 +74,12 @@ func WithConn(conn *pgx.Conn) Option {
 	}
 }
 
+func WithCollectionMetadata(metadata map[string]any) Option {
+	return func(p *Store) {
+		p.collectionMetadata = metadata
+	}
+}
+
 func applyClientOptions(opts ...Option) (Store, error) {
 	o := &Store{
 		collectionName:      DefaultCollectionName,

--- a/vectorstores/pgvector/pgvector.go
+++ b/vectorstores/pgvector/pgvector.go
@@ -161,7 +161,7 @@ func (s Store) createEmbeddingTableIfNotExists(ctx context.Context) error {
 	cmetadata json,
 	custom_id varchar,
 	"uuid" uuid NOT NULL,
-	CONSTRAINT langchain_pg_embedding_collection_id_fkey 
+	CONSTRAINT langchain_pg_embedding_collection_id_fkey
 	FOREIGN KEY (collection_id) REFERENCES %s (uuid) ON DELETE CASCADE,
 PRIMARY KEY (uuid))`, s.embeddingTableName, s.collectionTableName)
 	if _, err = tx.Exec(ctx, sql); err != nil {
@@ -260,7 +260,7 @@ FROM (
 	FROM
 		%s
 		JOIN %s ON %s.collection_id=%s.uuid WHERE %s.name='%s') AS data
-WHERE %s 
+WHERE %s
 ORDER BY
 	data.distance
 LIMIT $2`, s.embeddingTableName,

--- a/vectorstores/pgvector/pgvector.go
+++ b/vectorstores/pgvector/pgvector.go
@@ -304,7 +304,8 @@ func (s Store) RemoveCollection(ctx context.Context) error {
 
 func (s *Store) createOrGetCollection(ctx context.Context) error {
 	sql := fmt.Sprintf(`INSERT INTO %s (uuid, name, cmetadata)
-		VALUES($1, $2, $3) ON CONFLICT DO NOTHING`, s.collectionTableName)
+		VALUES($1, $2, $3) ON CONFLICT (name) DO
+		UPDATE SET cmetadata = $3`, s.collectionTableName)
 	if _, err := s.conn.Exec(ctx, sql, uuid.New().String(), s.collectionName, s.collectionMetadata); err != nil {
 		return err
 	}


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

-----

Added an option to PGVector to set the collection metadata

There was no way to set the collection metadata even though the struct had a field for it.

Therefor, I added an option so you can specify the metadata. If the collection already exists, the metadata gets updated.

Fixes #556