### PR TITLE
agents: [OneShotZeroAgent] Change regex to allow multi-line inputs

### DIFF
--- a/agents/markl_test.go
+++ b/agents/markl_test.go
@@ -26,6 +26,16 @@ func TestMRKLOutputParser(t *testing.T) {
 			expectedFinish: nil,
 			expectedErr:    nil,
 		},
+		{
+			input: "Action: foo\nAction Input:\nbar\nbaz",
+			expectedActions: []schema.AgentAction{{
+				Tool:      "foo",
+				ToolInput: "bar\nbaz",
+				Log:       "Action: foo\nAction Input:\nbar\nbaz",
+			}},
+			expectedFinish: nil,
+			expectedErr:    nil,
+		},
 	}
 
 	a := OneShotZeroAgent{}

--- a/agents/mrkl.go
+++ b/agents/mrkl.go
@@ -127,7 +127,7 @@ func (a *OneShotZeroAgent) parseOutput(output string) ([]schema.AgentAction, *sc
 		}, nil
 	}
 
-	r := regexp.MustCompile(`Action:\s*(.+)\s*Action Input:\s*(.+)`)
+	r := regexp.MustCompile(`Action:\s*(.+)\s*Action Input:\s(?s)*(.+)`)
 	matches := r.FindStringSubmatch(output)
 	if len(matches) == 0 {
 		return nil, nil, fmt.Errorf("%w: %s", ErrUnableToParseOutput, output)


### PR DESCRIPTION
This small code change is to allow the one-shot zero agent to pass multi-line input to a tool. I did not change the conversational one as the regex there is different from this one to start with and is missing unit tests (so I cannot confirm breaking changes).

Change is setting the `s` flag to true on the regex.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
