### PR TITLE
serpapi prevent exact-match google search

### DIFF
--- a/tools/serpapi/internal/client.go
+++ b/tools/serpapi/internal/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 const _url = "https://serpapi.com/search"
@@ -29,6 +30,12 @@ func New(apiKey string) *Client {
 }
 
 func (s *Client) Search(ctx context.Context, query string) (string, error) {
+	// prevent exact-match search: trim " symbol when it exists on both the left and right sides
+	// exact-match behaviour cause `No Google Search Results was found` error too frequently
+	if strings.HasPrefix(query, "\"") && strings.HasSuffix(query, "\"") {
+		query = strings.TrimPrefix(strings.TrimSuffix(query, "\""), "\"")
+	}
+
 	params := make(url.Values)
 	params.Add("q", query)
 	params.Add("google_domain", "google.com")

--- a/tools/serpapi/serpapi.go
+++ b/tools/serpapi/serpapi.go
@@ -37,11 +37,7 @@ func (t Tool) Name() string {
 }
 
 func (t Tool) Description() string {
-	return `
-	"A wrapper around Google Search. "
-	"Useful for when you need to answer questions about current events. "
-	"Always one of the first options when you need to find information on internet"
-	"Input should be a search query."`
+	return "A search engine. Useful for when you need to answer questions about current events. Input should be a search query."
 }
 
 func (t Tool) Call(ctx context.Context, input string) (string, error) {


### PR DESCRIPTION


I just encountered this error similar with the issue #323:
```
No good Google Search Results was found
```

after the investigation, I found sometimes the llm model(e.g. mistral in ollama) will return `Action Input` value surrounded by double quotes
which will became a exact-match behavior and usually find nothing:
```sh
# this is ok, just get name from search engine and continue the following steps
Action: GoogleSearch
Action Input: Oliva Wilde boyfriend age

# error: No good Google Search Results was found
Action: GoogleSearch
Action Input: "Oliva Wilde boyfriend age"
```

with quotes, the actual query string in serpapi became:
```sh
"q": "\"Oliva Wilde boyfriend age\"",
```

and this also appeared in issue #323 
```
    # python version
    "q": "current weather in Ramnicu Valcea, Romania",
    # langchaingo
    "q": ""current+weather+in+Ramnicu+Valcea,+Romania"",
```

another change is the description of this tool:
 I compared serpapi tool description in langchain python and langchaingo,
 I tried several times, In my use experience, I feel the python version would worked better, but I'm not the expert in prompt engineering , so if this should not be changed, I'm going to delete this modification.
```sh
# langchaingo currently use:
`
"A wrapper around Google Search. "
"Useful for when you need to answer questions about current events. "
"Always one of the first options when you need to find information on internet"
"Input should be a search query."
`

# langchain python serpapi:
"A search engine. Useful for when you need to answer questions about current events. Input should be a search query."
```

---
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

