### PR TITLE
documentloaders: add AssemblyAI document loader

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,6 +30,8 @@ linters:
     - ireturn # disabling temporarily
 
 linters-settings:
+  cyclop:
+    max-complexity: 12
   funlen:
     lines: 90
   depguard:

--- a/documentloaders/assemblyai.go
+++ b/documentloaders/assemblyai.go
@@ -1,0 +1,249 @@
+package documentloaders
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/AssemblyAI/assemblyai-go-sdk"
+	"github.com/tmc/langchaingo/schema"
+	"github.com/tmc/langchaingo/textsplitter"
+)
+
+// ErrMissingAudioSource is returned when neither an audio URL nor a reader has
+// been set using [WithAudioURL] or [WithAudioReader].
+var ErrMissingAudioSource = errors.New("assemblyai: missing audio source")
+
+var ErrUnsupportedTranscriptFormat = errors.New("assemblyai: unsupported transcript format")
+
+// TranscriptFormat represents the format of the document page content.
+type TranscriptFormat int
+
+const (
+	// Single document with full transcript text.
+	TranscriptFormatText TranscriptFormat = iota
+
+	// Multiple documents with each sentence as page content.
+	TranscriptFormatSentences
+
+	// Multiple documents with each paragraph as page content.
+	TranscriptFormatParagraphs
+
+	// Single document with SRT formatted subtitles as page content.
+	TranscriptFormatSubtitlesSRT
+
+	// Single document with VTT formatted subtitles as page content.
+	TranscriptFormatSubtitlesVTT
+)
+
+// AssemblyAIAudioTranscriptLoader transcribes an audio file using AssemblyAI
+// and loads the transcript.
+//
+// Audio files can be specified using either a URL or a reader.
+//
+// For a list of the supported audio and video formats, see the [FAQ].
+//
+// [FAQ]: https://www.assemblyai.com/docs/concepts/faq
+type AssemblyAIAudioTranscriptLoader struct {
+	client *assemblyai.Client
+
+	// URL of the audio file to transcribe.
+	url string
+
+	// Reader of the audio file to transcribe.
+	r io.Reader
+
+	// Optional parameters for the transcription.
+	params *assemblyai.TranscriptOptionalParams
+
+	// Format of the document page content.
+	format TranscriptFormat
+}
+
+var _ Loader = &AssemblyAIAudioTranscriptLoader{}
+
+type AssemblyAIOption func(loader *AssemblyAIAudioTranscriptLoader)
+
+// NewAssemblyAIAudioTranscript returns a new instance
+// AssemblyAIAudioTranscriptLoader.
+func NewAssemblyAIAudioTranscript(apiKey string, opts ...AssemblyAIOption) *AssemblyAIAudioTranscriptLoader {
+	loader := &AssemblyAIAudioTranscriptLoader{
+		client: assemblyai.NewClient(apiKey),
+		format: TranscriptFormatText,
+	}
+
+	for _, opt := range opts {
+		opt(loader)
+	}
+
+	return loader
+}
+
+// WithAudioURL configures the loader to transcribe an audio file from a URL.
+// The URL needs to be accessible from AssemblyAI's servers.
+func WithAudioURL(url string) AssemblyAIOption {
+	return func(a *AssemblyAIAudioTranscriptLoader) {
+		a.url = url
+	}
+}
+
+// WithAudioReader configures the loader to transcribe a local audio file.
+func WithAudioReader(r io.Reader) AssemblyAIOption {
+	return func(a *AssemblyAIAudioTranscriptLoader) {
+		a.r = r
+	}
+}
+
+// WithAudioReader configures the format of the document page content.
+func WithTranscriptFormat(format TranscriptFormat) AssemblyAIOption {
+	return func(a *AssemblyAIAudioTranscriptLoader) {
+		a.format = format
+	}
+}
+
+// WithTranscriptParams configures the optional parameters for the transcription.
+func WithTranscriptParams(params *assemblyai.TranscriptOptionalParams) AssemblyAIOption {
+	return func(a *AssemblyAIAudioTranscriptLoader) {
+		a.params = params
+	}
+}
+
+// Load transcribes an audio file, transcribes it using AssemblyAI, and returns
+// them transcript as a document.
+func (a *AssemblyAIAudioTranscriptLoader) Load(ctx context.Context) ([]schema.Document, error) {
+	transcript, err := a.transcribe(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	docs, err := a.formatTranscript(ctx, transcript)
+	if err != nil {
+		return nil, err
+	}
+
+	return docs, nil
+}
+
+// transcribe conditionally transcribes an audio file based on the specified
+// source.
+func (a *AssemblyAIAudioTranscriptLoader) transcribe(ctx context.Context) (assemblyai.Transcript, error) {
+	if a.url != "" {
+		return a.client.Transcripts.TranscribeFromURL(ctx, a.url, a.params)
+	}
+
+	if a.r != nil {
+		return a.client.Transcripts.TranscribeFromReader(ctx, a.r, a.params)
+	}
+
+	return assemblyai.Transcript{}, ErrMissingAudioSource
+}
+
+// formatTranscript returns a schema.Document for a transcript based on the
+// specific format.
+func (a *AssemblyAIAudioTranscriptLoader) formatTranscript(ctx context.Context, transcript assemblyai.Transcript) ([]schema.Document, error) {
+	switch a.format {
+	case TranscriptFormatSentences:
+		sentences, err := a.client.Transcripts.GetSentences(ctx, assemblyai.ToString(transcript.ID))
+		if err != nil {
+			return nil, err
+		}
+		return documentsFromSentences(sentences.Sentences)
+
+	case TranscriptFormatParagraphs:
+		paragraphs, err := a.client.Transcripts.GetParagraphs(ctx, assemblyai.ToString(transcript.ID))
+		if err != nil {
+			return nil, err
+		}
+		return documentsFromParagraphs(paragraphs.Paragraphs)
+
+	case TranscriptFormatSubtitlesSRT:
+		srt, err := a.client.Transcripts.GetSubtitles(ctx, assemblyai.ToString(transcript.ID), "srt", nil)
+		if err != nil {
+			return nil, err
+		}
+		return []schema.Document{{PageContent: string(srt)}}, nil
+
+	case TranscriptFormatSubtitlesVTT:
+		vtt, err := a.client.Transcripts.GetSubtitles(ctx, assemblyai.ToString(transcript.ID), "vtt", nil)
+		if err != nil {
+			return nil, err
+		}
+		return []schema.Document{{PageContent: string(vtt)}}, nil
+
+	case TranscriptFormatText:
+		fallthrough
+
+	default:
+		metadata, err := toMetadata(transcript)
+		if err != nil {
+			return nil, err
+		}
+		return []schema.Document{{PageContent: assemblyai.ToString(transcript.Text), Metadata: metadata}}, nil
+	}
+}
+
+func documentsFromSentences(sentences []assemblyai.TranscriptSentence) ([]schema.Document, error) {
+	docs := make([]schema.Document, 0, len(sentences))
+
+	for _, sentence := range sentences {
+		metadata, err := toMetadata(sentence)
+		if err != nil {
+			return nil, err
+		}
+
+		docs = append(docs, schema.Document{
+			PageContent: assemblyai.ToString(sentence.Text),
+			Metadata:    metadata,
+		})
+	}
+
+	return docs, nil
+}
+
+func documentsFromParagraphs(paragraphs []assemblyai.TranscriptParagraph) ([]schema.Document, error) {
+	docs := make([]schema.Document, 0, len(paragraphs))
+
+	for _, paragraph := range paragraphs {
+		metadata, err := toMetadata(paragraph)
+		if err != nil {
+			return nil, err
+		}
+
+		docs = append(docs, schema.Document{
+			PageContent: assemblyai.ToString(paragraph.Text),
+			Metadata:    metadata,
+		})
+	}
+
+	return docs, nil
+}
+
+// toMetadata converts a struct to a map representation to use as metadata.
+func toMetadata(obj any) (map[string]any, error) {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	var metadata map[string]any
+	if err := json.Unmarshal(b, &metadata); err != nil {
+		return nil, err
+	}
+
+	// Remove redundant transcript text.
+	delete(metadata, "text")
+
+	return metadata, nil
+}
+
+// LoadAndSplit transcribes the audio data and splits it into multiple documents
+// using a text splitter.
+func (a *AssemblyAIAudioTranscriptLoader) LoadAndSplit(ctx context.Context, splitter textsplitter.TextSplitter) ([]schema.Document, error) {
+	docs, err := a.Load(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return textsplitter.SplitDocuments(splitter, docs)
+}

--- a/documentloaders/assemblyai.go
+++ b/documentloaders/assemblyai.go
@@ -15,8 +15,6 @@ import (
 // been set using [WithAudioURL] or [WithAudioReader].
 var ErrMissingAudioSource = errors.New("assemblyai: missing audio source")
 
-var ErrUnsupportedTranscriptFormat = errors.New("assemblyai: unsupported transcript format")
-
 // TranscriptFormat represents the format of the document page content.
 type TranscriptFormat int
 
@@ -63,6 +61,7 @@ type AssemblyAIAudioTranscriptLoader struct {
 
 var _ Loader = &AssemblyAIAudioTranscriptLoader{}
 
+// AssemblyAIOption is an option for the AssemblyAI loader.
 type AssemblyAIOption func(loader *AssemblyAIAudioTranscriptLoader)
 
 // NewAssemblyAIAudioTranscript returns a new instance

--- a/documentloaders/assemblyai_test.go
+++ b/documentloaders/assemblyai_test.go
@@ -1,0 +1,54 @@
+package documentloaders
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	aai "github.com/AssemblyAI/assemblyai-go-sdk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssemblyAIAudioTranscriptLoader_Load(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	var apiKey string
+	if apiKey = os.Getenv("ASSEMBLYAI_API_KEY"); apiKey == "" {
+		t.Skip("ASSEMBLYAI_API_KEY not set")
+	}
+
+	audioURL := "https://github.com/AssemblyAI-Examples/audio-examples/raw/main/20230607_me_canadian_wildfires.mp3"
+
+	loader := NewAssemblyAIAudioTranscript(
+		apiKey,
+		WithAudioURL(audioURL),
+		WithTranscriptFormat(TranscriptFormatText),
+		WithTranscriptParams(&aai.TranscriptOptionalParams{
+			RedactPII:         aai.Bool(true),
+			RedactPIIPolicies: []aai.PIIPolicy{"person_name"},
+		}),
+	)
+
+	docs, err := loader.Load(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, docs, 1)
+
+	require.NotEmpty(t, docs[0].PageContent)
+	require.Equal(t, true, docs[0].Metadata["redact_pii"])
+}
+
+func TestAssemblyAIAudioTranscriptLoader_toMetadata(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := toMetadata(aai.TranscriptSentence{
+		Speaker: aai.String("1"),
+		Text:    aai.String("This is a test sentence."),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "1", metadata["speaker"])
+	require.Nil(t, metadata["text"])
+}

--- a/documentloaders/assemblyai_test.go
+++ b/documentloaders/assemblyai_test.go
@@ -37,7 +37,11 @@ func TestAssemblyAIAudioTranscriptLoader_Load(t *testing.T) {
 	require.Len(t, docs, 1)
 
 	require.NotEmpty(t, docs[0].PageContent)
-	require.Equal(t, true, docs[0].Metadata["redact_pii"])
+
+	redactPII, ok := docs[0].Metadata["redact_pii"].(bool)
+
+	require.True(t, ok)
+	require.True(t, redactPII)
 }
 
 func TestAssemblyAIAudioTranscriptLoader_toMetadata(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	cloud.google.com/go/iam v1.1.5 // indirect
 	cloud.google.com/go/longrunning v0.5.4 // indirect
 	dario.cat/mergo v1.0.0 // indirect
+	github.com/AssemblyAI/assemblyai-go-sdk v1.3.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
@@ -50,6 +51,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.1 // indirect
 	github.com/aws/smithy-go v1.20.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cockroachdb/errors v1.9.1 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f // indirect
@@ -82,6 +84,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/flatbuffers v23.5.26+incompatible // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
@@ -166,6 +169,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240123012728-ef4313101c80 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240123012728-ef4313101c80 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	nhooyr.io/websocket v1.8.7 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9vkmnHYOMsOr4WLk+Vo07yKIzd94sVoIqshQ4bU=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
+github.com/AssemblyAI/assemblyai-go-sdk v1.3.0 h1:AtOVgGxUycvK4P4ypP+1ZupecvFgnfH+Jsum0o5ILoU=
+github.com/AssemblyAI/assemblyai-go-sdk v1.3.0/go.mod h1:H0naZbvpIW49cDA5ZZ/gggeXqi7ojSGB1mqshRk6kNE=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -134,6 +136,8 @@ github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngE
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bugsnag/bugsnag-go v1.4.0/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/panicwrap v1.2.0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -219,7 +223,9 @@ github.com/getsentry/sentry-go v0.12.0 h1:era7g0re5iY13bHSdN/xMkyV+5zZppjRVQhZrX
 github.com/getsentry/sentry-go v0.12.0/go.mod h1:NSap0JBYWzHND8oMbyi0+XZhUalc1TBdRL1M71JZW2c=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
+github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
+github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127 h1:0gkP6mzaMqkmpcJYCFOLkIBwI7xFExG03bbkOkCvUPI=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
@@ -270,6 +276,10 @@ github.com/go-pg/pg/v10 v10.11.0 h1:CMKJqLgTrfpE/aOVeLdybezR2om071Vh38OLZjsyMI0=
 github.com/go-pg/pg/v10 v10.11.0/go.mod h1:4BpHRoxE61y4Onpof3x1a2SQvi9c+q1dJnrNdMjsroA=
 github.com/go-pg/zerochecker v0.2.0 h1:pp7f72c3DobMWOb2ErtZsnrPaSvHd2W4o9//8HtF4mU=
 github.com/go-pg/zerochecker v0.2.0/go.mod h1:NJZ4wKL0NmTtz0GKCoJ8kym6Xn/EQzXRl2OnAe7MmDo=
+github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
+github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
+github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
 github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -368,6 +378,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -461,6 +473,7 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.8.2/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.17.2 h1:RlWWUY/Dr4fL8qk9YG7DTZ7PDgME2V4csBXA8L/ixi4=
 github.com/klauspost/compress v1.17.2/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
@@ -480,6 +493,7 @@ github.com/labstack/echo/v4 v4.5.0/go.mod h1:czIriw4a0C1dFun+ObrXp7ok03xON0N1awS
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kULo2bwGEkFvCePZ3qHDDTC3/J9Swo=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
+github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
@@ -1227,6 +1241,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 mellium.im/sasl v0.3.1 h1:wE0LW6g7U83vhvxjC1IY8DnXM+EU095yeo8XClvCdfo=
 mellium.im/sasl v0.3.1/go.mod h1:xm59PUYpZHhgQ9ZqoJ5QaCqzWMi8IeS49dhp6plPCzw=
+nhooyr.io/websocket v1.8.7 h1:usjR2uOr/zjjkVMy0lW+PPohFok7PCow5sDjLgX4P4g=
+nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
This PR adds the AssemblyAI document loader from [LangChain](https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/document_loaders/assemblyai.py) and [LangChain JS](https://github.com/langchain-ai/langchainjs/blob/main/langchain/src/document_loaders/web/assemblyai.ts).

Unfortunately, due to the number of supported formats (in `formatTranscript()`), I had to increase the `cyclop` max complexity from 10 to 12. I first tried to break up the switch case, but then the `exhaustive` check failed. 

I could also split the loader into a loader for each format. Let me know if you'd prefer it that way.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
