### PR TITLE
github: Add docs site previews publishing 

### DIFF
--- a/.github/workflows/preview-docs.yaml
+++ b/.github/workflows/preview-docs.yaml
@@ -10,9 +10,6 @@ on:
 
 jobs:
   preview:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/preview-docs.yaml
+++ b/.github/workflows/preview-docs.yaml
@@ -1,22 +1,15 @@
-name: Deploy to GitHub Pages
+name: Preview Documentation Site
 
 on:
   push:
     branches:
       - main
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  pull_request:
+    branches:
+      - main
 
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
+  preview:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -29,21 +22,13 @@ jobs:
           node-version: 18
           cache: yarn
           cache-dependency-path: "docs/package-lock.json"
-
       - name: Install dependencies
         working-directory: docs
         run: yarn install --frozen-lockfile
       - name: Build website
         working-directory: docs
         run: yarn build
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+      - name: Preview Pages
+        uses: rajyan/preview-pages@v1
         with:
-          # Upload entire repository
-          path: "docs/build"
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+          source-dir: "docs/build"

--- a/.github/workflows/preview-docs.yaml
+++ b/.github/workflows/preview-docs.yaml
@@ -2,11 +2,7 @@ name: Preview Documentation Site
 
 on:
   pull_request:
-    paths:
-      - docs/**
   push:
-    paths:
-      - docs/**
     branches:
       - main
 

--- a/.github/workflows/preview-docs.yaml
+++ b/.github/workflows/preview-docs.yaml
@@ -28,6 +28,8 @@ jobs:
       - name: Build website
         working-directory: docs
         run: yarn build
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
       - name: Preview Pages
         uses: rajyan/preview-pages@v1
         with:

--- a/.github/workflows/preview-docs.yaml
+++ b/.github/workflows/preview-docs.yaml
@@ -2,7 +2,11 @@ name: Preview Documentation Site
 
 on:
   pull_request:
+    paths:
+      - docs/**
   push:
+    paths:
+      - docs/**
     branches:
       - main
 

--- a/.github/workflows/preview-docs.yaml
+++ b/.github/workflows/preview-docs.yaml
@@ -1,12 +1,18 @@
 name: Preview Documentation Site
 
 on:
+  pull_request:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+
+permissions:
+  pull-requests: write
+  contents: write
+
+concurrency:
+  group: preview-pages-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   preview:

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: 18
           cache: yarn
-          cache-dependency-path: 'docs/package-lock.json'
+          cache-dependency-path: "docs/package-lock.json"
 
       - name: Install dependencies
         working-directory: docs
@@ -43,7 +43,12 @@ jobs:
         uses: actions/upload-pages-artifact@v2
         with:
           # Upload entire repository
-          path: 'docs/build'
+          path: "docs/build"
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2
+
+      - name: Preview Pages
+        uses: rajyan/preview-pages@v1
+        with:
+          source-dir: "docs/build"

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: 18
           cache: yarn
-          cache-dependency-path: "docs/package-lock.json"
+          cache-dependency-path: 'docs/package-lock.json'
 
       - name: Install dependencies
         working-directory: docs
@@ -43,7 +43,7 @@ jobs:
         uses: actions/upload-pages-artifact@v2
         with:
           # Upload entire repository
-          path: "docs/build"
+          path: 'docs/build'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2


### PR DESCRIPTION
This adds docs site preview rendering+publishing for pushes/PRs which should assist in documentation contributors.