### PR TITLE
feat: add JSON format option to ollama

### DIFF
--- a/examples/ollama-functions-example/go.mod
+++ b/examples/ollama-functions-example/go.mod
@@ -1,0 +1,13 @@
+module github.com/tmc/langchaingo/examples/ollama-functions-example
+
+go 1.22.0
+
+require github.com/tmc/langchaingo v0.0.0
+
+require (
+	github.com/dlclark/regexp2 v1.8.1 // indirect
+	github.com/google/uuid v1.4.0 // indirect
+	github.com/pkoukk/tiktoken-go v0.1.2 // indirect
+)
+
+replace github.com/tmc/langchaingo => ../../

--- a/examples/ollama-functions-example/go.sum
+++ b/examples/ollama-functions-example/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.8.1 h1:6Lcdwya6GjPUNsBct8Lg/yRPwMhABj269AAzdGSiR+0=
+github.com/dlclark/regexp2 v1.8.1/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
+github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pkoukk/tiktoken-go v0.1.2 h1:u7PCSBiWJ3nJYoTGShyM9iHXz4dNyYkurwwp+GHtyHY=
+github.com/pkoukk/tiktoken-go v0.1.2/go.mod h1:boMWvk9pQCOTx11pgu0DrIdrAKgQzzJKUP6vLXaz7Rw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/ollama-functions-example/ollama_functions_example.go
+++ b/examples/ollama-functions-example/ollama_functions_example.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"slices"
+
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/ollama"
+	"github.com/tmc/langchaingo/schema"
+)
+
+func main() {
+	// allow specifying your own model via OLLAMA_TEST_MODEL
+	// (same as the Ollama unit tests).
+	model := "mistral:instruct"
+	if v := os.Getenv("OLLAMA_TEST_MODEL"); v != "" {
+		model = v
+	}
+
+	llm, err := ollama.New(
+		ollama.WithModel(model),
+		ollama.WithFormat("json"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var msgs []llms.MessageContent
+
+	// system message defines the available tools.
+	msgs = append(msgs, llms.TextParts(schema.ChatMessageTypeSystem,
+		systemMessage()))
+	msgs = append(msgs, llms.TextParts(schema.ChatMessageTypeHuman,
+		"What's the weather like in Beijing?"))
+
+	ctx := context.Background()
+
+	for {
+		resp, err := llm.GenerateContent(ctx, msgs)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		choice1 := resp.Choices[0]
+		msgs = append(msgs, llms.TextParts(schema.ChatMessageTypeAI, choice1.Content))
+
+		if c := unmarshalCall(choice1.Content); c != nil {
+			log.Printf("Call: %v", c.Tool)
+
+			msg, cont := dispatchCall(c)
+			if !cont {
+				break
+			}
+
+			msgs = append(msgs, msg)
+		} else {
+			// Ollama doesn't always respond with a function call, let it try again.
+			log.Printf("Not a call: %v", choice1.Content)
+
+			msgs = append(msgs, llms.TextParts(schema.ChatMessageTypeHuman, "Sorry, I don't understand. Please try again."))
+		}
+	}
+}
+
+type Call struct {
+	Tool  string         `json:"tool"`
+	Input map[string]any `json:"tool_input"`
+}
+
+func unmarshalCall(input string) *Call {
+	var c Call
+
+	if err := json.Unmarshal([]byte(input), &c); err == nil && c.Tool != "" {
+		return &c
+	}
+
+	return nil
+}
+
+func dispatchCall(c *Call) (llms.MessageContent, bool) {
+	// ollama doesn't always respond with a *valid* function call. As we're using prompt
+	// engineering to inject the tools, it may hallucinate.
+	if !validTool(c.Tool) {
+		log.Printf("invalid function call: %#v", c)
+
+		return llms.TextParts(schema.ChatMessageTypeHuman,
+			"Tool does not exist, please try again."), true
+	}
+
+	// we could make this more dynamic, by parsing the function schema.
+	switch c.Tool {
+	case "getCurrentWeather":
+		loc, ok := c.Input["location"].(string)
+		if !ok {
+			log.Fatal("invalid input")
+		}
+		unit, ok := c.Input["unit"].(string)
+		if !ok {
+			log.Fatal("invalid input")
+		}
+
+		weather, err := getCurrentWeather(loc, unit)
+		if err != nil {
+			log.Fatal(err)
+		}
+		return llms.TextParts(schema.ChatMessageTypeHuman, weather), true
+	case "finalResponse":
+		resp, ok := c.Input["response"].(string)
+		if !ok {
+			log.Fatal("invalid input")
+		}
+
+		log.Printf("Final response: %v", resp)
+
+		return llms.MessageContent{}, false
+	default:
+		// we already checked above if we had a valid tool.
+		panic("unreachable")
+	}
+}
+
+func validTool(name string) bool {
+	var valid []string
+
+	for _, v := range functions {
+		valid = append(valid, v.Name)
+	}
+
+	return slices.Contains(valid, name)
+}
+
+func systemMessage() string {
+	bs, err := json.Marshal(functions)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return fmt.Sprintf(`You have access to the following tools:
+
+%s
+
+To use a tool, respond with a JSON object with the following structure: 
+{
+	"tool": <name of the called tool>,
+	"tool_input": <parameters for the tool matching the above JSON schema>
+}
+`, string(bs))
+}
+
+func getCurrentWeather(location string, unit string) (string, error) {
+	weatherInfo := map[string]any{
+		"location":    location,
+		"temperature": "6",
+		"unit":        unit,
+		"forecast":    []string{"sunny", "windy"},
+	}
+	if unit == "fahrenheit" {
+		weatherInfo["temperature"] = 43
+	}
+
+	b, err := json.Marshal(weatherInfo)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+var functions = []llms.FunctionDefinition{
+	{
+		Name:        "getCurrentWeather",
+		Description: "Get the current weather in a given location",
+		Parameters: json.RawMessage(`{
+			"type": "object", 
+			"properties": {
+				"location": {"type": "string", "description": "The city and state, e.g. San Francisco, CA"}, 
+				"unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+			}, 
+			"required": ["location", "unit"]
+		}`),
+	},
+	{
+		// I found that providing a tool for Ollama to give the final response significantly
+		// increases the chances of success.
+		Name:        "finalResponse",
+		Description: "Provide the final response to the user query",
+		Parameters: json.RawMessage(`{
+			"type": "object", 
+			"properties": {
+				"response": {"type": "string", "description": "The final response to the user query"}
+			}, 
+			"required": ["response"]
+		}`),
+	},
+}

--- a/llms/ollama/ollamallm.go
+++ b/llms/ollama/ollamallm.go
@@ -101,6 +101,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 	ollamaOptions := makeOllamaOptionsFromOptions(o.options.ollamaOptions, opts)
 	req := &ollamaclient.ChatRequest{
 		Model:    model,
+		Format:   o.options.format,
 		Messages: chatMsgs,
 		Options:  ollamaOptions,
 		Stream:   func(b bool) *bool { return &b }(opts.StreamingFunc != nil),

--- a/llms/ollama/options.go
+++ b/llms/ollama/options.go
@@ -15,6 +15,7 @@ type options struct {
 	ollamaOptions       ollamaclient.Options
 	customModelTemplate string
 	system              string
+	format              string
 }
 
 type Option func(*options)
@@ -23,6 +24,13 @@ type Option func(*options)
 func WithModel(model string) Option {
 	return func(opts *options) {
 		opts.model = model
+	}
+}
+
+// WithFormat Sets the Ollama output format (currently Ollama only supports "json").
+func WithFormat(format string) Option {
+	return func(opts *options) {
+		opts.format = format
 	}
 }
 


### PR DESCRIPTION
## feat: add JSON format option to ollama

A new functionality was introduced to allow the setting of a specified
data format (currently Ollama only supports JSON). This is done via the
`WithFormat` option. The change provides more flexibility and control
over the format of data processed by the client.

Moreover, the test `TestWithFormat` has been added to assert the proper
functioning of this new feature.

Using the JSON format allows you to simulate `Functions` using prompt
injection, as it forces Ollama to respond in valid JSON.

## example: add new Ollama functions example

Add an example showing how the Ollama `JSON` format in combination with
prompt injection can be used to simulate Functions.

Output:
```bash
$ go run .
2024/03/06 11:03:24 Call: getCurrentWeather
2024/03/06 11:03:25 Call: finalResponse
2024/03/06 11:03:25 Final response: The forecast for Beijing is sunny and windy with a temperature of 6 degrees Celsius.
```