### PR TITLE
llms/openai: Azure: add check for `model` parameter

### DIFF
--- a/llms/openai/llm.go
+++ b/llms/openai/llm.go
@@ -9,9 +9,9 @@ import (
 )
 
 var (
-	ErrEmptyResponse              = errors.New("no response")
-	ErrMissingToken               = errors.New("missing the OpenAI API key, set it in the OPENAI_API_KEY environment variable") //nolint:lll
-	ErrMissingAzureEmbeddingModel = errors.New("embeddings model needs to be provided when using Azure API")
+	ErrEmptyResponse     = errors.New("no response")
+	ErrMissingToken      = errors.New("missing the OpenAI API key, set it in the OPENAI_API_KEY environment variable") //nolint:lll
+	ErrMissingAzureModel = errors.New("model needs to be provided when using Azure API")
 
 	ErrUnexpectedResponseLength = errors.New("unexpected length of response")
 )
@@ -34,8 +34,8 @@ func newClient(opts ...Option) (*options, *openaiclient.Client, error) {
 	// set of options needed for Azure client
 	if openaiclient.IsAzure(openaiclient.APIType(options.apiType)) && options.apiVersion == "" {
 		options.apiVersion = DefaultAPIVersion
-		if options.embeddingModel == "" {
-			return options, nil, ErrMissingAzureEmbeddingModel
+		if options.model == "" {
+			return options, nil, ErrMissingAzureModel
 		}
 	}
 

--- a/llms/openai/llm.go
+++ b/llms/openai/llm.go
@@ -9,9 +9,10 @@ import (
 )
 
 var (
-	ErrEmptyResponse     = errors.New("no response")
-	ErrMissingToken      = errors.New("missing the OpenAI API key, set it in the OPENAI_API_KEY environment variable") //nolint:lll
-	ErrMissingAzureModel = errors.New("model needs to be provided when using Azure API")
+	ErrEmptyResponse              = errors.New("no response")
+	ErrMissingToken               = errors.New("missing the OpenAI API key, set it in the OPENAI_API_KEY environment variable") //nolint:lll
+	ErrMissingAzureModel          = errors.New("model needs to be provided when using Azure API")
+	ErrMissingAzureEmbeddingModel = errors.New("embeddings model needs to be provided when using Azure API")
 
 	ErrUnexpectedResponseLength = errors.New("unexpected length of response")
 )
@@ -36,6 +37,9 @@ func newClient(opts ...Option) (*options, *openaiclient.Client, error) {
 		options.apiVersion = DefaultAPIVersion
 		if options.model == "" {
 			return options, nil, ErrMissingAzureModel
+		}
+		if options.embeddingModel == "" {
+			return options, nil, ErrMissingAzureEmbeddingModel
 		}
 	}
 

--- a/llms/openai/openaillm_option.go
+++ b/llms/openai/openaillm_option.go
@@ -68,7 +68,7 @@ func WithModel(model string) Option {
 	}
 }
 
-// WithEmbeddingModel passes the OpenAI model to the client.
+// WithEmbeddingModel passes the OpenAI model to the client. Required when ApiType is Azure.
 func WithEmbeddingModel(embeddingModel string) Option {
 	return func(opts *options) {
 		opts.embeddingModel = embeddingModel

--- a/llms/openai/openaillm_option.go
+++ b/llms/openai/openaillm_option.go
@@ -61,13 +61,14 @@ func WithToken(token string) Option {
 
 // WithModel passes the OpenAI model to the client. If not set, the model
 // is read from the OPENAI_MODEL environment variable.
+// Required when ApiType is Azure.
 func WithModel(model string) Option {
 	return func(opts *options) {
 		opts.model = model
 	}
 }
 
-// WithEmbeddingModel passes the OpenAI model to the client. Required when ApiType is Azure.
+// WithEmbeddingModel passes the OpenAI model to the client.
 func WithEmbeddingModel(embeddingModel string) Option {
 	return func(opts *options) {
 		opts.embeddingModel = embeddingModel


### PR DESCRIPTION
Using the `openai.New()` for models with `APITypeAzure`  without the `model` parameter results in a missing path parameter. Example from request dump: 
```
POST /openai/deployments//chat/completions?api-version=2024-02-15-preview HTTP/1.1
```

### How to test?

Create a new Azure OpenAI LLM using this code:
```go
llm, err := openai.New(
		openai.WithAPIType(openai.APITypeAzure),
		openai.WithToken(token),
		openai.WithBaseURL(baseURL),
		openai.WithEmbeddingModel("text-embedding-ada-002"),
		openai.WithAPIVersion("2024-02-15-preview"),
	)
```
This should fail with a 404 status - url is set to one like above.
Add the `WithModel` parameter, like this:
```go
llm, err := openai.New(
		openai.WithAPIType(openai.APITypeAzure),
		openai.WithToken(token),
		openai.WithBaseURL(baseURL),
		openai.WithModel("openai-gpt-35-turbo"),
		openai.WithEmbeddingModel("text-embedding-ada-002"),
		openai.WithAPIVersion("2024-02-15-preview"),
	)
```
The request should be executed successfully.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
