### PR TITLE
Fix agent stream callback

### DIFF
--- a/callbacks/agent_final_stream.go
+++ b/callbacks/agent_final_stream.go
@@ -97,7 +97,13 @@ func (handler *AgentFinalStreamHandler) HandleStreamingFunc(_ context.Context, c
 	}
 
 	// Check for colon and set print mode.
-	if handler.KeywordDetected && chunkStr != ":" {
+	if handler.KeywordDetected && chunkStr != "" {
+		// remove potential spaces and colon from the left contained in beginning of the answer
+		chunkStr = strings.TrimLeft(chunkStr, " ")
+		if strings.HasPrefix(chunkStr, ":") {
+			chunk = []byte(strings.TrimSpace(strings.TrimPrefix(chunkStr, ":")))
+		}
+
 		handler.PrintOutput = true
 	}
 

--- a/callbacks/agent_final_stream.go
+++ b/callbacks/agent_final_stream.go
@@ -78,15 +78,11 @@ func (handler *AgentFinalStreamHandler) HandleStreamingFunc(_ context.Context, c
 	handler.LastTokens += chunkStr
 
 	// Buffer the last few chunks to match the longest keyword size
-	longestSize := len(handler.Keywords[0])
+	var longestSize int
 	for _, k := range handler.Keywords {
 		if len(k) > longestSize {
 			longestSize = len(k)
 		}
-	}
-
-	if len(handler.LastTokens) > longestSize {
-		handler.LastTokens = handler.LastTokens[len(handler.LastTokens)-longestSize:]
 	}
 
 	// Check for keywords
@@ -94,6 +90,10 @@ func (handler *AgentFinalStreamHandler) HandleStreamingFunc(_ context.Context, c
 		if strings.Contains(handler.LastTokens, k) {
 			handler.KeywordDetected = true
 		}
+	}
+
+	if len(handler.LastTokens) > longestSize {
+		handler.LastTokens = handler.LastTokens[len(handler.LastTokens)-longestSize:]
 	}
 
 	// Check for colon and set print mode.

--- a/callbacks/agent_final_stream.go
+++ b/callbacks/agent_final_stream.go
@@ -97,7 +97,7 @@ func (handler *AgentFinalStreamHandler) HandleStreamingFunc(_ context.Context, c
 	}
 
 	// Check for colon and set print mode.
-	if handler.KeywordDetected && chunkStr != "" {
+	if handler.KeywordDetected && !handler.PrintOutput {
 		// remove potential spaces and colon from the left contained in beginning of the answer
 		chunkStr = strings.TrimLeft(chunkStr, " ")
 		if strings.HasPrefix(chunkStr, ":") {

--- a/callbacks/agent_final_stream_test.go
+++ b/callbacks/agent_final_stream_test.go
@@ -1,0 +1,29 @@
+package callbacks
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterFinalString(t *testing.T) {
+	t.Parallel()
+
+	keywork := "Final Answer:"
+	correctStr := "This is a correct final string."
+
+	mockchunkStr1 := fmt.Sprintf(` some other text.
+	Final Answer: %s`, correctStr)
+
+	mockchunkStr2 := fmt.Sprintf(`   :    %s`, correctStr)
+
+	filteredStr := filterFinalString(correctStr, keywork)
+
+	filteredStr1 := filterFinalString(mockchunkStr1, keywork)
+	filteredStr2 := filterFinalString(mockchunkStr2, keywork)
+
+	require.Equal(t, filteredStr, correctStr)
+	require.Equal(t, filteredStr1, correctStr)
+	require.Equal(t, filteredStr2, correctStr)
+}

--- a/callbacks/agent_final_stream_test.go
+++ b/callbacks/agent_final_stream_test.go
@@ -7,23 +7,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type filterFinalStringTestCase struct {
+	inputStr string
+}
+
 func TestFilterFinalString(t *testing.T) {
 	t.Parallel()
 
 	keywork := "Final Answer:"
+
+	// correct final string
 	correctStr := "This is a correct final string."
 
-	mockchunkStr1 := fmt.Sprintf(` some other text.
-	Final Answer: %s`, correctStr)
+	extraStrAbore := fmt.Sprintf(" some other text.\nFinal Answer: %s", correctStr)
+	extraStrBefore := fmt.Sprintf(" another text. Final Answer: %s", correctStr)
+	extraColonWithSpacesBefore := fmt.Sprintf(`   :    %s`, correctStr)
 
-	mockchunkStr2 := fmt.Sprintf(`   :    %s`, correctStr)
+	testCases := []filterFinalStringTestCase{
+		{correctStr},
+		{extraStrAbore},
+		{extraStrBefore},
+		{extraColonWithSpacesBefore},
+	}
 
-	filteredStr := filterFinalString(correctStr, keywork)
-
-	filteredStr1 := filterFinalString(mockchunkStr1, keywork)
-	filteredStr2 := filterFinalString(mockchunkStr2, keywork)
-
-	require.Equal(t, filteredStr, correctStr)
-	require.Equal(t, filteredStr1, correctStr)
-	require.Equal(t, filteredStr2, correctStr)
+	for _, tc := range testCases {
+		filteredStr := filterFinalString(tc.inputStr, keywork)
+		require.Equal(t, filteredStr, correctStr)
+	}
 }

--- a/callbacks/agent_final_stream_test.go
+++ b/callbacks/agent_final_stream_test.go
@@ -1,37 +1,53 @@
 package callbacks
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-type filterFinalStringTestCase struct {
-	inputStr string
-}
-
 func TestFilterFinalString(t *testing.T) {
 	t.Parallel()
 
-	keywork := "Final Answer:"
-
-	// correct final string
-	correctStr := "This is a correct final string."
-
-	extraStrAbore := fmt.Sprintf(" some other text.\nFinal Answer: %s", correctStr)
-	extraStrBefore := fmt.Sprintf(" another text. Final Answer: %s", correctStr)
-	extraColonWithSpacesBefore := fmt.Sprintf(`   :    %s`, correctStr)
-
-	testCases := []filterFinalStringTestCase{
-		{correctStr},
-		{extraStrAbore},
-		{extraStrBefore},
-		{extraColonWithSpacesBefore},
+	cases := []struct {
+		keyword  string
+		inputStr string
+		expected string
+	}{
+		{
+			keyword:  "Final Answer:",
+			inputStr: "This is a correct final string.",
+			expected: "This is a correct final string.",
+		},
+		{
+			keyword:  "Final Answer:",
+			inputStr: " some other text above.\nFinal Answer: This is a correct final string.",
+			expected: "This is a correct final string.",
+		},
+		{
+			keyword:  "Final Answer:",
+			inputStr: " another text before. Final Answer: This is a correct final string.",
+			expected: "This is a correct final string.",
+		},
+		{
+			keyword:  "Final Answer:",
+			inputStr: `   :    This is a correct final string.`,
+			expected: "This is a correct final string.",
+		},
+		{
+			keyword:  "Customed KeyWord_2:",
+			inputStr: " some other text above.\nSome Customed KeyWord_2: This is a correct final string.",
+			expected: "This is a correct final string.",
+		},
+		{
+			keyword:  "Customed KeyWord_$#@-123:",
+			inputStr: " another text before keyword. Some Customed KeyWord_$#@-123: This is a correct final string.",
+			expected: "This is a correct final string.",
+		},
 	}
 
-	for _, tc := range testCases {
-		filteredStr := filterFinalString(tc.inputStr, keywork)
-		require.Equal(t, filteredStr, correctStr)
+	for _, tc := range cases {
+		filteredStr := filterFinalString(tc.inputStr, tc.keyword)
+		require.Equal(t, tc.expected, filteredStr)
 	}
 }


### PR DESCRIPTION
I did a little change in this PR to handled 2 problems when using AgentFinalStreamHandler:

I followed  this example to study using agent
https://github.com/tmc/langchaingo/blob/main/examples/mrkl-agent-example/mrkl_agent.go
and use a handler to get streaming result  like this:
```go
	callbackHandler := callbacks.NewFinalStreamHandler()
	// callbackHandler.PrintOutput = true

	executor, err := agents.Initialize(
		llm,
		agentTools,
		agents.ZeroShotReactDescription,
		agents.WithMaxIterations(5),
		agents.WithCallbacksHandler(callbackHandler),
	)
```

#### problem1. Detect keyword failed:  
reason: cut out slice handler.LastTokens before doing detect keyword will cause Detection can’t success

for example:  
before the handler.LastTokens string value is 
```
"result Final Answer: As of February 18,"
```
after the reassign the slice value, it's become
```
"Answer: As of February 18,"
```
Then it can't pass the keywords check process which should contained `Final Answer:` keyword in LastTokens.

So I changed code order,  check keywords first, then reassign slice

#### problem2. Final Answer sometimes contain  colon symbol `:` at the beginning
Add few code to filter the colon if it exist

May this be a positive contribution.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
