### PR TITLE
GH actions: update lint workflow to newer version of Go

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,18 +12,18 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.22'
           # Cache is managed by golangci-lint
           # https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs
           cache: false
-      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@v4
         with:
           args: --timeout=4m
-          version: v1.57.1
+          version: v1.57.2
   build-examples:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
What motivates this is a newer lint version for local running with 1.22, which fixes the loop range issue and doesn't require spurious lint errors in tests any more.