### PR TITLE
embeddings: fix variable typo in huggingface_test

### DIFF
--- a/embeddings/huggingface/huggingface_test.go
+++ b/embeddings/huggingface/huggingface_test.go
@@ -12,7 +12,7 @@ import (
 func TestHuggingfaceEmbeddings(t *testing.T) {
 	t.Parallel()
 
-	if openaiKey := os.Getenv("HUGGINGFACEHUB_API_TOKEN"); openaiKey == "" {
+	if huggingfaceKey := os.Getenv("HUGGINGFACEHUB_API_TOKEN"); huggingfaceKey == "" {
 		t.Skip("HUGGINGFACEHUB_API_TOKEN not set")
 	}
 	e, err := NewHuggingface()


### PR DESCRIPTION
### Description

Fixes the typo of 'openaiKey' in huggingface_test.go.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
