### PR TITLE
llms/bedrock: Fixed error when using Claude3 model and giving MessageContent with images

### DIFF
--- a/llms/bedrock/internal/bedrockclient/provider_anthropic.go
+++ b/llms/bedrock/internal/bedrockclient/provider_anthropic.go
@@ -2,6 +2,7 @@ package bedrockclient
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 
@@ -243,9 +244,9 @@ func getAnthropicInputContent(message Message) anthropicTextGenerationInputConte
 		c = anthropicTextGenerationInputContent{
 			Type: message.Type,
 			Source: &anthropicBinGenerationInputSource{
-				Type:      message.Type,
+				Type:      "base64",
 				MediaType: message.MimeType,
-				Data:      message.Content,
+				Data:      base64.StdEncoding.EncodeToString([]byte(message.Content)),
 			},
 		}
 	}

--- a/llms/bedrock/internal/bedrockclient/provider_anthropic.go
+++ b/llms/bedrock/internal/bedrockclient/provider_anthropic.go
@@ -218,7 +218,7 @@ func processInputMessagesAnthropic(messages []Message) ([]*anthropicTextGenerati
 			}
 			for _, message := range chunk {
 				c := getAnthropicInputContent(message)
-				if c.Type != "text" {
+				if c.Type != AnthropicMessageTypeText {
 					return nil, "", errors.New("system prompt must be text")
 				}
 				systemPrompt += c.Text
@@ -260,12 +260,12 @@ func getAnthropicRole(role schema.ChatMessageType) (string, error) {
 
 func getAnthropicInputContent(message Message) anthropicTextGenerationInputContent {
 	var c anthropicTextGenerationInputContent
-	if message.Type == "text" {
+	if message.Type == AnthropicMessageTypeText {
 		c = anthropicTextGenerationInputContent{
 			Type: message.Type,
 			Text: message.Content,
 		}
-	} else if message.Type == "image" {
+	} else if message.Type == AnthropicMessageTypeImage {
 		c = anthropicTextGenerationInputContent{
 			Type: message.Type,
 			Source: &anthropicBinGenerationInputSource{

--- a/llms/bedrock/internal/bedrockclient/provider_anthropic.go
+++ b/llms/bedrock/internal/bedrockclient/provider_anthropic.go
@@ -188,26 +188,51 @@ func createAnthropicCompletion(ctx context.Context,
 // process the input messages to anthropic supported input
 // returns the input content and system prompt.
 func processInputMessagesAnthropic(messages []Message) ([]*anthropicTextGenerationInputMessage, string, error) {
+	chunkedMessages := make([][]Message, 0, len(messages))
+	var currentChunk []Message
+	var lastRole schema.ChatMessageType
+	for _, message := range messages {
+		if message.Role != lastRole {
+			if len(currentChunk) > 0 {
+				chunkedMessages = append(chunkedMessages, currentChunk)
+			}
+			currentChunk = nil
+		}
+		currentChunk = append(currentChunk, message)
+		lastRole = message.Role
+	}
+	if len(currentChunk) > 0 {
+		chunkedMessages = append(chunkedMessages, currentChunk)
+	}
+
 	inputContents := make([]*anthropicTextGenerationInputMessage, 0, len(messages))
 	var systemPrompt string
-	for _, message := range messages {
-		role, err := getAnthropicRole(message.Role)
+	for _, chunk := range chunkedMessages {
+		role, err := getAnthropicRole(chunk[0].Role)
 		if err != nil {
 			return nil, "", err
 		}
-		c := getAnthropicInputContent(message)
-
 		if role == AnthropicSystem {
 			if systemPrompt != "" {
 				return nil, "", errors.New("multiple system prompts")
 			}
-			systemPrompt = c.Text
-		} else {
-			inputContents = append(inputContents, &anthropicTextGenerationInputMessage{
-				Role:    role,
-				Content: []anthropicTextGenerationInputContent{c},
-			})
+			for _, message := range chunk {
+				c := getAnthropicInputContent(message)
+				if c.Type != "text" {
+					return nil, "", errors.New("system prompt must be text")
+				}
+				systemPrompt += c.Text
+			}
+			continue
 		}
+		content := make([]anthropicTextGenerationInputContent, 0, len(chunk))
+		for _, message := range chunk {
+			content = append(content, getAnthropicInputContent(message))
+		}
+		inputContents = append(inputContents, &anthropicTextGenerationInputMessage{
+			Role:    role,
+			Content: content,
+		})
 	}
 	return inputContents, systemPrompt, nil
 }

--- a/llms/bedrock/internal/bedrockclient/provider_anthropic.go
+++ b/llms/bedrock/internal/bedrockclient/provider_anthropic.go
@@ -189,14 +189,14 @@ func createAnthropicCompletion(ctx context.Context,
 // returns the input content and system prompt.
 func processInputMessagesAnthropic(messages []Message) ([]*anthropicTextGenerationInputMessage, string, error) {
 	chunkedMessages := make([][]Message, 0, len(messages))
-	var currentChunk []Message
+	currentChunk := make([]Message, 0, len(messages))
 	var lastRole schema.ChatMessageType
 	for _, message := range messages {
 		if message.Role != lastRole {
 			if len(currentChunk) > 0 {
 				chunkedMessages = append(chunkedMessages, currentChunk)
 			}
-			currentChunk = nil
+			currentChunk = make([]Message, 0, len(messages))
 		}
 		currentChunk = append(currentChunk, message)
 		lastRole = message.Role


### PR DESCRIPTION
### The problem want to solve with this PR

This PR concerns the execution of a prompt to recognize images using llms/bedrock's Claude3 model. In this PR, I would like to address some errors that occur when executing the following code.

```go
package main

import (
	"context"
	_ "embed"
	"log"

	"github.com/tmc/langchaingo/llms"
	"github.com/tmc/langchaingo/llms/bedrock"
	"github.com/tmc/langchaingo/schema"
)

//go:embed image.png
var image []byte

func main() {
	llm, err := bedrock.New(
		bedrock.WithModel(bedrock.ModelAnthropicClaudeV3Haiku),
	)
	if err != nil {
		log.Fatal(err)
	}
	ctx := context.Background()
	resp, err := llm.GenerateContent(
		ctx,
		[]llms.MessageContent{
			{
				Role: schema.ChatMessageTypeHuman,
				Parts: []llms.ContentPart{
					llms.BinaryPart("image/png", image),
					llms.TextPart("Please text what is written on this image."),
				},
			},
		},
	)
	if err != nil {
		log.Fatal(err)
	}
	for _, choice := range resp.Choices {
		log.Println(choice.Content)
	}
}
```
The code itself is simple, interpreting the image/png image given in the embedding as text.

The errors that occur are the following two types of errors that occur when executing this code.

- `2024/03/22 11:23:14 operation error Bedrock Runtime: InvokeModel, https response error StatusCode: 400, RequestID: 0fa522ef-9201-4f62-9f69-f40ff9046896, ValidationException: messages.0.content.0.image.source: Input tag 'image' found using 'type' does not match any of the expected tags: 'base64'`
- `2024/03/22 11:37:33 operation error Bedrock Runtime: InvokeModel, https response error StatusCode: 400, RequestID: 5741321f-54e4-4ef0-9351-d28eb104ee07, ValidationException: messages: roles must alternate between "user" and "assistant", but found multiple "user" roles in a row`

The specifications for this area are described in the following document.

https://docs.anthropic.com/claude/reference/claude-on-amazon-bedrock
https://docs.anthropic.com/claude/reference/messages_post

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
