### PR TITLE
fix: stackoverflow caused by textspliter

### DIFF
--- a/textsplitter/recursive_character.go
+++ b/textsplitter/recursive_character.go
@@ -36,14 +36,11 @@ func (s RecursiveCharacter) SplitText(text string) ([]string, error) {
 
 	// Find the appropriate separator
 	separator := s.Separators[len(s.Separators)-1]
-	for _, s := range s.Separators {
-		if s == "" {
-			separator = s
-			break
-		}
-
-		if strings.Contains(text, s) {
-			separator = s
+	newSeparators := []string{}
+	for i, c := range s.Separators {
+		if c == "" || strings.Contains(text, c) {
+			separator = c
+			newSeparators = s.Separators[i+1:]
 			break
 		}
 	}
@@ -65,11 +62,15 @@ func (s RecursiveCharacter) SplitText(text string) ([]string, error) {
 			goodSplits = make([]string, 0)
 		}
 
-		otherInfo, err := s.SplitText(split)
-		if err != nil {
-			return nil, err
+		if len(newSeparators) == 0 {
+			finalChunks = append(finalChunks, split)
+		} else {
+			otherInfo, err := s.SplitText(split)
+			if err != nil {
+				return nil, err
+			}
+			finalChunks = append(finalChunks, otherInfo...)
 		}
-		finalChunks = append(finalChunks, otherInfo...)
 	}
 
 	if len(goodSplits) > 0 {

--- a/textsplitter/recursive_character_test.go
+++ b/textsplitter/recursive_character_test.go
@@ -15,13 +15,25 @@ func TestRecursiveCharacterSplitter(t *testing.T) {
 		text         string
 		chunkOverlap int
 		chunkSize    int
+		separators   []string
 		expectedDocs []schema.Document
 	}
 	testCases := []testCase{
 		{
+			text:         "Hi, Harrison. \nI am glad to meet you",
+			chunkOverlap: 1,
+			chunkSize:    20,
+			separators:   []string{"\n", "$"},
+			expectedDocs: []schema.Document{
+				{PageContent: "Hi, Harrison.", Metadata: map[string]any{}},
+				{PageContent: "I am glad to meet you", Metadata: map[string]any{}},
+			},
+		},
+		{
 			text:         "Hi.\nI'm Harrison.\n\nHow?\na\nb",
 			chunkOverlap: 1,
 			chunkSize:    20,
+			separators:   []string{"\n\n", "\n", " ", ""},
 			expectedDocs: []schema.Document{
 				{PageContent: "Hi.\nI'm Harrison.", Metadata: map[string]any{}},
 				{PageContent: "How?\na\nb", Metadata: map[string]any{}},
@@ -31,6 +43,7 @@ func TestRecursiveCharacterSplitter(t *testing.T) {
 			text:         "Hi.\nI'm Harrison.\n\nHow?\na\nbHi.\nI'm Harrison.\n\nHow?\na\nb",
 			chunkOverlap: 1,
 			chunkSize:    40,
+			separators:   []string{"\n\n", "\n", " ", ""},
 			expectedDocs: []schema.Document{
 				{PageContent: "Hi.\nI'm Harrison.", Metadata: map[string]any{}},
 				{PageContent: "How?\na\nbHi.\nI'm Harrison.\n\nHow?\na\nb", Metadata: map[string]any{}},
@@ -40,6 +53,7 @@ func TestRecursiveCharacterSplitter(t *testing.T) {
 			text:         "name: Harrison\nage: 30",
 			chunkOverlap: 1,
 			chunkSize:    40,
+			separators:   []string{"\n\n", "\n", " ", ""},
 			expectedDocs: []schema.Document{
 				{PageContent: "name: Harrison\nage: 30", Metadata: map[string]any{}},
 			},
@@ -52,6 +66,7 @@ name: Joe
 age: 32`,
 			chunkOverlap: 1,
 			chunkSize:    40,
+			separators:   []string{"\n\n", "\n", " ", ""},
 			expectedDocs: []schema.Document{
 				{PageContent: "name: Harrison\nage: 30", Metadata: map[string]any{}},
 				{PageContent: "name: Joe\nage: 32", Metadata: map[string]any{}},
@@ -70,6 +85,7 @@ Bye!
 -H.`,
 			chunkOverlap: 1,
 			chunkSize:    10,
+			separators:   []string{"\n\n", "\n", " ", ""},
 			expectedDocs: []schema.Document{
 				{PageContent: "Hi.", Metadata: map[string]any{}},
 				{PageContent: "I'm", Metadata: map[string]any{}},
@@ -95,6 +111,7 @@ Bye!
 	for _, tc := range testCases {
 		splitter.ChunkOverlap = tc.chunkOverlap
 		splitter.ChunkSize = tc.chunkSize
+		splitter.Separators = tc.separators
 
 		docs, err := CreateDocuments(splitter, []string{tc.text}, nil)
 		require.NoError(t, err)

--- a/textsplitter/recursive_character_test.go
+++ b/textsplitter/recursive_character_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tmc/langchaingo/schema"
 )
 
-//nolint:dupword
+//nolint:dupword,funlen
 func TestRecursiveCharacterSplitter(t *testing.T) {
 	t.Parallel()
 	type testCase struct {
@@ -27,16 +27,6 @@ func TestRecursiveCharacterSplitter(t *testing.T) {
 			expectedDocs: []schema.Document{
 				{PageContent: "Hi, Harrison.", Metadata: map[string]any{}},
 				{PageContent: "I am glad to meet you", Metadata: map[string]any{}},
-			},
-		},
-		{
-			text:         "Hi.\nI'm Harrison.\n\nHow?\na\nb",
-			chunkOverlap: 1,
-			chunkSize:    20,
-			separators:   []string{"\n\n", "\n", " ", ""},
-			expectedDocs: []schema.Document{
-				{PageContent: "Hi.\nI'm Harrison.", Metadata: map[string]any{}},
-				{PageContent: "How?\na\nb", Metadata: map[string]any{}},
 			},
 		},
 		{


### PR DESCRIPTION
fix #607  #231 

Add the newSeparators array to avoid entering an infinite loop call.
Inspired by https://github.com/langchain-ai/langchain/blob/00a09e1b7117f3bde14a44748510fcccc95f9de5/libs/langchain/langchain/text_splitter.py.


