### PR TITLE
all: set explicit 1.22 version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tmc/langchaingo
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
https://go.dev/ref/mod#go-mod-file-go

----

**go directive**

A go directive indicates that a module was written assuming the semantics of a given version of Go. The version must be a valid [Go version](https://go.dev/doc/toolchain#version), such as 1.9, 1.14, or 1.21rc1.

The go directive sets the minimum version of Go required to use this module. Before Go 1.21, the directive was advisory only; now it is a mandatory requirement: Go toolchains refuse to use modules declaring newer Go versions.

----

Per https://github.com/golang/go/issues/62278#issuecomment-1693538776, `go 1.22` is insufficient and may return errors for "go1.22 toolchain not available"

