### PR TITLE
docs: fixup a bunch of links

### DIFF
--- a/docs/docs/modules/agents/index.mdx
+++ b/docs/docs/modules/agents/index.mdx
@@ -9,7 +9,7 @@ import DocCardList from "@theme/DocCardList";
 # Unfinished Agents
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/agents)
+[Conceptual Guide](https://python.langchain.com/docs/modules/agents)
 :::
 
 Some applications will require not just a predetermined chain of calls to LLMs/other tools, but potentially an unknown chain that depends on the user's input. In these types of chains, there is a “agent” which has access to a suite of tools. Depending on the user input, the agent can then decide which, if any, of these tools to call.

--- a/docs/docs/modules/agents/tools/index.mdx
+++ b/docs/docs/modules/agents/tools/index.mdx
@@ -8,5 +8,5 @@ import DocCardList from "@theme/DocCardList";
 # Tools
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/agents/tool)
+[Conceptual Guide](https://python.langchain.com/docs/modules/agents/tools)
 :::

--- a/docs/docs/modules/chains/index.mdx
+++ b/docs/docs/modules/chains/index.mdx
@@ -11,7 +11,7 @@ import CodeBlock from "@theme/CodeBlock";
 # Getting Started: Chains
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/chains)
+[Conceptual Guide](https://python.langchain.com/docs/modules/chains)
 :::info
 
 Using a language model in isolation is fine for some applications, but it is often useful to combine language models with other sources of information, third-party APIs, or even other language models. This is where the concept of a chain comes in.

--- a/docs/docs/modules/chains/llm_chain.mdx
+++ b/docs/docs/modules/chains/llm_chain.mdx
@@ -10,7 +10,7 @@ import ExampleLLM from "@examples/llm-chain-example/llm_chain.go";
 # Getting Started: LLMChain
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/chains/llm-chain)
+[Conceptual Guide](https://python.langchain.com/docs/modules/chains)
 :::
 
 An `LLMChain` is a simple chain that adds some functionality around language models. It is used widely throughout LangChain, including in other chains and agents.

--- a/docs/docs/modules/data_connection/document_loaders/index.mdx
+++ b/docs/docs/modules/data_connection/document_loaders/index.mdx
@@ -9,7 +9,7 @@ import DocCardList from "@theme/DocCardList";
 # Getting Started: Document Loaders
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/indexing/document-loaders)
+[Conceptual Guide](https://python.langchain.com/docs/modules/data_connection/document_loaders)
 :::
 
 Document loaders make it easy to create documents from a variety of sources. These documents can then be loaded onto [Vector Stores](../vector_stores/) to load documents from a source.

--- a/docs/docs/modules/data_connection/index.mdx
+++ b/docs/docs/modules/data_connection/index.mdx
@@ -9,7 +9,7 @@ import DocCardList from "@theme/DocCardList";
 # Data Connection 
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/indexing)
+[Conceptual Guide](https://python.langchain.com/docs/modules/data_connection/indexing)
 :::
 
 Many LLM applications require user-specific data that is not part of the model's training set. LangChain gives you the 

--- a/docs/docs/modules/data_connection/retrievers/index.mdx
+++ b/docs/docs/modules/data_connection/retrievers/index.mdx
@@ -8,7 +8,7 @@ import DocCardList from "@theme/DocCardList";
 # Retrievers
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/indexing/retriever)
+[Conceptual Guide](https://python.langchain.com/docs/modules/data_connection/retrievers/)
 :::
 
 <DocCardList />

--- a/docs/docs/modules/data_connection/text_splitters/index.mdx
+++ b/docs/docs/modules/data_connection/text_splitters/index.mdx
@@ -10,7 +10,7 @@ import CodeBlock from "@theme/CodeBlock";
 # Getting Started: Text Splitters
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/indexing/text-splitters)
+[Conceptual Guide](https://python.langchain.com/docs/modules/data_connection/document_transformers)
 :::
 
 Language Models are often limited by the amount of text that you can pass to them. Therefore, it is neccessary to split them up into smaller chunks. LangChain provides several utilities for doing so.

--- a/docs/docs/modules/data_connection/vector_stores/index.mdx
+++ b/docs/docs/modules/data_connection/vector_stores/index.mdx
@@ -7,7 +7,7 @@ draft: true
 # Getting Started: Vector Stores
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/indexing/vectorstore)
+[Conceptual Guide](https://python.langchain.com/docs/modules/data_connection/vectorstores)
 :::
 
 A vector store is a particular type of database optimized for storing documents and their [embeddings](../../models/embeddings/), and then fetching of the most relevant documents for a particular query, ie. those whose embeddings are most similar to the embedding of the query.

--- a/docs/docs/modules/memory/index.mdx
+++ b/docs/docs/modules/memory/index.mdx
@@ -9,7 +9,7 @@ import DocCardList from "@theme/DocCardList";
 # Getting Started: Memory
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/memory)
+[Conceptual Guide](https://python.langchain.com/docs/modules/memory)
 :::
 
 Memory is the concept of storing and retrieving data in the process of a conversation.

--- a/docs/docs/modules/model_io/models/chat/index.mdx
+++ b/docs/docs/modules/model_io/models/chat/index.mdx
@@ -10,7 +10,7 @@ import DocCardList from "@theme/DocCardList";
 # Getting Started: Chat Models
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/models/chat-model)
+[Conceptual Guide](https://python.langchain.com/docs/modules/model_io/chat)
 :::
 
 LangChain provides a standard interface for using chat models. Chat models are a variation on language models.

--- a/docs/docs/modules/model_io/models/embeddings/index.mdx
+++ b/docs/docs/modules/model_io/models/embeddings/index.mdx
@@ -11,7 +11,7 @@ import Example from "@examples/vertex-embedding-example/vertex-embedding-example
 # Getting Started: Embeddings
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/models/text-embedding-model)
+[Conceptual Guide](https://python.langchain.com/docs/modules/data_connection/text_embedding)
 :::
 
 Embeddings can be used to create a numerical representation of textual data. This numerical representation is useful because it can be used to find similar documents.

--- a/docs/docs/modules/model_io/models/index.mdx
+++ b/docs/docs/modules/model_io/models/index.mdx
@@ -9,7 +9,7 @@ import DocCardList from "@theme/DocCardList";
 # Models
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/models/)
+[Conceptual Guide](https://python.langchain.com/docs/modules/model_io)
 :::
 
 Models are a core component of LangChain. LangChain is not a provider of models, but rather provides a standard interface through which you can interact with a variety of language models.

--- a/docs/docs/modules/model_io/models/llms/index.mdx
+++ b/docs/docs/modules/model_io/models/llms/index.mdx
@@ -10,7 +10,7 @@ import DocCardList from "@theme/DocCardList";
 # LLMs
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/models/language-model)
+[Conceptual Guide](https://python.langchain.com/docs/modules/model_io/llms)
 :::
 
 Large Language Models (LLMs) are a core component of LangChain. 

--- a/docs/docs/modules/model_io/output_parsers/index.mdx
+++ b/docs/docs/modules/model_io/output_parsers/index.mdx
@@ -6,7 +6,7 @@ sidebar_position: 3
 # Output Parsers
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/prompts/output-parser)
+[Conceptual Guide](https://python.langchain.com/docs/modules/model_io/output_parsers)
 :::
 
 Language models output text. But many times you may want to get more structured information than just text back. This is where output parsers come in.

--- a/docs/docs/modules/model_io/prompts/index.mdx
+++ b/docs/docs/modules/model_io/prompts/index.mdx
@@ -9,7 +9,7 @@ import DocCardList from "@theme/DocCardList";
 # Prompts
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/prompts)
+[Conceptual Guide](https://python.langchain.com/docs/modules/model_io/prompts)
 :::
 
 A prompt refers to the input to a language model. This input is often constructed from multiple components. 

--- a/docs/docs/modules/model_io/prompts/prompt_templates/index.mdx
+++ b/docs/docs/modules/model_io/prompts/prompt_templates/index.mdx
@@ -10,7 +10,7 @@ import DocCardList from "@theme/DocCardList";
 # Prompt templates
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/prompts/prompt-template)
+[Conceptual Guide](https://python.langchain.com/docs/modules/model_io/prompts/quick_start#prompttemplate)
 :::
 
 A fundemental part of working with language models is taking some input and formatting it in some way using a template. 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -132,7 +132,7 @@ const config = {
         title: "🦜️🔗 LangChainGo",
         items: [
           {
-            href: "https://docs.langchain.com/docs/",
+            href: "https://python.langchain.com/docs/get_started/introduction/",
             label: "Concepts",
             position: "left",
           },


### PR DESCRIPTION
It seems like a bunch of links were broken and docs.langchain.com now redirects to the python docs.