### PR TITLE
agent:Implement openai agent tool calling (#765)

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -5,6 +5,7 @@ type AgentAction struct {
 	Tool      string
 	ToolInput string
 	Log       string
+	ToolId    string
 }
 
 // AgentStep is a step of the agent.


### PR DESCRIPTION
### PR Checklist


- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.


I noticed that after the recent addition of ToolCalls support，it is no longer effective to use the tool with the openai agent. This is because after obtaining the openai results for the first time, the tool was called, but the next request to call openai could not be correctly formed, resulting in empty response. I improved each request and solved the problem

When running the TestExecutorWithOpenAIFunctionAgent in the executor_test.go directory of the agent, both tools will return an empty response, and the result can now be returned correctly 
