### PR TITLE
tools: serpapi api key option

### DIFF
--- a/tools/serpapi/options.go
+++ b/tools/serpapi/options.go
@@ -1,0 +1,15 @@
+package serpapi
+
+type options struct {
+	apiKey string
+}
+
+type Option func(*options)
+
+// WithAPIKey passes the Serpapi API token to the client. If not set, the token
+// is read from the SERPAPI_API_KEY environment variable.
+func WithAPIKey(apiKey string) Option {
+	return func(opts *options) {
+		opts.apiKey = apiKey
+	}
+}

--- a/tools/serpapi/serpapi.go
+++ b/tools/serpapi/serpapi.go
@@ -21,14 +21,21 @@ type Tool struct {
 var _ tools.Tool = Tool{}
 
 // New creates a new serpapi tool to search on internet.
-func New() (*Tool, error) {
-	apiKey := os.Getenv("SERPAPI_API_KEY")
-	if apiKey == "" {
+func New(opts ...Option) (*Tool, error) {
+	options := &options{
+		apiKey: os.Getenv("SERPAPI_API_KEY"),
+	}
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if options.apiKey == "" {
 		return nil, ErrMissingToken
 	}
 
 	return &Tool{
-		client: internal.New(apiKey),
+		client: internal.New(options.apiKey),
 	}, nil
 }
 


### PR DESCRIPTION
### Serpapi API key option

It is often desirable to be able to control the names of environment variables and not having them predefined by the package. This PR allows to pass Serpapi API key as an configuration option, while maintaining backwards compatibility with existing applications.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
