### PR TITLE
llms/anthropic: Implement WithBaseURL and WithHTTPClient for Anthropic LLM

### DIFF
--- a/llms/anthropic/anthropicllm.go
+++ b/llms/anthropic/anthropicllm.go
@@ -36,7 +36,7 @@ func New(opts ...Option) (*LLM, error) {
 func newClient(opts ...Option) (*anthropicclient.Client, error) {
 	options := &options{
 		token:      os.Getenv(tokenEnvVarName),
-		baseUrl:    anthropicclient.DefaultBaseURL,
+		baseURL:    anthropicclient.DefaultBaseURL,
 		httpClient: http.DefaultClient,
 	}
 

--- a/llms/anthropic/anthropicllm.go
+++ b/llms/anthropic/anthropicllm.go
@@ -3,6 +3,7 @@ package anthropic
 import (
 	"context"
 	"errors"
+	"net/http"
 	"os"
 
 	"github.com/tmc/langchaingo/callbacks"
@@ -34,7 +35,9 @@ func New(opts ...Option) (*LLM, error) {
 
 func newClient(opts ...Option) (*anthropicclient.Client, error) {
 	options := &options{
-		token: os.Getenv(tokenEnvVarName),
+		token:      os.Getenv(tokenEnvVarName),
+		baseUrl:    anthropicclient.DefaultBaseURL,
+		httpClient: http.DefaultClient,
 	}
 
 	for _, opt := range opts {
@@ -45,7 +48,7 @@ func newClient(opts ...Option) (*anthropicclient.Client, error) {
 		return nil, ErrMissingToken
 	}
 
-	return anthropicclient.New(options.token, options.model)
+	return anthropicclient.New(options.token, options.model, options.baseUrl, options.httpClient)
 }
 
 // Call requests a completion for the given prompt.

--- a/llms/anthropic/anthropicllm.go
+++ b/llms/anthropic/anthropicllm.go
@@ -48,7 +48,7 @@ func newClient(opts ...Option) (*anthropicclient.Client, error) {
 		return nil, ErrMissingToken
 	}
 
-	return anthropicclient.New(options.token, options.model, options.baseUrl, options.httpClient)
+	return anthropicclient.New(options.token, options.model, options.baseURL, options.httpClient)
 }
 
 // Call requests a completion for the given prompt.

--- a/llms/anthropic/anthropicllm_option.go
+++ b/llms/anthropic/anthropicllm_option.go
@@ -11,7 +11,7 @@ const (
 type options struct {
 	token      string
 	model      string
-	baseUrl    string
+	baseURL    string
 	httpClient anthropicclient.Doer
 }
 

--- a/llms/anthropic/anthropicllm_option.go
+++ b/llms/anthropic/anthropicllm_option.go
@@ -42,7 +42,7 @@ func WithBaseURL(baseURL string) Option {
 
 // WithHTTPClient allows setting a custom HTTP client. If not set, the default value
 // is http.DefaultClient.
-func WithHTTPClient(client openaiclient.Doer) Option {
+func WithHTTPClient(client anthropicclient.Doer) Option {
 	return func(opts *options) {
 		opts.httpClient = client
 	}

--- a/llms/anthropic/anthropicllm_option.go
+++ b/llms/anthropic/anthropicllm_option.go
@@ -1,12 +1,18 @@
 package anthropic
 
+import (
+	"github.com/tmc/langchaingo/llms/anthropic/internal/anthropicclient"
+)
+
 const (
 	tokenEnvVarName = "ANTHROPIC_API_KEY" //nolint:gosec
 )
 
 type options struct {
-	token string
-	model string
+	token      string
+	model      string
+	baseUrl    string
+	httpClient anthropicclient.Doer
 }
 
 type Option func(*options)
@@ -23,5 +29,21 @@ func WithToken(token string) Option {
 func WithModel(model string) Option {
 	return func(opts *options) {
 		opts.model = model
+	}
+}
+
+// WithBaseUrl passes the Anthropic base URL to the client.
+// If not set, the default base URL is used.
+func WithBaseURL(baseURL string) Option {
+	return func(opts *options) {
+		opts.baseURL = baseURL
+	}
+}
+
+// WithHTTPClient allows setting a custom HTTP client. If not set, the default value
+// is http.DefaultClient.
+func WithHTTPClient(client openaiclient.Doer) Option {
+	return func(opts *options) {
+		opts.httpClient = client
 	}
 }

--- a/llms/anthropic/internal/anthropicclient/anthropicclient.go
+++ b/llms/anthropic/internal/anthropicclient/anthropicclient.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 )
 
 const (
-	defaultBaseURL = "https://api.anthropic.com/v1"
+	DefaultBaseURL = "https://api.anthropic.com/v1"
 )
 
 // ErrEmptyResponse is returned when the Anthropic API returns an empty response.
@@ -40,12 +41,12 @@ func WithHTTPClient(client Doer) Option {
 }
 
 // New returns a new Anthropic client.
-func New(token string, model string, opts ...Option) (*Client, error) {
+func New(token string, model string, baseUrl string, httpClient Doer, opts ...Option) (*Client, error) {
 	c := &Client{
 		Model:      model,
 		token:      token,
-		baseURL:    defaultBaseURL,
-		httpClient: http.DefaultClient,
+		baseURL:    strings.TrimSuffix(baseURL, "/"),
+		httpClient: httpClient,
 	}
 
 	for _, opt := range opts {

--- a/llms/anthropic/internal/anthropicclient/anthropicclient.go
+++ b/llms/anthropic/internal/anthropicclient/anthropicclient.go
@@ -41,11 +41,11 @@ func WithHTTPClient(client Doer) Option {
 }
 
 // New returns a new Anthropic client.
-func New(token string, model string, baseUrl string, httpClient Doer, opts ...Option) (*Client, error) {
+func New(token string, model string, baseURL string, httpClient Doer, opts ...Option) (*Client, error) {
 	c := &Client{
 		Model:      model,
 		token:      token,
-		baseURL:    strings.TrimSuffix(baseUrl, "/"),
+		baseURL:    strings.TrimSuffix(baseURL, "/"),
 		httpClient: httpClient,
 	}
 

--- a/llms/anthropic/internal/anthropicclient/anthropicclient.go
+++ b/llms/anthropic/internal/anthropicclient/anthropicclient.go
@@ -45,7 +45,7 @@ func New(token string, model string, baseUrl string, httpClient Doer, opts ...Op
 	c := &Client{
 		Model:      model,
 		token:      token,
-		baseURL:    strings.TrimSuffix(baseURL, "/"),
+		baseURL:    strings.TrimSuffix(baseUrl, "/"),
 		httpClient: httpClient,
 	}
 

--- a/llms/anthropic/internal/anthropicclient/completions.go
+++ b/llms/anthropic/internal/anthropicclient/completions.go
@@ -80,7 +80,7 @@ func (c *Client) createCompletion(ctx context.Context, payload *completionPayloa
 	}
 
 	if c.baseURL == "" {
-		c.baseURL = defaultBaseURL
+		c.baseURL = DefaultBaseURL
 	}
 
 	url := fmt.Sprintf("%s/complete", c.baseURL)


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

This PR implements the WithBaseURL and WithHTTPClient options for the anthropic llms and wires them up. This implementation was derived from the `llms/openai` implementation. This is needed to enable using a tool such as [Helicone](https://www.helicone.ai) with the Anthropic models (I suspect more people may start using them thanks to Claude 3).
