### PR TITLE
chains: fix issue with overriding defaults in chainCallOption

### DIFF
--- a/chains/api_test.go
+++ b/chains/api_test.go
@@ -66,5 +66,5 @@ func TestAPI(t *testing.T) {
 	if !ok {
 		t.Fatal("expected answer to be a string")
 	}
-	require.True(t, strings.Contains(answer, "temperature"), `result does not contain the keyword 'temperature'`)
+	require.True(t, strings.Contains(answer, "Munich"), `result does not contain the keyword 'Munich'`)
 }

--- a/chains/llm_test.go
+++ b/chains/llm_test.go
@@ -84,11 +84,6 @@ func TestLLMChainWithGoogleAI(t *testing.T) {
 			"country": "France",
 		},
 		WithCallback(callbacks.LogHandler{}),
-		WithModel("gemini-pro"),
-		WithMaxTokens(200),
-		WithStopWords(nil),
-		WithTopK(3),
-		WithTopP(0.95),
 	)
 	require.NoError(t, err)
 	require.True(t, strings.Contains(result, "Paris"))

--- a/chains/options.go
+++ b/chains/options.go
@@ -10,30 +10,59 @@ import (
 // ChainCallOption is a function that can be used to modify the behavior of the Call function.
 type ChainCallOption func(*chainCallOption)
 
+// For issue #626, each field here has a boolean "set" flag so we can
+// distinguish between the case where the option was actually set explicitly
+// on chainCallOption, or asked to remain default. The reason we need this is
+// that in translating options from ChainCallOption to llms.CallOption, the
+// notion of "default value the user didn't explicitly ask to change" is
+// violated.
+// These flags are hopefully a temporary backwards-compatible solution, until
+// we find a more fundamental solution for #626.
 type chainCallOption struct {
 	// Model is the model to use in an LLM call.
-	Model string
+	Model    string
+	modelSet bool
+
 	// MaxTokens is the maximum number of tokens to generate to use in an LLM call.
-	MaxTokens int
+	MaxTokens    int
+	maxTokensSet bool
+
 	// Temperature is the temperature for sampling to use in an LLM call, between 0 and 1.
-	Temperature float64
+	Temperature    float64
+	temperatureSet bool
+
 	// StopWords is a list of words to stop on to use in an LLM call.
-	StopWords []string
+	StopWords    []string
+	stopWordsSet bool
+
 	// StreamingFunc is a function to be called for each chunk of a streaming response.
-	// Return an error to stop streaming earl.
+	// Return an error to stop streaming early.
 	StreamingFunc func(ctx context.Context, chunk []byte) error
+
 	// TopK is the number of tokens to consider for top-k sampling in an LLM call.
-	TopK int
+	TopK    int
+	topkSet bool
+
 	// TopP is the cumulative probability for top-p sampling in an LLM call.
-	TopP float64
+	TopP    float64
+	toppSet bool
+
 	// Seed is a seed for deterministic sampling in an LLM call.
-	Seed int
+	Seed    int
+	seedSet bool
+
 	// MinLength is the minimum length of the generated text in an LLM call.
-	MinLength int
+	MinLength    int
+	minLengthSet bool
+
 	// MaxLength is the maximum length of the generated text in an LLM call.
-	MaxLength int
+	MaxLength    int
+	maxLengthSet bool
+
 	// RepetitionPenalty is the repetition penalty for sampling in an LLM call.
-	RepetitionPenalty float64
+	RepetitionPenalty    float64
+	repetitionPenaltySet bool
+
 	// CallbackHandler is the callback handler for Chain
 	CallbackHandler callbacks.Handler
 }
@@ -42,6 +71,7 @@ type chainCallOption struct {
 func WithModel(model string) ChainCallOption {
 	return func(o *chainCallOption) {
 		o.Model = model
+		o.modelSet = true
 	}
 }
 
@@ -49,6 +79,7 @@ func WithModel(model string) ChainCallOption {
 func WithMaxTokens(maxTokens int) ChainCallOption {
 	return func(o *chainCallOption) {
 		o.MaxTokens = maxTokens
+		o.maxTokensSet = true
 	}
 }
 
@@ -56,13 +87,7 @@ func WithMaxTokens(maxTokens int) ChainCallOption {
 func WithTemperature(temperature float64) ChainCallOption {
 	return func(o *chainCallOption) {
 		o.Temperature = temperature
-	}
-}
-
-// WithOptions is an option for LLM.Call.
-func WithOptions(options chainCallOption) ChainCallOption {
-	return func(o *chainCallOption) {
-		*o = options
+		o.temperatureSet = true
 	}
 }
 
@@ -77,6 +102,7 @@ func WithStreamingFunc(streamingFunc func(ctx context.Context, chunk []byte) err
 func WithTopK(topK int) ChainCallOption {
 	return func(o *chainCallOption) {
 		o.TopK = topK
+		o.topkSet = true
 	}
 }
 
@@ -84,6 +110,7 @@ func WithTopK(topK int) ChainCallOption {
 func WithTopP(topP float64) ChainCallOption {
 	return func(o *chainCallOption) {
 		o.TopP = topP
+		o.toppSet = true
 	}
 }
 
@@ -91,6 +118,7 @@ func WithTopP(topP float64) ChainCallOption {
 func WithSeed(seed int) ChainCallOption {
 	return func(o *chainCallOption) {
 		o.Seed = seed
+		o.seedSet = true
 	}
 }
 
@@ -98,6 +126,7 @@ func WithSeed(seed int) ChainCallOption {
 func WithMinLength(minLength int) ChainCallOption {
 	return func(o *chainCallOption) {
 		o.MinLength = minLength
+		o.minLengthSet = true
 	}
 }
 
@@ -105,6 +134,7 @@ func WithMinLength(minLength int) ChainCallOption {
 func WithMaxLength(maxLength int) ChainCallOption {
 	return func(o *chainCallOption) {
 		o.MaxLength = maxLength
+		o.maxLengthSet = true
 	}
 }
 
@@ -112,6 +142,7 @@ func WithMaxLength(maxLength int) ChainCallOption {
 func WithRepetitionPenalty(repetitionPenalty float64) ChainCallOption {
 	return func(o *chainCallOption) {
 		o.RepetitionPenalty = repetitionPenalty
+		o.repetitionPenaltySet = true
 	}
 }
 
@@ -119,17 +150,18 @@ func WithRepetitionPenalty(repetitionPenalty float64) ChainCallOption {
 func WithStopWords(stopWords []string) ChainCallOption {
 	return func(o *chainCallOption) {
 		o.StopWords = stopWords
+		o.stopWordsSet = true
 	}
 }
 
 // WithCallback allows setting a custom Callback Handler.
 func WithCallback(callbackHandler callbacks.Handler) ChainCallOption {
-	return func(opts *chainCallOption) {
-		opts.CallbackHandler = callbackHandler
+	return func(o *chainCallOption) {
+		o.CallbackHandler = callbackHandler
 	}
 }
 
-func getLLMCallOptions(options ...ChainCallOption) []llms.CallOption {
+func getLLMCallOptions(options ...ChainCallOption) []llms.CallOption { //nolint:cyclop
 	opts := &chainCallOption{}
 	for _, option := range options {
 		option(opts)
@@ -141,18 +173,37 @@ func getLLMCallOptions(options ...ChainCallOption) []llms.CallOption {
 		}
 	}
 
-	chainCallOption := []llms.CallOption{
-		llms.WithModel(opts.Model),
-		llms.WithMaxTokens(opts.MaxTokens),
-		llms.WithTemperature(opts.Temperature),
-		llms.WithStopWords(opts.StopWords),
-		llms.WithStreamingFunc(opts.StreamingFunc),
-		llms.WithTopK(opts.TopK),
-		llms.WithTopP(opts.TopP),
-		llms.WithSeed(opts.Seed),
-		llms.WithMinLength(opts.MinLength),
-		llms.WithMaxLength(opts.MaxLength),
-		llms.WithRepetitionPenalty(opts.RepetitionPenalty),
+	var chainCallOption []llms.CallOption
+
+	if opts.modelSet {
+		chainCallOption = append(chainCallOption, llms.WithModel(opts.Model))
+	}
+	if opts.maxTokensSet {
+		chainCallOption = append(chainCallOption, llms.WithMaxTokens(opts.MaxTokens))
+	}
+	if opts.temperatureSet {
+		chainCallOption = append(chainCallOption, llms.WithTemperature(opts.Temperature))
+	}
+	if opts.stopWordsSet {
+		chainCallOption = append(chainCallOption, llms.WithStopWords(opts.StopWords))
+	}
+	if opts.topkSet {
+		chainCallOption = append(chainCallOption, llms.WithTopK(opts.TopK))
+	}
+	if opts.toppSet {
+		chainCallOption = append(chainCallOption, llms.WithTopP(opts.TopP))
+	}
+	if opts.seedSet {
+		chainCallOption = append(chainCallOption, llms.WithSeed(opts.Seed))
+	}
+	if opts.minLengthSet {
+		chainCallOption = append(chainCallOption, llms.WithMinLength(opts.MinLength))
+	}
+	if opts.maxLengthSet {
+		chainCallOption = append(chainCallOption, llms.WithMaxLength(opts.MaxLength))
+	}
+	if opts.repetitionPenaltySet {
+		chainCallOption = append(chainCallOption, llms.WithRepetitionPenalty(opts.RepetitionPenalty))
 	}
 
 	return chainCallOption


### PR DESCRIPTION
Updates #626

Fixes #603
Fixes #604
Fixes #594

This is a backwards compatible fix until we fix #626 for real.
Note that the workaround can now be removed in the GoogleAI chains test.