### PR TITLE
vectorstores: Added an option to specify the vector dimensions for the embeddings

### DIFF
--- a/vectorstores/pgvector/options.go
+++ b/vectorstores/pgvector/options.go
@@ -15,6 +15,7 @@ const (
 	DefaultPreDeleteCollection      = false
 	DefaultEmbeddingStoreTableName  = "langchain_pg_embedding"
 	DefaultCollectionStoreTableName = "langchain_pg_collection"
+	DefaultVectorDimensions         = 1536
 )
 
 // ErrInvalidOptions is returned when the options given are invalid.
@@ -80,12 +81,20 @@ func WithCollectionMetadata(metadata map[string]any) Option {
 	}
 }
 
+// WithVectorDimensions is an option for specifying the vector size.
+func WithVectorDimensions(size int) Option {
+	return func(p *Store) {
+		p.vectorDimensions = size
+	}
+}
+
 func applyClientOptions(opts ...Option) (Store, error) {
 	o := &Store{
 		collectionName:      DefaultCollectionName,
 		preDeleteCollection: DefaultPreDeleteCollection,
 		embeddingTableName:  DefaultEmbeddingStoreTableName,
 		collectionTableName: DefaultCollectionStoreTableName,
+		vectorDimensions:    DefaultVectorDimensions,
 	}
 
 	for _, opt := range opts {

--- a/vectorstores/pgvector/options.go
+++ b/vectorstores/pgvector/options.go
@@ -15,7 +15,6 @@ const (
 	DefaultPreDeleteCollection      = false
 	DefaultEmbeddingStoreTableName  = "langchain_pg_embedding"
 	DefaultCollectionStoreTableName = "langchain_pg_collection"
-	DefaultVectorDimensions         = 1536
 )
 
 // ErrInvalidOptions is returned when the options given are invalid.
@@ -94,7 +93,6 @@ func applyClientOptions(opts ...Option) (Store, error) {
 		preDeleteCollection: DefaultPreDeleteCollection,
 		embeddingTableName:  DefaultEmbeddingStoreTableName,
 		collectionTableName: DefaultCollectionStoreTableName,
-		vectorDimensions:    DefaultVectorDimensions,
 	}
 
 	for _, opt := range opts {

--- a/vectorstores/pgvector/pgvector.go
+++ b/vectorstores/pgvector/pgvector.go
@@ -151,16 +151,21 @@ func (s Store) createEmbeddingTableIfNotExists(ctx context.Context, tx pgx.Tx) e
 		return err
 	}
 
+	vectorDimensions := ""
+	if s.vectorDimensions > 0 {
+		vectorDimensions = fmt.Sprintf("(%d)", s.vectorDimensions)
+	}
+
 	sql := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
 	collection_id uuid,
-	embedding vector(%d),
+	embedding vector%s,
 	document varchar,
 	cmetadata json,
 	custom_id varchar,
 	"uuid" uuid NOT NULL,
 	CONSTRAINT langchain_pg_embedding_collection_id_fkey
 	FOREIGN KEY (collection_id) REFERENCES %s (uuid) ON DELETE CASCADE,
-	PRIMARY KEY (uuid))`, s.embeddingTableName, s.vectorDimensions, s.collectionTableName)
+	PRIMARY KEY (uuid))`, s.embeddingTableName, vectorDimensions, s.collectionTableName)
 	if _, err := tx.Exec(ctx, sql); err != nil {
 		return err
 	}


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

----

Added an option to specify the vector dimensions for the embeddings

This is needed when you eventually want to add [an HNSW index](https://github.com/pgvector/pgvector#hnsw) to the embeddings to speed up the querying.