### PR TITLE
tests: Perform env-var checking skips sooner as to speed up tests

### DIFF
--- a/vectorstores/chroma/chroma_test.go
+++ b/vectorstores/chroma/chroma_test.go
@@ -562,6 +562,11 @@ func TestChromaAsRetrieverWithMetadataFilters(t *testing.T) {
 func getValues(t *testing.T) (string, string) {
 	t.Helper()
 
+	openaiAPIKey := os.Getenv(chroma.OpenAIAPIKeyEnvVarName)
+	if openaiAPIKey == "" {
+		t.Skipf("Must set %s to run test", chroma.OpenAIAPIKeyEnvVarName)
+	}
+
 	chromaURL := os.Getenv(chroma.ChromaURLKeyEnvVarName)
 	if chromaURL == "" {
 		chromaContainer, err := tcchroma.RunContainer(context.Background(), testcontainers.WithImage("chromadb/chroma:0.4.24"))
@@ -577,11 +582,6 @@ func getValues(t *testing.T) (string, string) {
 		if err != nil {
 			t.Skipf("Failed to get chroma container REST endpoint: %s", err)
 		}
-	}
-
-	openaiAPIKey := os.Getenv(chroma.OpenAIAPIKeyEnvVarName)
-	if openaiAPIKey == "" {
-		t.Skipf("Must set %s to run test", chroma.OpenAIAPIKeyEnvVarName)
 	}
 
 	return chromaURL, openaiAPIKey

--- a/vectorstores/milvus/milvus_test.go
+++ b/vectorstores/milvus/milvus_test.go
@@ -36,6 +36,11 @@ func getEmbedder(t *testing.T) (embeddings.Embedder, error) {
 
 func getNewStore(t *testing.T, opts ...Option) (Store, error) {
 	t.Helper()
+	e, err := getEmbedder(t)
+	if err != nil {
+		return Store{}, err
+	}
+
 	url := os.Getenv("MILVUS_URL")
 	if url == "" {
 		milvusContainer, err := tcmilvus.RunContainer(context.Background(), testcontainers.WithImage("milvusdb/milvus:v2.3.9"))
@@ -54,10 +59,6 @@ func getNewStore(t *testing.T, opts ...Option) (Store, error) {
 	}
 	config := client.Config{
 		Address: url,
-	}
-	e, err := getEmbedder(t)
-	if err != nil {
-		return Store{}, err
 	}
 	idx, err := entity.NewIndexAUTOINDEX(entity.L2)
 	if err != nil {

--- a/vectorstores/opensearch/opensearch_test.go
+++ b/vectorstores/opensearch/opensearch_test.go
@@ -26,6 +26,11 @@ func getEnvVariables(t *testing.T) (string, string, string) {
 	var osUser string
 	var osPassword string
 
+	openaiKey := os.Getenv("OPENAI_API_KEY")
+	if openaiKey == "" {
+		t.Skipf("Must set %s to run test", "OPENAI_API_KEY")
+	}
+
 	opensearchEndpoint := os.Getenv("OPENSEARCH_ENDPOINT")
 	if opensearchEndpoint == "" {
 		openseachContainer, err := tcopensearch.RunContainer(context.Background(), testcontainers.WithImage("opensearchproject/opensearch:2.11.1"))
@@ -61,10 +66,6 @@ func getEnvVariables(t *testing.T) (string, string, string) {
 		if opensearchPassword == "" {
 			t.Skipf("Must set %s to run test", "OPENSEARCH_PASSWORD")
 		}
-	}
-	openaiKey := os.Getenv("OPENAI_API_KEY")
-	if openaiKey == "" {
-		t.Skipf("Must set %s to run test", "OPENAI_API_KEY")
 	}
 
 	return opensearchEndpoint, opensearchUser, opensearchPassword


### PR DESCRIPTION
Fixes #705 by running env checks sooner.