### PR TITLE
change mrkl-prompt to python version

### DIFF
--- a/agents/mrkl_prompt.go
+++ b/agents/mrkl_prompt.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	_defaultMrklPrefix = `Today is {{.today}} and you can use tools to get new information.
-Answer the following questions as best you can using the following tools:
+	_defaultMrklPrefix = `Today is {{.today}}.
+Answer the following questions as best you can. You have access to the following tools:
 
 {{.tool_descriptions}}`
 


### PR DESCRIPTION
change prompt the same as python version:
Current mrkl-prompt in langchaingo would get some very weird answer when I Don't need to use agent-tools in a agent conversation. 
Seems like It's forced llm to use some tool to get the Final Answer 

And this is langchain python mrkl-prompt:
```python
PREFIX = """Answer the following questions as best you can. You have access to the following tools:"""
FORMAT_INSTRUCTIONS = """Use the following format:
"""
```
This have no problem

---
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
