### PR TITLE
chore: Pinning chroma-go ahead of major new release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -149,7 +149,7 @@ require (
 	cloud.google.com/go/vertexai v0.6.0
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/PuerkitoBio/goquery v1.8.1
-	github.com/amikos-tech/chroma-go v0.0.0-20240109142503-c8fb49c3e28c
+	github.com/amikos-tech/chroma-go v0.0.1
 	github.com/cohere-ai/tokenizer v1.1.2
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/go-sql-driver/mysql v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/airbrake/gobrake v3.6.1+incompatible/go.mod h1:wM4gu3Cn0W0K7GUuVWnlXZ
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/amikos-tech/chroma-go v0.0.0-20240109142503-c8fb49c3e28c h1:DzSXJSUVK5ed+HhAnGA1TKgBdXqAW/iXPRvpd9rXWLc=
 github.com/amikos-tech/chroma-go v0.0.0-20240109142503-c8fb49c3e28c/go.mod h1:uJwgGN4rBUTMI88Rn68Xia+cTRogOo0/elcPvJYFtBU=
+github.com/amikos-tech/chroma-go v0.0.1 h1:yWgl6YUhM+kXuH82DR9Q8dWddcjgaFuFPk+MtWNreqE=
+github.com/amikos-tech/chroma-go v0.0.1/go.mod h1:uJwgGN4rBUTMI88Rn68Xia+cTRogOo0/elcPvJYFtBU=
 github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
 github.com/andybalholm/cascadia v1.3.2 h1:3Xi6Dw5lHF15JtdcmAHD3i1+T8plmv7BQ/nsViSLyss=
 github.com/andybalholm/cascadia v1.3.2/go.mod h1:7gtRlve5FxPPgIgX36uWBX58OdBsSS6lUvCFb+h7KvU=


### PR DESCRIPTION
I'm making a major overhaul of the chroma-go package, so I need to pin the version until the upgrade is done, at which point I'll create a PR for any breaking changes.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
