### PR TITLE
llms/anthropic: adds full support for messages api

### DIFF
--- a/examples/anthropic-completion-example/anthropic_completion_example.go
+++ b/examples/anthropic-completion-example/anthropic_completion_example.go
@@ -10,13 +10,14 @@ import (
 )
 
 func main() {
-	llm, err := anthropic.New()
-	// note: You would include anthropic.WithModel("claude-2") to use the claude-2 model.
+	llm, err := anthropic.New(
+		anthropic.WithModel("claude-3-opus-20240229"),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
 	ctx := context.Background()
-	completion, err := llms.GenerateFromSinglePrompt(ctx, llm, "Human: Who was the first man to walk on the moon?\nAssistant:",
+	completion, err := llms.GenerateFromSinglePrompt(ctx, llm, "Hi claude, write a poem about golang powered AI systems",
 		llms.WithTemperature(0.8),
 		llms.WithStreamingFunc(func(ctx context.Context, chunk []byte) error {
 			fmt.Print(string(chunk))

--- a/llms/anthropic/anthropicllm.go
+++ b/llms/anthropic/anthropicllm.go
@@ -43,10 +43,9 @@ func New(opts ...Option) (*LLM, error) {
 
 func newClient(opts ...Option) (*anthropicclient.Client, error) {
 	options := &options{
-		token:             os.Getenv(tokenEnvVarName),
-		baseURL:           anthropicclient.DefaultBaseURL,
-		httpClient:        http.DefaultClient,
-		useCompletionsAPI: true,
+		token:      os.Getenv(tokenEnvVarName),
+		baseURL:    anthropicclient.DefaultBaseURL,
+		httpClient: http.DefaultClient,
 	}
 
 	for _, opt := range opts {
@@ -57,7 +56,10 @@ func newClient(opts ...Option) (*anthropicclient.Client, error) {
 		return nil, ErrMissingToken
 	}
 
-	return anthropicclient.New(options.token, options.model, options.baseURL, options.httpClient)
+	return anthropicclient.New(options.token, options.model, options.baseURL,
+		anthropicclient.WithHTTPClient(options.httpClient),
+		anthropicclient.WithLegacyTextCompletionsAPI(options.useLegacyTextCompletionsAPI),
+	)
 }
 
 // Call requests a completion for the given prompt.
@@ -76,7 +78,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		opt(opts)
 	}
 
-	if o.client.UseCompletionsAPI {
+	if o.client.UseLegacyTextCompletionsAPI {
 		return generateCompletionsContent(ctx, o, messages, opts)
 	}
 	return generateMessagesContent(ctx, o, messages, opts)

--- a/llms/anthropic/anthropicllm_option.go
+++ b/llms/anthropic/anthropicllm_option.go
@@ -9,10 +9,11 @@ const (
 )
 
 type options struct {
-	token      string
-	model      string
-	baseURL    string
-	httpClient anthropicclient.Doer
+	token             string
+	model             string
+	baseURL           string
+	httpClient        anthropicclient.Doer
+	useCompletionsAPI bool
 }
 
 type Option func(*options)
@@ -45,5 +46,12 @@ func WithBaseURL(baseURL string) Option {
 func WithHTTPClient(client anthropicclient.Doer) Option {
 	return func(opts *options) {
 		opts.httpClient = client
+	}
+}
+
+// WithMessagesAPI allows setting the client to use the messages API.
+func WithMessagesAPI() Option {
+	return func(opts *options) {
+		opts.useCompletionsAPI = false
 	}
 }

--- a/llms/anthropic/anthropicllm_option.go
+++ b/llms/anthropic/anthropicllm_option.go
@@ -9,11 +9,12 @@ const (
 )
 
 type options struct {
-	token             string
-	model             string
-	baseURL           string
-	httpClient        anthropicclient.Doer
-	useCompletionsAPI bool
+	token      string
+	model      string
+	baseURL    string
+	httpClient anthropicclient.Doer
+
+	useLegacyTextCompletionsAPI bool
 }
 
 type Option func(*options)
@@ -49,9 +50,9 @@ func WithHTTPClient(client anthropicclient.Doer) Option {
 	}
 }
 
-// WithMessagesAPI allows setting the client to use the messages API.
-func WithMessagesAPI() Option {
+// WithLegacyTextCompletionsAPI enables the use of the legacy text completions API.
+func WithLegacyTextCompletionsAPI() Option {
 	return func(opts *options) {
-		opts.useCompletionsAPI = false
+		opts.useLegacyTextCompletionsAPI = true
 	}
 }

--- a/llms/anthropic/internal/anthropicclient/anthropicclient.go
+++ b/llms/anthropic/internal/anthropicclient/anthropicclient.go
@@ -27,7 +27,8 @@ type Client struct {
 
 	httpClient Doer
 
-	UseCompletionsAPI bool
+	// UseLegacyTextCompletionsAPI is a flag to use the legacy text completions API.
+	UseLegacyTextCompletionsAPI bool
 }
 
 // Option is an option for the Anthropic client.
@@ -47,13 +48,20 @@ func WithHTTPClient(client Doer) Option {
 	}
 }
 
+// WithLegacyTextCompletionsAPI enables the use of the legacy text completions API.
+func WithLegacyTextCompletionsAPI(val bool) Option {
+	return func(opts *Client) error {
+		opts.UseLegacyTextCompletionsAPI = val
+		return nil
+	}
+}
+
 // New returns a new Anthropic client.
-func New(token string, model string, baseURL string, httpClient Doer, opts ...Option) (*Client, error) {
+func New(token string, model string, baseURL string, opts ...Option) (*Client, error) {
 	c := &Client{
-		Model:      model,
-		token:      token,
-		baseURL:    strings.TrimSuffix(baseURL, "/"),
-		httpClient: httpClient,
+		Model:   model,
+		token:   token,
+		baseURL: strings.TrimSuffix(baseURL, "/"),
 	}
 
 	for _, opt := range opts {

--- a/llms/anthropic/internal/anthropicclient/anthropicclient.go
+++ b/llms/anthropic/internal/anthropicclient/anthropicclient.go
@@ -9,6 +9,8 @@ import (
 
 const (
 	DefaultBaseURL = "https://api.anthropic.com/v1"
+
+	defaultModel = "claude-1.3"
 )
 
 // ErrEmptyResponse is returned when the Anthropic API returns an empty response.
@@ -21,6 +23,8 @@ type Client struct {
 	baseURL string
 
 	httpClient Doer
+
+	UseCompletionsAPI bool
 }
 
 // Option is an option for the Anthropic client.
@@ -98,9 +102,48 @@ func (c *Client) CreateCompletion(ctx context.Context, r *CompletionRequest) (*C
 	}, nil
 }
 
+type MessageRequest struct {
+	Model       string        `json:"model"`
+	Messages    []ChatMessage `json:"messages"`
+	System      string        `json:"system,omitempty"`
+	Temperature float64       `json:"temperature"`
+	MaxTokens   int           `json:"max_tokens,omitempty"`
+	TopP        float64       `json:"top_p,omitempty"`
+	StopWords   []string      `json:"stop_sequences,omitempty"`
+	Stream      bool          `json:"stream,omitempty"`
+
+	StreamingFunc func(ctx context.Context, chunk []byte) error `json:"-"`
+}
+
+// CreateMessage creates message for the messages api
+func (c *Client) CreateMessage(ctx context.Context, r *MessageRequest) (*MessageResponsePayload, error) {
+	resp, err := c.createMessage(ctx, &messagePayload{
+		Model:         r.Model,
+		Messages:      r.Messages,
+		System:        r.System,
+		Temperature:   r.Temperature,
+		MaxTokens:     r.MaxTokens,
+		StopWords:     r.StopWords,
+		TopP:          r.TopP,
+		Stream:        r.Stream,
+		StreamingFunc: r.StreamingFunc,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
 func (c *Client) setHeaders(req *http.Request) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-api-key", c.token)
 	// TODO: expose version as a option/parameter
 	req.Header.Set("anthropic-version", "2023-06-01")
+}
+
+type errorMessage struct {
+	Error struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+	} `json:"error"`
 }

--- a/llms/anthropic/internal/anthropicclient/completions.go
+++ b/llms/anthropic/internal/anthropicclient/completions.go
@@ -12,10 +12,6 @@ import (
 	"strings"
 )
 
-const (
-	defaultCompletionModel = "claude-1"
-)
-
 type completionPayload struct {
 	Model       string   `json:"model"`
 	Prompt      string   `json:"prompt"`
@@ -34,13 +30,6 @@ type CompletionResponsePayload struct {
 	Model      string `json:"model,omitempty"`
 	Stop       string `json:"stop,omitempty"`
 	StopReason string `json:"stop_reason,omitempty"`
-}
-
-type errorMessage struct {
-	Error struct {
-		Message string `json:"message"`
-		Type    string `json:"type"`
-	} `json:"error"`
 }
 
 func (c *Client) setCompletionDefaults(payload *completionPayload) {
@@ -62,7 +51,7 @@ func (c *Client) setCompletionDefaults(payload *completionPayload) {
 		payload.Model = c.Model
 	// Fallback: use the default model
 	default:
-		payload.Model = defaultCompletionModel
+		payload.Model = defaultModel
 	}
 	if payload.StreamingFunc != nil {
 		payload.Stream = true

--- a/llms/anthropic/internal/anthropicclient/messages.go
+++ b/llms/anthropic/internal/anthropicclient/messages.go
@@ -1,0 +1,214 @@
+package anthropicclient
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+)
+
+type ChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type messagePayload struct {
+	Model       string        `json:"model"`
+	Messages    []ChatMessage `json:"messages"`
+	System      string        `json:"system,omitempty"`
+	MaxTokens   int           `json:"max_tokens,omitempty"`
+	StopWords   []string      `json:"stop_sequences,omitempty"`
+	Stream      bool          `json:"stream,omitempty"`
+	Temperature float64       `json:"temperature"`
+	TopP        float64       `json:"top_p,omitempty"`
+
+	StreamingFunc func(ctx context.Context, chunk []byte) error `json:"-"`
+}
+
+type MessageResponsePayload struct {
+	Content []struct {
+		Text string `json:"text"`
+		Type string `json:"type"`
+	} `json:"content"`
+	ID           string `json:"id"`
+	Model        string `json:"model"`
+	Role         string `json:"role"`
+	StopReason   string `json:"stop_reason"`
+	StopSequence string `json:"stop_sequence"`
+	Type         string `json:"type"`
+	Usage        struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	}
+}
+
+func (c *Client) setMessageDefaults(payload *messagePayload) {
+	// Set defaults
+	if payload.MaxTokens == 0 {
+		payload.MaxTokens = 256
+	}
+
+	if len(payload.StopWords) == 0 {
+		payload.StopWords = nil
+	}
+
+	switch {
+	// Prefer the model specified in the payload.
+	case payload.Model != "":
+
+	// If no model is set in the payload, take the one specified in the client.
+	case c.Model != "":
+		payload.Model = c.Model
+	// Fallback: use the default model
+	default:
+		payload.Model = defaultModel
+	}
+	if payload.StreamingFunc != nil {
+		payload.Stream = true
+	}
+}
+
+func (c *Client) createMessage(ctx context.Context, payload *messagePayload) (*MessageResponsePayload, error) {
+	c.setMessageDefaults(payload)
+
+	// Build request payload
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal payload: %w", err)
+	}
+
+	if c.baseURL == "" {
+		c.baseURL = DefaultBaseURL
+	}
+
+	url := fmt.Sprintf("%s/messages", c.baseURL)
+	// Build request
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payloadBytes))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	c.setHeaders(req)
+
+	// Send request
+	r, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send request: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		msg := fmt.Sprintf("API returned unexpected status code: %d", r.StatusCode)
+
+		// No need to check the error here: if it fails, we'll just return the
+		// status code.
+		var errResp errorMessage
+		if err := json.NewDecoder(r.Body).Decode(&errResp); err != nil {
+			return nil, errors.New(msg) // nolint:goerr113
+		}
+
+		return nil, fmt.Errorf("%s: %s", msg, errResp.Error.Message) // nolint:goerr113
+	}
+	if payload.StreamingFunc != nil {
+		// Read chunks
+		return parseStreamingMessageResponse(ctx, r, payload)
+	}
+
+	// Parse response
+	var response MessageResponsePayload
+	if err := json.NewDecoder(r.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+func parseStreamingMessageResponse(ctx context.Context, r *http.Response, payload *messagePayload) (*MessageResponsePayload, error) {
+	scanner := bufio.NewScanner(r.Body)
+	responseChan := make(chan *MessageResponsePayload)
+	go func() {
+		defer close(responseChan)
+		var response MessageResponsePayload
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+			if !strings.HasPrefix(line, "data:") {
+				continue
+			}
+			data := strings.TrimPrefix(line, "data: ")
+			var event map[string]interface{}
+			err := json.NewDecoder(bytes.NewReader([]byte(data))).Decode(&event)
+			if err != nil {
+				log.Fatalf("failed to decode stream event: %v", err)
+			}
+			eventType, ok := event["type"].(string)
+			if !ok {
+				log.Println("missing event type")
+				continue
+			}
+			switch eventType {
+			case "message_start":
+				message := event["message"].(map[string]interface{})
+				response = MessageResponsePayload{
+					ID:    message["id"].(string),
+					Model: message["model"].(string),
+					Role:  message["role"].(string),
+					Type:  message["type"].(string),
+				}
+				response.Usage.InputTokens = int(message["usage"].(map[string]interface{})["input_tokens"].(float64))
+			case "content_block_start":
+				index := int(event["index"].(float64))
+				if len(response.Content) <= index {
+					response.Content = append(response.Content, struct {
+						Text string `json:"text"`
+						Type string `json:"type"`
+					}{})
+				}
+			case "content_block_delta":
+				index := int(event["index"].(float64))
+				delta := event["delta"].(map[string]interface{})
+				if delta["type"] == "text_delta" {
+					response.Content[index].Text += delta["text"].(string)
+				}
+				if payload.StreamingFunc != nil {
+					err := payload.StreamingFunc(ctx, []byte(delta["text"].(string)))
+					if err != nil {
+						return
+					}
+				}
+			case "content_block_stop":
+				// Nothing to do here
+			case "message_delta":
+				delta := event["delta"].(map[string]interface{})
+				if stopReason, ok := delta["stop_reason"]; ok {
+					response.StopReason = stopReason.(string)
+				}
+				usage := event["usage"].(map[string]interface{})
+				if outputTokens, ok := usage["output_tokens"]; ok {
+					response.Usage.OutputTokens = int(outputTokens.(float64))
+				}
+			case "message_stop":
+				responseChan <- &response
+			case "ping":
+				// Nothing to do here
+			default:
+				log.Printf("unknown event type: %s", eventType)
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			log.Println("issue scanning response:", err)
+		}
+	}()
+	var lastResponse *MessageResponsePayload
+	for response := range responseChan {
+		lastResponse = response
+	}
+	return lastResponse, nil
+}

--- a/llms/anthropic/internal/anthropicclient/messages.go
+++ b/llms/anthropic/internal/anthropicclient/messages.go
@@ -123,17 +123,17 @@ func parseStreamingMessageResponse(ctx context.Context, r *http.Response, payloa
 			data := strings.TrimPrefix(line, "data: ")
 			event, err := parseStreamEvent(data)
 			if err != nil {
-				eventChan <- StreamedEvent{Response: nil, Err: fmt.Errorf("failed to parse stream event: %v", err)}
+				eventChan <- StreamedEvent{Response: nil, Err: fmt.Errorf("failed to parse stream event: %w", err)}
 				return
 			}
 			response, err = processStreamEvent(ctx, event, payload, response, eventChan)
 			if err != nil {
-				eventChan <- StreamedEvent{Response: nil, Err: fmt.Errorf("failed to process stream event: %v", err)}
+				eventChan <- StreamedEvent{Response: nil, Err: fmt.Errorf("failed to process stream event: %w", err)}
 				return
 			}
 		}
 		if err := scanner.Err(); err != nil {
-			eventChan <- StreamedEvent{Response: nil, Err: fmt.Errorf("issue scanning response: %v", err)}
+			eventChan <- StreamedEvent{Response: nil, Err: fmt.Errorf("issue scanning response: %w", err)}
 		}
 	}()
 


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

This adds full support for the new messages API including streaming. 
It backwards compatible with client option flag for using message api. 
It also updates the default model to 1.3 as 1.0 isn't supported by either completions or messages API.

Closes #695