### PR TITLE
openai: add toolcalls support when streaming

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -459,7 +459,7 @@ func combineStreamingChatResponse(ctx context.Context, payload *ChatRequest, res
 			response.Choices[0].Message.ToolCalls = append(response.Choices[0].Message.ToolCalls, t)
 		}
 
-		if len(streamResponse.Choices[0].Delta.ToolCalls) > 1 {
+		if len(streamResponse.Choices[0].Delta.ToolCalls) > 0 {
 			chunk, _ = json.Marshal(streamResponse.Choices[0].Delta.ToolCalls) // nolint:errchkjson
 		}
 

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -456,10 +456,11 @@ func combineStreamingChatResponse(ctx context.Context, payload *ChatRequest, res
 			}
 
 			// Otherwise, this is a new tool call, append that to the stack
-			response.Choices[0].Message.ToolCalls = append(response.Choices[0].Message.ToolCalls, t)
+			response.Choices[0].Message.ToolCalls = append(response.Choices[0].Message.ToolCalls, *t)
 		}
 
 		if len(streamResponse.Choices[0].Delta.ToolCalls) > 0 {
+			// walk through the delta and append to the stack
 			chunk, response.Choices[0].Message.ToolCalls = StreamingChatResponseTools(response.Choices[0].Message.ToolCalls, streamResponse.Choices[0].Delta.ToolCalls)
 		}
 
@@ -473,7 +474,8 @@ func combineStreamingChatResponse(ctx context.Context, payload *ChatRequest, res
 	return &response, nil
 }
 
-func StreamingChatResponseTools(tools, delta []ToolCall) ([]byte, []ToolCall) {
+// StreamingChatResponseTools is a helper function to append tool calls to the stack.
+func StreamingChatResponseTools(tools []ToolCall, delta []*ToolCall) ([]byte, []ToolCall) {
 	if len(delta) == 0 {
 		return []byte{}, tools
 	}
@@ -490,7 +492,7 @@ func StreamingChatResponseTools(tools, delta []ToolCall) ([]byte, []ToolCall) {
 		}
 
 		// Otherwise, this is a new tool call, append that to the stack
-		tools = append(tools, t)
+		tools = append(tools, *t)
 	}
 
 	chunk, _ := json.Marshal(delta) // nolint:errchkjson

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -404,64 +404,21 @@ func combineStreamingChatResponse(ctx context.Context, payload *ChatRequest, res
 		},
 	}
 
-	var (
-		currentTool  ToolCall
-		currentIndex = -1
-	)
 	for streamResponse := range responseChan {
 		if len(streamResponse.Choices) == 0 {
 			continue
 		}
-		chunk := []byte(streamResponse.Choices[0].Delta.Content)
-		response.Choices[0].Message.Content += streamResponse.Choices[0].Delta.Content
-		response.Choices[0].FinishReason = streamResponse.Choices[0].FinishReason
-		if streamResponse.Choices[0].Delta.FunctionCall != nil {
-			if response.Choices[0].Message.FunctionCall == nil {
-				response.Choices[0].Message.FunctionCall = streamResponse.Choices[0].Delta.FunctionCall
-			} else {
-				response.Choices[0].Message.FunctionCall.Arguments += streamResponse.Choices[0].Delta.FunctionCall.Arguments
-			}
-			chunk, _ = json.Marshal(response.Choices[0].Message.FunctionCall) // nolint:errchkjson
-		}
-		if len(streamResponse.Choices[0].Delta.ToolCalls) > 0 {
-			for _, streamTool := range streamResponse.Choices[0].Delta.ToolCalls {
-				if streamTool.ID != "" {
-					currentTool = ToolCall{
-						ID:   streamTool.ID,
-						Type: streamTool.Type,
-						Function: ToolFunction{
-							Name:      streamTool.Function.Name,
-							Arguments: streamTool.Function.Arguments,
-						},
-					}
-					response.Choices[0].Message.ToolCalls = append(response.Choices[0].Message.ToolCalls, currentTool)
-					currentIndex++
-				} else {
-					response.Choices[0].Message.ToolCalls[currentIndex].Function.Arguments += streamTool.Function.Arguments
-				}
-			}
-			chunk, _ = json.Marshal(response.Choices[0].Message.ToolCalls) // nolint:errchkjson
+		choice := streamResponse.Choices[0]
+		chunk := []byte(choice.Delta.Content)
+		response.Choices[0].Message.Content += choice.Delta.Content
+		response.Choices[0].FinishReason = choice.FinishReason
+
+		if choice.Delta.FunctionCall != nil {
+			chunk = updateFunctionCall(response.Choices[0].Message, choice.Delta.FunctionCall)
 		}
 
-		for _, t := range streamResponse.Choices[0].Delta.ToolCalls {
-			// if we have arguments append to the last Tool call
-			if t.Type == `` && t.Function.Arguments != `` {
-				lindex := len(response.Choices[0].Message.ToolCalls) - 1
-				if lindex < 0 {
-					continue
-				}
-
-				response.Choices[0].Message.ToolCalls[lindex].Function.Arguments += t.Function.Arguments
-				continue
-			}
-
-			// Otherwise, this is a new tool call, append that to the stack
-			response.Choices[0].Message.ToolCalls = append(response.Choices[0].Message.ToolCalls, *t)
-		}
-
-		if len(streamResponse.Choices[0].Delta.ToolCalls) > 0 {
-			// walk through the delta and append to the stack
-			chunk, response.Choices[0].Message.ToolCalls = StreamingChatResponseTools(response.Choices[0].Message.ToolCalls, streamResponse.Choices[0].Delta.ToolCalls)
+		if len(choice.Delta.ToolCalls) > 0 {
+			chunk, response.Choices[0].Message.ToolCalls = updateToolCalls(response.Choices[0].Message.ToolCalls, choice.Delta.ToolCalls)
 		}
 
 		if payload.StreamingFunc != nil {
@@ -472,6 +429,41 @@ func combineStreamingChatResponse(ctx context.Context, payload *ChatRequest, res
 		}
 	}
 	return &response, nil
+}
+
+func updateFunctionCall(message ChatMessage, functionCall *FunctionCall) []byte {
+	if message.FunctionCall == nil {
+		message.FunctionCall = functionCall
+	} else {
+		message.FunctionCall.Arguments += functionCall.Arguments
+	}
+	chunk, _ := json.Marshal(message.FunctionCall) // nolint:errchkjson
+	return chunk
+}
+
+func updateToolCalls(tools []ToolCall, delta []*ToolCall) ([]byte, []ToolCall) {
+	if len(delta) == 0 {
+		return []byte{}, tools
+	}
+	for _, t := range delta {
+		// if we have arguments append to the last Tool call
+		if t.Type == `` && t.Function.Arguments != `` {
+			lindex := len(tools) - 1
+			if lindex < 0 {
+				continue
+			}
+
+			tools[lindex].Function.Arguments += t.Function.Arguments
+			continue
+		}
+
+		// Otherwise, this is a new tool call, append that to the stack
+		tools = append(tools, *t)
+	}
+
+	chunk, _ := json.Marshal(delta) // nolint:errchkjson
+
+	return chunk, tools
 }
 
 // StreamingChatResponseTools is a helper function to append tool calls to the stack.

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -444,7 +444,7 @@ func combineStreamingChatResponse(ctx context.Context, payload *ChatRequest, res
 		}
 
 		for _, t := range streamResponse.Choices[0].Delta.ToolCalls {
-			//if we have arguments append to the last Tool call
+			// if we have arguments append to the last Tool call
 			if t.Type == `` && t.Function.Arguments != `` {
 				lindex := len(response.Choices[0].Message.ToolCalls) - 1
 				if lindex < 0 {
@@ -455,7 +455,7 @@ func combineStreamingChatResponse(ctx context.Context, payload *ChatRequest, res
 				continue
 			}
 
-			//Otherwise, this is a new tool call, append that to the stack
+			// Otherwise, this is a new tool call, append that to the stack
 			response.Choices[0].Message.ToolCalls = append(response.Choices[0].Message.ToolCalls, t)
 		}
 


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

I noticed that after the recent addition of ToolCalls support that streaming with functions/toolCalls is no longer working. I created this PR to add tool calls support to the streaming functionality.

you can see this in action if you call this example: https://github.com/tmc/langchaingo/blob/main/examples/openai-function-call-streaming-example/openai_function_call_example.go

This example with current code will not print this final message. With the change in this PR you will see the correct result

Expected output:
```
Function call: &{getCurrentWeather {
  "location": "Boston, MA",
  "rationale": "User asked for the current weather in Boston"
}}
``` 