### PR TITLE
feat: add WithKeepSeparator option for RecursiveCharacter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,6 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/gage-technologies/mistral-go v1.0.0 // indirect
 	github.com/getsentry/sentry-go v0.12.0 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -185,6 +184,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.4
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.7.1
 	github.com/cohere-ai/tokenizer v1.1.2
+	github.com/gage-technologies/mistral-go v1.0.0
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/gocolly/colly v1.2.0

--- a/textsplitter/options.go
+++ b/textsplitter/options.go
@@ -121,7 +121,7 @@ func WithReferenceLinks(referenceLinks bool) Option {
 	}
 }
 
-// WithKeepSeparator set the keep_separator for a text splitter
+// WithKeepSeparator set the keep_separator for a text splitter.
 func WithKeepSeparator(keepSeparator bool) Option {
 	return func(o *Options) {
 		o.KeepSeparator = keepSeparator

--- a/textsplitter/options.go
+++ b/textsplitter/options.go
@@ -7,6 +7,7 @@ type Options struct {
 	ChunkSize         int
 	ChunkOverlap      int
 	Separators        []string
+	KeepSeparator     bool
 	LenFunc           func(string) int
 	ModelName         string
 	EncodingName      string
@@ -20,10 +21,11 @@ type Options struct {
 // DefaultOptions returns the default options for all text splitter.
 func DefaultOptions() Options {
 	return Options{
-		ChunkSize:    _defaultTokenChunkSize,
-		ChunkOverlap: _defaultTokenChunkOverlap,
-		Separators:   []string{"\n\n", "\n", " ", ""},
-		LenFunc:      utf8.RuneCountInString,
+		ChunkSize:     _defaultTokenChunkSize,
+		ChunkOverlap:  _defaultTokenChunkOverlap,
+		Separators:    []string{"\n\n", "\n", " ", ""},
+		KeepSeparator: false,
+		LenFunc:       utf8.RuneCountInString,
 
 		ModelName:         _defaultTokenModelName,
 		EncodingName:      _defaultTokenEncoding,
@@ -116,5 +118,12 @@ func WithCodeBlocks(renderCode bool) Option {
 func WithReferenceLinks(referenceLinks bool) Option {
 	return func(o *Options) {
 		o.ReferenceLinks = referenceLinks
+	}
+}
+
+// WithKeepSeparator set the keep_separator for a text splitter
+func WithKeepSeparator(keepSeparator bool) Option {
+	return func(o *Options) {
+		o.KeepSeparator = keepSeparator
 	}
 }

--- a/textsplitter/options.go
+++ b/textsplitter/options.go
@@ -121,7 +121,11 @@ func WithReferenceLinks(referenceLinks bool) Option {
 	}
 }
 
-// WithKeepSeparator set the keep_separator for a text splitter.
+// WithKeepSeparator sets whether the separators should be kept in the resulting
+// split text or not. When it is set to True, the separators are included in the
+// resulting split text. When it is set to False, the separators are not included
+// in the resulting split text. The purpose of having this parameter is to provide
+// flexibility in how text splitting is handled.
 func WithKeepSeparator(keepSeparator bool) Option {
 	return func(o *Options) {
 		o.KeepSeparator = keepSeparator

--- a/textsplitter/options.go
+++ b/textsplitter/options.go
@@ -125,7 +125,7 @@ func WithReferenceLinks(referenceLinks bool) Option {
 // split text or not. When it is set to True, the separators are included in the
 // resulting split text. When it is set to False, the separators are not included
 // in the resulting split text. The purpose of having this parameter is to provide
-// flexibility in how text splitting is handled.
+// flexibility in how text splitting is handled. Default to False if not specified.
 func WithKeepSeparator(keepSeparator bool) Option {
 	return func(o *Options) {
 		o.KeepSeparator = keepSeparator

--- a/textsplitter/recursive_character.go
+++ b/textsplitter/recursive_character.go
@@ -39,6 +39,18 @@ func (s RecursiveCharacter) SplitText(text string) ([]string, error) {
 	return s.splitText(text, s.Separators)
 }
 
+// addSeparatorInSplits adds the separator in each of splits
+func (s RecursiveCharacter) addSeparatorInSplits(splits []string, separator string) []string {
+	splitsWithSeparator := make([]string, 0, len(splits))
+	for i, s := range splits {
+		if i > 0 {
+			s = separator + s
+		}
+		splitsWithSeparator = append(splitsWithSeparator, s)
+	}
+	return splitsWithSeparator
+}
+
 func (s RecursiveCharacter) splitText(text string, separators []string) ([]string, error) {
 	finalChunks := make([]string, 0)
 
@@ -55,15 +67,8 @@ func (s RecursiveCharacter) splitText(text string, separators []string) ([]strin
 
 	splits := strings.Split(text, separator)
 	if s.KeepSeparator {
-		splitsWithSeparator := make([]string, 0, len(splits))
-		for i, s := range splits {
-			if i > 0 {
-				s = separator + s
-			}
-			splitsWithSeparator = append(splitsWithSeparator, s)
-		}
+		splits = s.addSeparatorInSplits(splits, separator)
 		separator = ""
-		splits = splitsWithSeparator
 	}
 	goodSplits := make([]string, 0)
 

--- a/textsplitter/recursive_character.go
+++ b/textsplitter/recursive_character.go
@@ -7,10 +7,11 @@ import (
 // RecursiveCharacter is a text splitter that will split texts recursively by different
 // characters.
 type RecursiveCharacter struct {
-	Separators   []string
-	ChunkSize    int
-	ChunkOverlap int
-	LenFunc      func(string) int
+	Separators    []string
+	ChunkSize     int
+	ChunkOverlap  int
+	LenFunc       func(string) int
+	KeepSeparator bool
 }
 
 // NewRecursiveCharacter creates a new recursive character splitter with default values. By
@@ -23,10 +24,11 @@ func NewRecursiveCharacter(opts ...Option) RecursiveCharacter {
 	}
 
 	s := RecursiveCharacter{
-		Separators:   options.Separators,
-		ChunkSize:    options.ChunkSize,
-		ChunkOverlap: options.ChunkOverlap,
-		LenFunc:      options.LenFunc,
+		Separators:    options.Separators,
+		ChunkSize:     options.ChunkSize,
+		ChunkOverlap:  options.ChunkOverlap,
+		LenFunc:       options.LenFunc,
+		KeepSeparator: options.KeepSeparator,
 	}
 
 	return s
@@ -34,20 +36,35 @@ func NewRecursiveCharacter(opts ...Option) RecursiveCharacter {
 
 // SplitText splits a text into multiple text.
 func (s RecursiveCharacter) SplitText(text string) ([]string, error) {
+	return s.splitText(text, s.Separators)
+}
+
+func (s RecursiveCharacter) splitText(text string, separators []string) ([]string, error) {
 	finalChunks := make([]string, 0)
 
 	// Find the appropriate separator
-	separator := s.Separators[len(s.Separators)-1]
+	separator := separators[len(separators)-1]
 	newSeparators := []string{}
-	for i, c := range s.Separators {
+	for i, c := range separators {
 		if c == "" || strings.Contains(text, c) {
 			separator = c
-			newSeparators = s.Separators[i+1:]
+			newSeparators = separators[i+1:]
 			break
 		}
 	}
 
 	splits := strings.Split(text, separator)
+	if s.KeepSeparator {
+		splitsWithSeparator := make([]string, 0, len(splits))
+		for i, s := range splits {
+			if i > 0 {
+				s = separator + s
+			}
+			splitsWithSeparator = append(splitsWithSeparator, s)
+		}
+		separator = ""
+		splits = splitsWithSeparator
+	}
 	goodSplits := make([]string, 0)
 
 	// Merge the splits, recursively splitting larger texts.
@@ -67,7 +84,7 @@ func (s RecursiveCharacter) SplitText(text string) ([]string, error) {
 		if len(newSeparators) == 0 {
 			finalChunks = append(finalChunks, split)
 		} else {
-			otherInfo, err := s.SplitText(split)
+			otherInfo, err := s.splitText(split, newSeparators)
 			if err != nil {
 				return nil, err
 			}

--- a/textsplitter/recursive_character.go
+++ b/textsplitter/recursive_character.go
@@ -39,7 +39,7 @@ func (s RecursiveCharacter) SplitText(text string) ([]string, error) {
 	return s.splitText(text, s.Separators)
 }
 
-// addSeparatorInSplits adds the separator in each of splits
+// addSeparatorInSplits adds the separator in each of splits.
 func (s RecursiveCharacter) addSeparatorInSplits(splits []string, separator string) []string {
 	splitsWithSeparator := make([]string, 0, len(splits))
 	for i, s := range splits {
@@ -54,7 +54,7 @@ func (s RecursiveCharacter) addSeparatorInSplits(splits []string, separator stri
 func (s RecursiveCharacter) splitText(text string, separators []string) ([]string, error) {
 	finalChunks := make([]string, 0)
 
-	// Find the appropriate separator
+	// Find the appropriate separator.
 	separator := separators[len(separators)-1]
 	newSeparators := []string{}
 	for i, c := range separators {


### PR DESCRIPTION
Fix issue #720 
Reference Implementation In Python:  [RecursiveCharacterTextSplitter](https://api.python.langchain.com/en/latest/_modules/langchain_text_splitters/character.html#RecursiveCharacterTextSplitter)