### PR TITLE
docs: resolve rendering issue with code block in getting started docs

### DIFF
--- a/docs/docs/getting-started/guide-openai.mdx
+++ b/docs/docs/getting-started/guide-openai.mdx
@@ -14,8 +14,8 @@ Dive right into executing your first program utilizing LangChainGo in tandem wit
 ## Steps
 
 1. **Set up your OpenAI API Key**: Before interacting with the OpenAI API, ensure that you've set up your API key. Typically, this is done by setting an environment variable. In your terminal, run the command:
-   ```shell
-   export OPENAI_API_KEY=your_openai_api_key_here
+```shell
+export OPENAI_API_KEY=your_openai_api_key_here
 ```
 
 2. Run the Example: Execute the following command:


### PR DESCRIPTION
# Summary

This MR resolves an issue with the rendering of a code block from the [docs/getting-started/guide-openai](https://tmc.github.io/langchaingo/docs/getting-started/guide-openai) docs page. 

## What Changed

- Remove unnecessary whitespace that causes rendering issues.

## Breadcrumbs / Screenshots

You can observe the rendering issue within the following section (https://tmc.github.io/langchaingo/docs/getting-started/guide-openai#steps):
<img width="990" alt="Screenshot 2024-04-04 at 10 30 31 PM" src="https://github.com/tmc/langchaingo/assets/77141303/e802aba1-4b17-4799-a8b9-a050ce9eb628">
Notice that the second step gets rendered as if it were in a code block. Removing the extra spacing fixes this block.

### PR Checklist

- [X] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [X] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [X] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [X] Describes the source of new concepts.
- [X] References existing implementations as appropriate.
- [X] Contains test coverage for new functions.
- [X] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
