### PR TITLE
googleai: fix options need add default value

### DIFF
--- a/chains/llm_test.go
+++ b/chains/llm_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/callbacks"
+	"github.com/tmc/langchaingo/llms/googleai"
 	"github.com/tmc/langchaingo/llms/openai"
 	"github.com/tmc/langchaingo/prompts"
 )
@@ -54,4 +55,33 @@ func TestLLMChainWithChatPromptTemplate(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, "AI: foo\nHuman: boo", result)
+}
+
+func TestLLMChainWithGoogleAI(t *testing.T) {
+	t.Parallel()
+	genaiKey := os.Getenv("GENAI_API_KEY")
+	if genaiKey == "" {
+		t.Skip("GENAI_API_KEY not set")
+	}
+	model, err := googleai.New(context.Background(), googleai.WithAPIKey(genaiKey))
+	require.NoError(t, err)
+	require.NoError(t, err)
+	model.CallbacksHandler = callbacks.LogHandler{}
+
+	prompt := prompts.NewPromptTemplate(
+		"What is the capital of {{.country}}",
+		[]string{"country"},
+	)
+	require.NoError(t, err)
+
+	chain := NewLLMChain(model, prompt)
+
+	result, err := Predict(context.Background(), chain,
+		map[string]any{
+			"country": "France",
+		},
+		WithCallback(callbacks.LogHandler{}),
+	)
+	require.NoError(t, err)
+	require.True(t, strings.Contains(result, "Paris"))
 }

--- a/llms/googleai/googleai.go
+++ b/llms/googleai/googleai.go
@@ -50,6 +50,7 @@ func (g *GoogleAI) GenerateContent(ctx context.Context, messages []llms.MessageC
 	for _, opt := range options {
 		opt(&opts)
 	}
+	g.setCallOptionsDefaults(&opts)
 
 	model := g.client.GenerativeModel(opts.Model)
 	model.SetCandidateCount(int32(opts.CandidateCount))
@@ -80,6 +81,27 @@ func (g *GoogleAI) GenerateContent(ctx context.Context, messages []llms.MessageC
 	}
 
 	return response, nil
+}
+
+func (g *GoogleAI) setCallOptionsDefaults(opts *llms.CallOptions) {
+	if opts.Model == "" {
+		opts.Model = g.opts.defaultModel
+	}
+	if opts.CandidateCount == 0 {
+		opts.CandidateCount = g.opts.defaultCandidateCount
+	}
+	if opts.MaxTokens == 0 {
+		opts.MaxTokens = g.opts.defaultMaxTokens
+	}
+	if opts.Temperature == 0 {
+		opts.Temperature = g.opts.defaultTemperature
+	}
+	if opts.TopP == 0 {
+		opts.TopP = g.opts.defaultTopP
+	}
+	if opts.TopK == 0 {
+		opts.TopK = g.opts.defaultTopK
+	}
 }
 
 // convertCandidates converts a sequence of genai.Candidate to a response.


### PR DESCRIPTION
You can find out the problem by first executing the tests added in the current pr.

Let me explain what happened:
When calling `llm` via `chain`, because it goes through the function： https://github.com/tmc/langchaingo/blob/853fc0492d2331518252a357759546abfb1f9fea/chains/options.go#L132-L158 

Before this function, only a certain `ChainCallOption` may have been called, but after this function, it will return the 11 l`lms.CallOptions` that are currently available (although some of them are with empty value in there), so the empty value need to be dealt with at the `llm` level.

I'm **guessing** that openai's handler is in the
https://github.com/tmc/langchaingo/blob/853fc0492d2331518252a357759546abfb1f9fea/llms/openai/internal/openaiclient/completions.go#L49-L70

cc @tmc @eliben 