### PR TITLE
vectorstores/pinecone: update pinecone connection with host field

### DIFF
--- a/vectorstores/pinecone/grpcapi.go
+++ b/vectorstores/pinecone/grpcapi.go
@@ -19,12 +19,7 @@ func (s Store) getGRPCConn(ctx context.Context) (*grpc.ClientConn, error) {
 		MinVersion: tls.VersionTLS12,
 	}
 
-	target := fmt.Sprintf(
-		"%s-%s.svc.%s.pinecone.io:443",
-		s.indexName,
-		s.projectName,
-		s.environment,
-	)
+	target := s.host
 
 	ctx = metadata.AppendToOutgoingContext(ctx, "api-key", s.apiKey)
 

--- a/vectorstores/pinecone/options.go
+++ b/vectorstores/pinecone/options.go
@@ -19,26 +19,10 @@ var ErrInvalidOptions = errors.New("invalid options")
 // Option is a function type that can be used to modify the client.
 type Option func(p *Store)
 
-// WithIndexName is an option for specifying the index name. Must be set.
-func WithIndexName(name string) Option {
+// WithHost is an option for setting the host to use. Must be set.
+func WithHost(host string) Option {
 	return func(p *Store) {
-		p.indexName = name
-	}
-}
-
-// WithEnvironment is an option for specifying the environment. Must be set.
-func WithEnvironment(environment string) Option {
-	return func(p *Store) {
-		p.environment = environment
-	}
-}
-
-// WithProjectName is an option for specifying the project name. Must be set. The
-// project name associated with the api key can be obtained using the whoami
-// operation.
-func WithProjectName(name string) Option {
-	return func(p *Store) {
-		p.projectName = name
+		p.host = host
 	}
 }
 
@@ -90,16 +74,8 @@ func applyClientOptions(opts ...Option) (Store, error) {
 		opt(o)
 	}
 
-	if o.indexName == "" {
-		return Store{}, fmt.Errorf("%w: missing index name", ErrInvalidOptions)
-	}
-
-	if o.environment == "" {
-		return Store{}, fmt.Errorf("%w: missing environment", ErrInvalidOptions)
-	}
-
-	if o.projectName == "" {
-		return Store{}, fmt.Errorf("%w: missing project name", ErrInvalidOptions)
+	if o.host == "" {
+		return Store{}, fmt.Errorf("%w: missing host", ErrInvalidOptions)
 	}
 
 	if o.embedder == nil {

--- a/vectorstores/pinecone/pinecone.go
+++ b/vectorstores/pinecone/pinecone.go
@@ -32,13 +32,11 @@ type Store struct {
 	grpcConn *grpc.ClientConn
 	client   pinecone_grpc.VectorServiceClient
 
-	indexName   string
-	projectName string
-	environment string
-	apiKey      string
-	textKey     string
-	nameSpace   string
-	useGRPC     bool
+	host      string
+	apiKey    string
+	textKey   string
+	nameSpace string
+	useGRPC   bool
 }
 
 var _ vectorstores.VectorStore = Store{}

--- a/vectorstores/pinecone/pinecone_test.go
+++ b/vectorstores/pinecone/pinecone_test.go
@@ -16,10 +16,6 @@ import (
 	"github.com/tmc/langchaingo/vectorstores/pinecone"
 )
 
-var (
-	id = uuid.New().String()
-)
-
 func getValues(t *testing.T) (string, string) {
 	t.Helper()
 
@@ -41,28 +37,88 @@ func getValues(t *testing.T) (string, string) {
 	return pineconeAPIKey, pineconeHost
 }
 
-func TestPineconeStoreAddDocuments(t *testing.T) {
-	apiKey, pineconeHost := getValues(t)
+/* func TestPineconeStoreGRPC(t *testing.T) {
+	t.Parallel()
+
+	environment, apiKey, indexName, projectName := getValues(t)
+	e, err := embeddings.NewOpenAI()
+	require.NoError(t, err)
+
+	storer, err := pinecone.New(
+		context.Background(),
+		pinecone.WithAPIKey(apiKey),
+		pinecone.WithEnvironment(environment),
+		pinecone.WithIndexName(indexName),
+		pinecone.WithProjectName(projectName),
+		pinecone.WithEmbedder(e),
+		pinecone.WithNameSpace(uuid.New().String()),
+		withGrpc(),
+	)
+	require.NoError(t, err)
+
+	err = storer.AddDocuments(context.Background(), []schema.Document{
+		{PageContent: "yes"},
+		{PageContent: "no"},
+	})
+	require.NoError(t, err)
+
+	docs, err := storer.SimilaritySearch(context.Background(), "yeah", 1)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.Equal(t, docs[0].PageContent, "yes")
+} */
+
+func TestPineconeStoreRest(t *testing.T) {
+	t.Parallel()
+
+	apiKey, host := getValues(t)
 
 	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
 	require.NoError(t, err)
-
 	e, err := embeddings.NewEmbedder(llm)
 	require.NoError(t, err)
 
 	storer, err := pinecone.New(
 		context.Background(),
 		pinecone.WithAPIKey(apiKey),
-		pinecone.WithHost(pineconeHost),
+		pinecone.WithHost(host),
 		pinecone.WithEmbedder(e),
-		pinecone.WithNameSpace(id),
+		pinecone.WithNameSpace(uuid.New().String()),
 	)
 	require.NoError(t, err)
 
 	_, err = storer.AddDocuments(context.Background(), []schema.Document{
-		{PageContent: "Artificial intelligence (AI), in its broadest sense, is intelligence exhibited by machines, particularly computer systems."},
-		{PageContent: "It is a field of research in computer science that develops and studies methods and software which enable machines to perceive their environment and uses learning and intelligence to take actions that maximize their chances of achieving defined goals."},
-		{PageContent: "Alan Turing was the first person to conduct substantial research in the field that he called machine intelligence."},
+		{PageContent: "tokyo"},
+		{PageContent: "potato"},
+	})
+	require.NoError(t, err)
+
+	docs, err := storer.SimilaritySearch(context.Background(), "japan", 1)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.Equal(t, "tokyo", docs[0].PageContent)
+}
+
+func TestPineconeStoreRestWithScoreThreshold(t *testing.T) {
+	t.Parallel()
+
+	apiKey, host := getValues(t)
+
+	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	storer, err := pinecone.New(
+		context.Background(),
+		pinecone.WithAPIKey(apiKey),
+		pinecone.WithHost(host),
+		pinecone.WithEmbedder(e),
+		pinecone.WithNameSpace(uuid.New().String()),
+	)
+	require.NoError(t, err)
+
+	_, err = storer.AddDocuments(context.Background(), []schema.Document{
 		{PageContent: "Tokyo"},
 		{PageContent: "Yokohama"},
 		{PageContent: "Osaka"},
@@ -73,74 +129,75 @@ func TestPineconeStoreAddDocuments(t *testing.T) {
 		{PageContent: "Paris"},
 		{PageContent: "London "},
 		{PageContent: "New York"},
-		{PageContent: "The color of the house is blue."},
-		{PageContent: "The color of the car is red."},
-		{PageContent: "The color of the desk is orange."},
-		{PageContent: "The color of the lamp beside the desk is black."},
-		{PageContent: "The color of the chair beside the desk is beige."},
-		{
-			PageContent: "The color of the lamp beside the desk is black.",
-			Metadata: map[string]any{
-				"location": "kitchen",
-			},
-		},
-		{
-			PageContent: "The color of the lamp beside the desk is blue.",
-			Metadata: map[string]any{
-				"location": "bedroom",
-			},
-		},
-		{
-			PageContent: "The color of the lamp beside the desk is orange.",
-			Metadata: map[string]any{
-				"location": "office",
-			},
-		},
-		{
-			PageContent: "The color of the lamp beside the desk is purple.",
-			Metadata: map[string]any{
-				"location": "sitting room",
-			},
-		},
-		{
-			PageContent: "The color of the lamp beside the desk is yellow.",
-			Metadata: map[string]any{
-				"location": "patio",
-			},
-		},
-		{
-			PageContent: "The color of the lamp beside the desk is orange.",
-			Metadata: map[string]any{
-				"location":    "office",
-				"square_feet": 100,
-			},
-		},
-		{
-			PageContent: "The color of the lamp beside the desk is purple.",
-			Metadata: map[string]any{
-				"location":    "sitting room",
-				"square_feet": 400,
-			},
-		},
-		{
-			PageContent: "The color of the lamp beside the desk is yellow.",
-			Metadata: map[string]any{
-				"location":    "patio",
-				"square_feet": 800,
-			},
-		},
-		{PageContent: "yes"},
-		{PageContent: "no"},
 	})
 	require.NoError(t, err)
+
+	// test with a score threshold of 0.8, expected 6 documents
+	docs, err := storer.SimilaritySearch(context.Background(),
+		"Which of these are cities in Japan", 10,
+		vectorstores.WithScoreThreshold(0.8))
+	require.NoError(t, err)
+	require.Len(t, docs, 6)
+
+	// test with a score threshold of 0, expected all 10 documents
+	docs, err = storer.SimilaritySearch(context.Background(),
+		"Which of these are cities in Japan", 10,
+		vectorstores.WithScoreThreshold(0))
+	require.NoError(t, err)
+	require.Len(t, docs, 10)
 }
 
-/* func TestPineconeStoreGRPC(t *testing.T) {
+func TestSimilaritySearchWithInvalidScoreThreshold(t *testing.T) {
+	t.Parallel()
+
 	apiKey, host := getValues(t)
 
 	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
 	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
 
+	storer, err := pinecone.New(
+		context.Background(),
+		pinecone.WithAPIKey(apiKey),
+		pinecone.WithHost(host),
+		pinecone.WithEmbedder(e),
+		pinecone.WithNameSpace(uuid.New().String()),
+	)
+	require.NoError(t, err)
+
+	_, err = storer.AddDocuments(context.Background(), []schema.Document{
+		{PageContent: "Tokyo"},
+		{PageContent: "Yokohama"},
+		{PageContent: "Osaka"},
+		{PageContent: "Nagoya"},
+		{PageContent: "Sapporo"},
+		{PageContent: "Fukuoka"},
+		{PageContent: "Dublin"},
+		{PageContent: "Paris"},
+		{PageContent: "London "},
+		{PageContent: "New York"},
+	})
+	require.NoError(t, err)
+
+	_, err = storer.SimilaritySearch(context.Background(),
+		"Which of these are cities in Japan", 10,
+		vectorstores.WithScoreThreshold(-0.8))
+	require.Error(t, err)
+
+	_, err = storer.SimilaritySearch(context.Background(),
+		"Which of these are cities in Japan", 10,
+		vectorstores.WithScoreThreshold(1.8))
+	require.Error(t, err)
+}
+
+func TestPineconeAsRetriever(t *testing.T) {
+	t.Parallel()
+
+	apiKey, host := getValues(t)
+
+	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
+	require.NoError(t, err)
 	e, err := embeddings.NewEmbedder(llm)
 	require.NoError(t, err)
 
@@ -149,39 +206,20 @@ func TestPineconeStoreAddDocuments(t *testing.T) {
 		pinecone.WithAPIKey(apiKey),
 		pinecone.WithHost(host),
 		pinecone.WithEmbedder(e),
-		pinecone.WithNameSpace(id),
-		withGrpc(),
 	)
 	require.NoError(t, err)
 
-	docs, err := store.SimilaritySearch(context.Background(), "yeah", 1, vectorstores.WithNameSpace(id))
-	require.NoError(t, err)
-	require.Len(t, docs, 1)
-	require.Equal(t, docs[0].PageContent, "yes")
-} */
+	id := uuid.New().String()
 
-func TestPineconeAsRetriever(t *testing.T) {
-	apiKey, pineconeHost := getValues(t)
-
-	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
-	require.NoError(t, err)
-
-	e, err := embeddings.NewEmbedder(llm)
-	require.NoError(t, err)
-
-	store, err := pinecone.New(
+	_, err = store.AddDocuments(
 		context.Background(),
-		pinecone.WithAPIKey(apiKey),
-		pinecone.WithHost(pineconeHost),
-		pinecone.WithEmbedder(e),
+		[]schema.Document{
+			{PageContent: "The color of the house is blue."},
+			{PageContent: "The color of the car is red."},
+			{PageContent: "The color of the desk is orange."},
+		},
+		vectorstores.WithNameSpace(id),
 	)
-	require.NoError(t, err)
-
-	_, err = store.AddDocuments(context.Background(), []schema.Document{
-		{PageContent: "Artificial intelligence (AI), in its broadest sense, is intelligence exhibited by machines, particularly computer systems."},
-		{PageContent: "It is a field of research in computer science that develops and studies methods and software which enable machines to perceive their environment and uses learning and intelligence to take actions that maximize their chances of achieving defined goals."},
-		{PageContent: "Alan Turing was the first person to conduct substantial research in the field that he called machine intelligence."},
-	}, vectorstores.WithNameSpace(id))
 	require.NoError(t, err)
 
 	result, err := chains.Run(
@@ -190,96 +228,42 @@ func TestPineconeAsRetriever(t *testing.T) {
 			llm,
 			vectorstores.ToRetriever(store, 1, vectorstores.WithNameSpace(id)),
 		),
-		"who was the first person to conduct substantial research in AI?",
+		"What color is the desk?",
 	)
 	require.NoError(t, err)
-	require.True(t, strings.Contains(result, "Alan Turing"), "expected Alan Turing in result")
-}
-
-func TestPineconeStoreRestWithScoreThreshold(t *testing.T) {
-	apiKey, pineconeHost := getValues(t)
-
-	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
-	require.NoError(t, err)
-
-	e, err := embeddings.NewEmbedder(llm)
-	require.NoError(t, err)
-
-	store, err := pinecone.New(
-		context.Background(),
-		pinecone.WithAPIKey(apiKey),
-		pinecone.WithHost(pineconeHost),
-		pinecone.WithEmbedder(e),
-		pinecone.WithNameSpace(id),
-	)
-	require.NoError(t, err)
-
-	// test with a score threshold of 0.8, expected 6 documents
-	docs, err := store.SimilaritySearch(context.Background(),
-		"Which of these are cities in Japan?", 10,
-		vectorstores.WithScoreThreshold(0.8),
-		vectorstores.WithNameSpace(id),
-	)
-	require.NoError(t, err)
-	require.Len(t, docs, 6)
-
-	// test with a score threshold of 0, expected all 10 documents
-	docs, err = store.SimilaritySearch(context.Background(),
-		"Which of these are cities in Japan", 10,
-		vectorstores.WithScoreThreshold(0),
-		vectorstores.WithNameSpace(id),
-	)
-	require.NoError(t, err)
-	require.Len(t, docs, 10)
-}
-
-func TestSimilaritySearchWithInvalidScoreThreshold(t *testing.T) {
-	apiKey, pineconeHost := getValues(t)
-
-	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
-	require.NoError(t, err)
-
-	e, err := embeddings.NewEmbedder(llm)
-	require.NoError(t, err)
-
-	store, err := pinecone.New(
-		context.Background(),
-		pinecone.WithAPIKey(apiKey),
-		pinecone.WithHost(pineconeHost),
-		pinecone.WithEmbedder(e),
-		pinecone.WithNameSpace(id),
-	)
-	require.NoError(t, err)
-
-	_, err = store.SimilaritySearch(context.Background(),
-		"Which of these are cities in Japan", 10,
-		vectorstores.WithScoreThreshold(-0.8),
-		vectorstores.WithNameSpace(id),
-	)
-	require.Error(t, err)
-
-	_, err = store.SimilaritySearch(context.Background(),
-		"Which of these are cities in Japan", 10,
-		vectorstores.WithScoreThreshold(1.8),
-		vectorstores.WithNameSpace(id),
-	)
-	require.Error(t, err)
+	require.True(t, strings.Contains(result, "orange"), "expected orange in result")
 }
 
 func TestPineconeAsRetrieverWithScoreThreshold(t *testing.T) {
-	apiKey, pineconeHost := getValues(t)
+	t.Parallel()
+
+	apiKey, host := getValues(t)
 
 	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
 	require.NoError(t, err)
-
 	e, err := embeddings.NewEmbedder(llm)
 	require.NoError(t, err)
 
 	store, err := pinecone.New(
 		context.Background(),
 		pinecone.WithAPIKey(apiKey),
-		pinecone.WithHost(pineconeHost),
+		pinecone.WithHost(host),
 		pinecone.WithEmbedder(e),
+	)
+	require.NoError(t, err)
+
+	id := uuid.New().String()
+
+	_, err = store.AddDocuments(
+		context.Background(),
+		[]schema.Document{
+			{PageContent: "The color of the house is blue."},
+			{PageContent: "The color of the car is red."},
+			{PageContent: "The color of the desk is orange."},
+			{PageContent: "The color of the lamp beside the desk is black."},
+			{PageContent: "The color of the chair beside the desk is beige."},
+		},
+		vectorstores.WithNameSpace(id),
 	)
 	require.NoError(t, err)
 
@@ -287,7 +271,8 @@ func TestPineconeAsRetrieverWithScoreThreshold(t *testing.T) {
 		context.TODO(),
 		chains.NewRetrievalQAFromLLM(
 			llm,
-			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(id), vectorstores.WithScoreThreshold(0.8)),
+			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(
+				id), vectorstores.WithScoreThreshold(0.8)),
 		),
 		"What colors is each piece of furniture next to the desk?",
 	)
@@ -299,19 +284,60 @@ func TestPineconeAsRetrieverWithScoreThreshold(t *testing.T) {
 }
 
 func TestPineconeAsRetrieverWithMetadataFilterEqualsClause(t *testing.T) {
-	apiKey, pineconeHost := getValues(t)
+	t.Parallel()
+
+	apiKey, host := getValues(t)
 
 	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
 	require.NoError(t, err)
-
 	e, err := embeddings.NewEmbedder(llm)
 	require.NoError(t, err)
 
 	store, err := pinecone.New(
 		context.Background(),
 		pinecone.WithAPIKey(apiKey),
-		pinecone.WithHost(pineconeHost),
+		pinecone.WithHost(host),
 		pinecone.WithEmbedder(e),
+	)
+	require.NoError(t, err)
+
+	id := uuid.New().String()
+
+	_, err = store.AddDocuments(
+		context.Background(),
+		[]schema.Document{
+			{
+				PageContent: "The color of the lamp beside the desk is black.",
+				Metadata: map[string]any{
+					"location": "kitchen",
+				},
+			},
+			{
+				PageContent: "The color of the lamp beside the desk is blue.",
+				Metadata: map[string]any{
+					"location": "bedroom",
+				},
+			},
+			{
+				PageContent: "The color of the lamp beside the desk is orange.",
+				Metadata: map[string]any{
+					"location": "office",
+				},
+			},
+			{
+				PageContent: "The color of the lamp beside the desk is purple.",
+				Metadata: map[string]any{
+					"location": "sitting room",
+				},
+			},
+			{
+				PageContent: "The color of the lamp beside the desk is yellow.",
+				Metadata: map[string]any{
+					"location": "patio",
+				},
+			},
+		},
+		vectorstores.WithNameSpace(id),
 	)
 	require.NoError(t, err)
 
@@ -324,7 +350,8 @@ func TestPineconeAsRetrieverWithMetadataFilterEqualsClause(t *testing.T) {
 		context.TODO(),
 		chains.NewRetrievalQAFromLLM(
 			llm,
-			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(id), vectorstores.WithFilters(filter)),
+			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(
+				id), vectorstores.WithFilters(filter)),
 		),
 		"What colors is the lamp?",
 	)
@@ -334,19 +361,60 @@ func TestPineconeAsRetrieverWithMetadataFilterEqualsClause(t *testing.T) {
 }
 
 func TestPineconeAsRetrieverWithMetadataFilterInClause(t *testing.T) {
-	apiKey, pineconeHost := getValues(t)
+	t.Parallel()
+
+	apiKey, host := getValues(t)
 
 	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
 	require.NoError(t, err)
-
 	e, err := embeddings.NewEmbedder(llm)
 	require.NoError(t, err)
 
 	store, err := pinecone.New(
 		context.Background(),
 		pinecone.WithAPIKey(apiKey),
-		pinecone.WithHost(pineconeHost),
+		pinecone.WithHost(host),
 		pinecone.WithEmbedder(e),
+	)
+	require.NoError(t, err)
+
+	id := uuid.New().String()
+
+	_, err = store.AddDocuments(
+		context.Background(),
+		[]schema.Document{
+			{
+				PageContent: "The color of the lamp beside the desk is black.",
+				Metadata: map[string]any{
+					"location": "kitchen",
+				},
+			},
+			{
+				PageContent: "The color of the lamp beside the desk is blue.",
+				Metadata: map[string]any{
+					"location": "bedroom",
+				},
+			},
+			{
+				PageContent: "The color of the lamp beside the desk is orange.",
+				Metadata: map[string]any{
+					"location": "office",
+				},
+			},
+			{
+				PageContent: "The color of the lamp beside the desk is purple.",
+				Metadata: map[string]any{
+					"location": "sitting room",
+				},
+			},
+			{
+				PageContent: "The color of the lamp beside the desk is yellow.",
+				Metadata: map[string]any{
+					"location": "patio",
+				},
+			},
+		},
+		vectorstores.WithNameSpace(id),
 	)
 	require.NoError(t, err)
 
@@ -359,7 +427,8 @@ func TestPineconeAsRetrieverWithMetadataFilterInClause(t *testing.T) {
 		context.TODO(),
 		chains.NewRetrievalQAFromLLM(
 			llm,
-			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(id), vectorstores.WithFilters(filter)),
+			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(
+				id), vectorstores.WithFilters(filter)),
 		),
 		"What color is the lamp in each room?",
 	)
@@ -369,20 +438,128 @@ func TestPineconeAsRetrieverWithMetadataFilterInClause(t *testing.T) {
 	require.Contains(t, result, "orange", "expected orange in result")
 }
 
-func TestPineconeAsRetrieverWithMetadataFilters(t *testing.T) {
-	apiKey, pineconeHost := getValues(t)
+func TestPineconeAsRetrieverWithMetadataFilterNotSelected(t *testing.T) {
+	t.Parallel()
+
+	apiKey, host := getValues(t)
 
 	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
 	require.NoError(t, err)
-
 	e, err := embeddings.NewEmbedder(llm)
 	require.NoError(t, err)
 
 	store, err := pinecone.New(
 		context.Background(),
 		pinecone.WithAPIKey(apiKey),
-		pinecone.WithHost(pineconeHost),
+		pinecone.WithHost(host),
 		pinecone.WithEmbedder(e),
+	)
+	require.NoError(t, err)
+
+	id := uuid.New().String()
+
+	_, err = store.AddDocuments(
+		context.Background(),
+		[]schema.Document{
+			{
+				PageContent: "The color of the lamp beside the desk is black.",
+				Metadata: map[string]any{
+					"location": "kitchen",
+				},
+			},
+			{
+				PageContent: "The color of the lamp beside the desk is blue.",
+				Metadata: map[string]any{
+					"location": "bedroom",
+				},
+			},
+			{
+				PageContent: "The color of the lamp beside the desk is orange.",
+				Metadata: map[string]any{
+					"location": "office",
+				},
+			},
+			{
+				PageContent: "The color of the lamp beside the desk is purple.",
+				Metadata: map[string]any{
+					"location": "sitting room",
+				},
+			},
+			{
+				PageContent: "The color of the lamp beside the desk is yellow.",
+				Metadata: map[string]any{
+					"location": "patio",
+				},
+			},
+		},
+		vectorstores.WithNameSpace(id),
+	)
+	require.NoError(t, err)
+
+	result, err := chains.Run(
+		context.TODO(),
+		chains.NewRetrievalQAFromLLM(
+			llm,
+			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(
+				id)),
+		),
+		"What color is the lamp in each room?",
+	)
+	require.NoError(t, err)
+
+	require.Contains(t, result, "black", "expected black in result")
+	require.Contains(t, result, "blue", "expected blue in result")
+	require.Contains(t, result, "orange", "expected orange in result")
+	require.Contains(t, result, "purple", "expected purple in result")
+	require.Contains(t, result, "yellow", "expected yellow in result")
+}
+
+func TestPineconeAsRetrieverWithMetadataFilters(t *testing.T) {
+	t.Parallel()
+
+	apiKey, host := getValues(t)
+
+	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	store, err := pinecone.New(
+		context.Background(),
+		pinecone.WithAPIKey(apiKey),
+		pinecone.WithHost(host),
+		pinecone.WithEmbedder(e),
+	)
+	require.NoError(t, err)
+
+	id := uuid.New().String()
+
+	_, err = store.AddDocuments(
+		context.Background(),
+		[]schema.Document{
+			{
+				PageContent: "The color of the lamp beside the desk is orange.",
+				Metadata: map[string]any{
+					"location":    "office",
+					"square_feet": 100,
+				},
+			},
+			{
+				PageContent: "The color of the lamp beside the desk is purple.",
+				Metadata: map[string]any{
+					"location":    "sitting room",
+					"square_feet": 400,
+				},
+			},
+			{
+				PageContent: "The color of the lamp beside the desk is yellow.",
+				Metadata: map[string]any{
+					"location":    "patio",
+					"square_feet": 800,
+				},
+			},
+		},
+		vectorstores.WithNameSpace(id),
 	)
 	require.NoError(t, err)
 
@@ -405,7 +582,8 @@ func TestPineconeAsRetrieverWithMetadataFilters(t *testing.T) {
 		context.TODO(),
 		chains.NewRetrievalQAFromLLM(
 			llm,
-			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(id), vectorstores.WithFilters(filter)),
+			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(
+				id), vectorstores.WithFilters(filter)),
 		),
 		"What color is the lamp in each room?",
 	)

--- a/vectorstores/pinecone/pinecone_test.go
+++ b/vectorstores/pinecone/pinecone_test.go
@@ -16,7 +16,11 @@ import (
 	"github.com/tmc/langchaingo/vectorstores/pinecone"
 )
 
-func getValues(t *testing.T) (string, string, string, string) {
+var (
+	id = uuid.New().String()
+)
+
+func getValues(t *testing.T) (string, string) {
 	t.Helper()
 
 	pineconeAPIKey := os.Getenv("PINECONE_API_KEY")
@@ -24,26 +28,17 @@ func getValues(t *testing.T) (string, string, string, string) {
 		t.Skip("Must set PINECONE_API_KEY to run test")
 	}
 
-	environment := os.Getenv("PINECONE_ENVIRONMENT")
-	if environment == "" {
-		t.Skip("Must set PINECONE_ENVIRONMENT to run test")
+	pineconeHost := os.Getenv("PINECONE_HOST")
+	if pineconeHost == "" {
+		t.Skip("Must set PINECONE_HOST to run test")
 	}
 
-	indexName := os.Getenv("PINECONE_INDEX")
-	if environment == "" {
-		t.Skip("Must set PINECONE_INDEX to run test")
+	openaiAPIKey := os.Getenv("OPENAI_API_KEY")
+	if openaiAPIKey == "" {
+		t.Skip("Must set OPENAI_API_KEY to run test")
 	}
 
-	projectName := os.Getenv("PINECONE_PROJECT")
-	if environment == "" {
-		t.Skip("Must set PINECONE_INDEX to run test")
-	}
-
-	if openaiKey := os.Getenv("OPENAI_API_KEY"); openaiKey == "" {
-		t.Skip("OPENAI_API_KEY not set")
-	}
-
-	return environment, pineconeAPIKey, indexName, projectName
+	return pineconeAPIKey, pineconeHost
 }
 
 /* func TestPineconeStoreGRPC(t *testing.T) {
@@ -77,61 +72,28 @@ func getValues(t *testing.T) (string, string, string, string) {
 	require.Equal(t, docs[0].PageContent, "yes")
 } */
 
-func TestPineconeStoreRest(t *testing.T) {
-	t.Parallel()
+func TestPineconeStoreAddDocuments(t *testing.T) {
+	apiKey, pineconeHost := getValues(t)
 
-	environment, apiKey, indexName, projectName := getValues(t)
-
-	llm, err := openai.New()
+	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
 	require.NoError(t, err)
+
 	e, err := embeddings.NewEmbedder(llm)
 	require.NoError(t, err)
 
 	storer, err := pinecone.New(
 		context.Background(),
 		pinecone.WithAPIKey(apiKey),
-		pinecone.WithEnvironment(environment),
-		pinecone.WithIndexName(indexName),
-		pinecone.WithProjectName(projectName),
+		pinecone.WithHost(pineconeHost),
 		pinecone.WithEmbedder(e),
-		pinecone.WithNameSpace(uuid.New().String()),
+		pinecone.WithNameSpace(id),
 	)
 	require.NoError(t, err)
 
 	_, err = storer.AddDocuments(context.Background(), []schema.Document{
-		{PageContent: "tokyo"},
-		{PageContent: "potato"},
-	})
-	require.NoError(t, err)
-
-	docs, err := storer.SimilaritySearch(context.Background(), "japan", 1)
-	require.NoError(t, err)
-	require.Len(t, docs, 1)
-	require.Equal(t, "tokyo", docs[0].PageContent)
-}
-
-func TestPineconeStoreRestWithScoreThreshold(t *testing.T) {
-	t.Parallel()
-
-	environment, apiKey, indexName, projectName := getValues(t)
-
-	llm, err := openai.New()
-	require.NoError(t, err)
-	e, err := embeddings.NewEmbedder(llm)
-	require.NoError(t, err)
-
-	storer, err := pinecone.New(
-		context.Background(),
-		pinecone.WithAPIKey(apiKey),
-		pinecone.WithEnvironment(environment),
-		pinecone.WithIndexName(indexName),
-		pinecone.WithProjectName(projectName),
-		pinecone.WithEmbedder(e),
-		pinecone.WithNameSpace(uuid.New().String()),
-	)
-	require.NoError(t, err)
-
-	_, err = storer.AddDocuments(context.Background(), []schema.Document{
+		{PageContent: "Artificial intelligence (AI), in its broadest sense, is intelligence exhibited by machines, particularly computer systems."},
+		{PageContent: "It is a field of research in computer science that develops and studies methods and software which enable machines to perceive their environment and uses learning and intelligence to take actions that maximize their chances of achieving defined goals."},
+		{PageContent: "Alan Turing was the first person to conduct substantial research in the field that he called machine intelligence."},
 		{PageContent: "Tokyo"},
 		{PageContent: "Yokohama"},
 		{PageContent: "Osaka"},
@@ -142,101 +104,88 @@ func TestPineconeStoreRestWithScoreThreshold(t *testing.T) {
 		{PageContent: "Paris"},
 		{PageContent: "London "},
 		{PageContent: "New York"},
+		{PageContent: "The color of the house is blue."},
+		{PageContent: "The color of the car is red."},
+		{PageContent: "The color of the desk is orange."},
+		{PageContent: "The color of the lamp beside the desk is black."},
+		{PageContent: "The color of the chair beside the desk is beige."},
+		{
+			PageContent: "The color of the lamp beside the desk is black.",
+			Metadata: map[string]any{
+				"location": "kitchen",
+			},
+		},
+		{
+			PageContent: "The color of the lamp beside the desk is blue.",
+			Metadata: map[string]any{
+				"location": "bedroom",
+			},
+		},
+		{
+			PageContent: "The color of the lamp beside the desk is orange.",
+			Metadata: map[string]any{
+				"location": "office",
+			},
+		},
+		{
+			PageContent: "The color of the lamp beside the desk is purple.",
+			Metadata: map[string]any{
+				"location": "sitting room",
+			},
+		},
+		{
+			PageContent: "The color of the lamp beside the desk is yellow.",
+			Metadata: map[string]any{
+				"location": "patio",
+			},
+		},
+		{
+			PageContent: "The color of the lamp beside the desk is orange.",
+			Metadata: map[string]any{
+				"location":    "office",
+				"square_feet": 100,
+			},
+		},
+		{
+			PageContent: "The color of the lamp beside the desk is purple.",
+			Metadata: map[string]any{
+				"location":    "sitting room",
+				"square_feet": 400,
+			},
+		},
+		{
+			PageContent: "The color of the lamp beside the desk is yellow.",
+			Metadata: map[string]any{
+				"location":    "patio",
+				"square_feet": 800,
+			},
+		},
 	})
 	require.NoError(t, err)
-
-	// test with a score threshold of 0.8, expected 6 documents
-	docs, err := storer.SimilaritySearch(context.Background(),
-		"Which of these are cities in Japan", 10,
-		vectorstores.WithScoreThreshold(0.8))
-	require.NoError(t, err)
-	require.Len(t, docs, 6)
-
-	// test with a score threshold of 0, expected all 10 documents
-	docs, err = storer.SimilaritySearch(context.Background(),
-		"Which of these are cities in Japan", 10,
-		vectorstores.WithScoreThreshold(0))
-	require.NoError(t, err)
-	require.Len(t, docs, 10)
-}
-
-func TestSimilaritySearchWithInvalidScoreThreshold(t *testing.T) {
-	t.Parallel()
-
-	environment, apiKey, indexName, projectName := getValues(t)
-
-	llm, err := openai.New()
-	require.NoError(t, err)
-	e, err := embeddings.NewEmbedder(llm)
-	require.NoError(t, err)
-
-	storer, err := pinecone.New(
-		context.Background(),
-		pinecone.WithAPIKey(apiKey),
-		pinecone.WithEnvironment(environment),
-		pinecone.WithIndexName(indexName),
-		pinecone.WithProjectName(projectName),
-		pinecone.WithEmbedder(e),
-		pinecone.WithNameSpace(uuid.New().String()),
-	)
-	require.NoError(t, err)
-
-	_, err = storer.AddDocuments(context.Background(), []schema.Document{
-		{PageContent: "Tokyo"},
-		{PageContent: "Yokohama"},
-		{PageContent: "Osaka"},
-		{PageContent: "Nagoya"},
-		{PageContent: "Sapporo"},
-		{PageContent: "Fukuoka"},
-		{PageContent: "Dublin"},
-		{PageContent: "Paris"},
-		{PageContent: "London "},
-		{PageContent: "New York"},
-	})
-	require.NoError(t, err)
-
-	_, err = storer.SimilaritySearch(context.Background(),
-		"Which of these are cities in Japan", 10,
-		vectorstores.WithScoreThreshold(-0.8))
-	require.Error(t, err)
-
-	_, err = storer.SimilaritySearch(context.Background(),
-		"Which of these are cities in Japan", 10,
-		vectorstores.WithScoreThreshold(1.8))
-	require.Error(t, err)
 }
 
 func TestPineconeAsRetriever(t *testing.T) {
-	t.Parallel()
+	apiKey, pineconeHost := getValues(t)
 
-	environment, apiKey, indexName, projectName := getValues(t)
-
-	llm, err := openai.New()
+	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
 	require.NoError(t, err)
+
 	e, err := embeddings.NewEmbedder(llm)
 	require.NoError(t, err)
 
 	store, err := pinecone.New(
 		context.Background(),
 		pinecone.WithAPIKey(apiKey),
-		pinecone.WithEnvironment(environment),
-		pinecone.WithIndexName(indexName),
-		pinecone.WithProjectName(projectName),
+		pinecone.WithHost(pineconeHost),
 		pinecone.WithEmbedder(e),
 	)
 	require.NoError(t, err)
 
-	id := uuid.New().String()
-
-	_, err = store.AddDocuments(
-		context.Background(),
-		[]schema.Document{
-			{PageContent: "The color of the house is blue."},
-			{PageContent: "The color of the car is red."},
-			{PageContent: "The color of the desk is orange."},
-		},
-		vectorstores.WithNameSpace(id),
-	)
+	_, err = store.AddDocuments(context.Background(), []schema.Document{
+		{PageContent: "Artificial intelligence (AI), in its broadest sense, is intelligence exhibited by machines, particularly computer systems."},
+		{PageContent: "It is a field of research in computer science that develops and studies methods and software which enable machines to perceive their environment and uses learning and intelligence to take actions that maximize their chances of achieving defined goals."},
+		{PageContent: "Alan Turing was the first person to conduct substantial research in the field that he called machine intelligence."},
+	}, vectorstores.WithNameSpace(id))
 	require.NoError(t, err)
 
 	result, err := chains.Run(
@@ -245,44 +194,96 @@ func TestPineconeAsRetriever(t *testing.T) {
 			llm,
 			vectorstores.ToRetriever(store, 1, vectorstores.WithNameSpace(id)),
 		),
-		"What color is the desk?",
+		"who was the first person to conduct substantial research in AI?",
 	)
 	require.NoError(t, err)
-	require.True(t, strings.Contains(result, "orange"), "expected orange in result")
+	require.True(t, strings.Contains(result, "Alan Turing"), "expected Alan Turing in result")
+}
+
+func TestPineconeStoreRestWithScoreThreshold(t *testing.T) {
+	apiKey, pineconeHost := getValues(t)
+
+	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
+	require.NoError(t, err)
+
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	storer, err := pinecone.New(
+		context.Background(),
+		pinecone.WithAPIKey(apiKey),
+		pinecone.WithHost(pineconeHost),
+		pinecone.WithEmbedder(e),
+		pinecone.WithNameSpace(id),
+	)
+	require.NoError(t, err)
+
+	// test with a score threshold of 0.8, expected 6 documents
+	docs, err := storer.SimilaritySearch(context.Background(),
+		"Which of these are cities in Japan?", 10,
+		vectorstores.WithScoreThreshold(0.8),
+		vectorstores.WithNameSpace(id),
+	)
+	require.NoError(t, err)
+	require.Len(t, docs, 6)
+
+	// test with a score threshold of 0, expected all 10 documents
+	docs, err = storer.SimilaritySearch(context.Background(),
+		"Which of these are cities in Japan", 10,
+		vectorstores.WithScoreThreshold(0),
+		vectorstores.WithNameSpace(id),
+	)
+	require.NoError(t, err)
+	require.Len(t, docs, 10)
+}
+
+func TestSimilaritySearchWithInvalidScoreThreshold(t *testing.T) {
+	apiKey, pineconeHost := getValues(t)
+
+	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
+	require.NoError(t, err)
+
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	storer, err := pinecone.New(
+		context.Background(),
+		pinecone.WithAPIKey(apiKey),
+		pinecone.WithHost(pineconeHost),
+		pinecone.WithEmbedder(e),
+		pinecone.WithNameSpace(id),
+	)
+	require.NoError(t, err)
+
+	_, err = storer.SimilaritySearch(context.Background(),
+		"Which of these are cities in Japan", 10,
+		vectorstores.WithScoreThreshold(-0.8),
+		vectorstores.WithNameSpace(id),
+	)
+	require.Error(t, err)
+
+	_, err = storer.SimilaritySearch(context.Background(),
+		"Which of these are cities in Japan", 10,
+		vectorstores.WithScoreThreshold(1.8),
+		vectorstores.WithNameSpace(id),
+	)
+	require.Error(t, err)
 }
 
 func TestPineconeAsRetrieverWithScoreThreshold(t *testing.T) {
-	t.Parallel()
+	apiKey, pineconeHost := getValues(t)
 
-	environment, apiKey, indexName, projectName := getValues(t)
-
-	llm, err := openai.New()
+	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
 	require.NoError(t, err)
+
 	e, err := embeddings.NewEmbedder(llm)
 	require.NoError(t, err)
 
 	store, err := pinecone.New(
 		context.Background(),
 		pinecone.WithAPIKey(apiKey),
-		pinecone.WithEnvironment(environment),
-		pinecone.WithIndexName(indexName),
-		pinecone.WithProjectName(projectName),
+		pinecone.WithHost(pineconeHost),
 		pinecone.WithEmbedder(e),
-	)
-	require.NoError(t, err)
-
-	id := uuid.New().String()
-
-	_, err = store.AddDocuments(
-		context.Background(),
-		[]schema.Document{
-			{PageContent: "The color of the house is blue."},
-			{PageContent: "The color of the car is red."},
-			{PageContent: "The color of the desk is orange."},
-			{PageContent: "The color of the lamp beside the desk is black."},
-			{PageContent: "The color of the chair beside the desk is beige."},
-		},
-		vectorstores.WithNameSpace(id),
 	)
 	require.NoError(t, err)
 
@@ -290,8 +291,7 @@ func TestPineconeAsRetrieverWithScoreThreshold(t *testing.T) {
 		context.TODO(),
 		chains.NewRetrievalQAFromLLM(
 			llm,
-			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(
-				id), vectorstores.WithScoreThreshold(0.8)),
+			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(id), vectorstores.WithScoreThreshold(0.8)),
 		),
 		"What colors is each piece of furniture next to the desk?",
 	)
@@ -303,62 +303,19 @@ func TestPineconeAsRetrieverWithScoreThreshold(t *testing.T) {
 }
 
 func TestPineconeAsRetrieverWithMetadataFilterEqualsClause(t *testing.T) {
-	t.Parallel()
+	apiKey, pineconeHost := getValues(t)
 
-	environment, apiKey, indexName, projectName := getValues(t)
-
-	llm, err := openai.New()
+	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
 	require.NoError(t, err)
+
 	e, err := embeddings.NewEmbedder(llm)
 	require.NoError(t, err)
 
 	store, err := pinecone.New(
 		context.Background(),
 		pinecone.WithAPIKey(apiKey),
-		pinecone.WithEnvironment(environment),
-		pinecone.WithIndexName(indexName),
-		pinecone.WithProjectName(projectName),
+		pinecone.WithHost(pineconeHost),
 		pinecone.WithEmbedder(e),
-	)
-	require.NoError(t, err)
-
-	id := uuid.New().String()
-
-	_, err = store.AddDocuments(
-		context.Background(),
-		[]schema.Document{
-			{
-				PageContent: "The color of the lamp beside the desk is black.",
-				Metadata: map[string]any{
-					"location": "kitchen",
-				},
-			},
-			{
-				PageContent: "The color of the lamp beside the desk is blue.",
-				Metadata: map[string]any{
-					"location": "bedroom",
-				},
-			},
-			{
-				PageContent: "The color of the lamp beside the desk is orange.",
-				Metadata: map[string]any{
-					"location": "office",
-				},
-			},
-			{
-				PageContent: "The color of the lamp beside the desk is purple.",
-				Metadata: map[string]any{
-					"location": "sitting room",
-				},
-			},
-			{
-				PageContent: "The color of the lamp beside the desk is yellow.",
-				Metadata: map[string]any{
-					"location": "patio",
-				},
-			},
-		},
-		vectorstores.WithNameSpace(id),
 	)
 	require.NoError(t, err)
 
@@ -371,8 +328,7 @@ func TestPineconeAsRetrieverWithMetadataFilterEqualsClause(t *testing.T) {
 		context.TODO(),
 		chains.NewRetrievalQAFromLLM(
 			llm,
-			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(
-				id), vectorstores.WithFilters(filter)),
+			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(id), vectorstores.WithFilters(filter)),
 		),
 		"What colors is the lamp?",
 	)
@@ -382,62 +338,19 @@ func TestPineconeAsRetrieverWithMetadataFilterEqualsClause(t *testing.T) {
 }
 
 func TestPineconeAsRetrieverWithMetadataFilterInClause(t *testing.T) {
-	t.Parallel()
+	apiKey, pineconeHost := getValues(t)
 
-	environment, apiKey, indexName, projectName := getValues(t)
-
-	llm, err := openai.New()
+	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
 	require.NoError(t, err)
+
 	e, err := embeddings.NewEmbedder(llm)
 	require.NoError(t, err)
 
 	store, err := pinecone.New(
 		context.Background(),
 		pinecone.WithAPIKey(apiKey),
-		pinecone.WithEnvironment(environment),
-		pinecone.WithIndexName(indexName),
-		pinecone.WithProjectName(projectName),
+		pinecone.WithHost(pineconeHost),
 		pinecone.WithEmbedder(e),
-	)
-	require.NoError(t, err)
-
-	id := uuid.New().String()
-
-	_, err = store.AddDocuments(
-		context.Background(),
-		[]schema.Document{
-			{
-				PageContent: "The color of the lamp beside the desk is black.",
-				Metadata: map[string]any{
-					"location": "kitchen",
-				},
-			},
-			{
-				PageContent: "The color of the lamp beside the desk is blue.",
-				Metadata: map[string]any{
-					"location": "bedroom",
-				},
-			},
-			{
-				PageContent: "The color of the lamp beside the desk is orange.",
-				Metadata: map[string]any{
-					"location": "office",
-				},
-			},
-			{
-				PageContent: "The color of the lamp beside the desk is purple.",
-				Metadata: map[string]any{
-					"location": "sitting room",
-				},
-			},
-			{
-				PageContent: "The color of the lamp beside the desk is yellow.",
-				Metadata: map[string]any{
-					"location": "patio",
-				},
-			},
-		},
-		vectorstores.WithNameSpace(id),
 	)
 	require.NoError(t, err)
 
@@ -450,8 +363,7 @@ func TestPineconeAsRetrieverWithMetadataFilterInClause(t *testing.T) {
 		context.TODO(),
 		chains.NewRetrievalQAFromLLM(
 			llm,
-			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(
-				id), vectorstores.WithFilters(filter)),
+			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(id), vectorstores.WithFilters(filter)),
 		),
 		"What color is the lamp in each room?",
 	)
@@ -459,134 +371,22 @@ func TestPineconeAsRetrieverWithMetadataFilterInClause(t *testing.T) {
 
 	require.Contains(t, result, "black", "expected black in result")
 	require.Contains(t, result, "orange", "expected orange in result")
-}
-
-func TestPineconeAsRetrieverWithMetadataFilterNotSelected(t *testing.T) {
-	t.Parallel()
-
-	environment, apiKey, indexName, projectName := getValues(t)
-
-	llm, err := openai.New()
-	require.NoError(t, err)
-	e, err := embeddings.NewEmbedder(llm)
-	require.NoError(t, err)
-
-	store, err := pinecone.New(
-		context.Background(),
-		pinecone.WithAPIKey(apiKey),
-		pinecone.WithEnvironment(environment),
-		pinecone.WithIndexName(indexName),
-		pinecone.WithProjectName(projectName),
-		pinecone.WithEmbedder(e),
-	)
-	require.NoError(t, err)
-
-	id := uuid.New().String()
-
-	_, err = store.AddDocuments(
-		context.Background(),
-		[]schema.Document{
-			{
-				PageContent: "The color of the lamp beside the desk is black.",
-				Metadata: map[string]any{
-					"location": "kitchen",
-				},
-			},
-			{
-				PageContent: "The color of the lamp beside the desk is blue.",
-				Metadata: map[string]any{
-					"location": "bedroom",
-				},
-			},
-			{
-				PageContent: "The color of the lamp beside the desk is orange.",
-				Metadata: map[string]any{
-					"location": "office",
-				},
-			},
-			{
-				PageContent: "The color of the lamp beside the desk is purple.",
-				Metadata: map[string]any{
-					"location": "sitting room",
-				},
-			},
-			{
-				PageContent: "The color of the lamp beside the desk is yellow.",
-				Metadata: map[string]any{
-					"location": "patio",
-				},
-			},
-		},
-		vectorstores.WithNameSpace(id),
-	)
-	require.NoError(t, err)
-
-	result, err := chains.Run(
-		context.TODO(),
-		chains.NewRetrievalQAFromLLM(
-			llm,
-			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(
-				id)),
-		),
-		"What color is the lamp in each room?",
-	)
-	require.NoError(t, err)
-
-	require.Contains(t, result, "black", "expected black in result")
-	require.Contains(t, result, "blue", "expected blue in result")
-	require.Contains(t, result, "orange", "expected orange in result")
-	require.Contains(t, result, "purple", "expected purple in result")
-	require.Contains(t, result, "yellow", "expected yellow in result")
 }
 
 func TestPineconeAsRetrieverWithMetadataFilters(t *testing.T) {
-	t.Parallel()
+	apiKey, pineconeHost := getValues(t)
 
-	environment, apiKey, indexName, projectName := getValues(t)
-
-	llm, err := openai.New()
+	llm, err := openai.New(openai.WithEmbeddingModel("text-embedding-ada-002"))
 	require.NoError(t, err)
+
 	e, err := embeddings.NewEmbedder(llm)
 	require.NoError(t, err)
 
 	store, err := pinecone.New(
 		context.Background(),
 		pinecone.WithAPIKey(apiKey),
-		pinecone.WithEnvironment(environment),
-		pinecone.WithIndexName(indexName),
-		pinecone.WithProjectName(projectName),
+		pinecone.WithHost(pineconeHost),
 		pinecone.WithEmbedder(e),
-	)
-	require.NoError(t, err)
-
-	id := uuid.New().String()
-
-	_, err = store.AddDocuments(
-		context.Background(),
-		[]schema.Document{
-			{
-				PageContent: "The color of the lamp beside the desk is orange.",
-				Metadata: map[string]any{
-					"location":    "office",
-					"square_feet": 100,
-				},
-			},
-			{
-				PageContent: "The color of the lamp beside the desk is purple.",
-				Metadata: map[string]any{
-					"location":    "sitting room",
-					"square_feet": 400,
-				},
-			},
-			{
-				PageContent: "The color of the lamp beside the desk is yellow.",
-				Metadata: map[string]any{
-					"location":    "patio",
-					"square_feet": 800,
-				},
-			},
-		},
-		vectorstores.WithNameSpace(id),
 	)
 	require.NoError(t, err)
 
@@ -609,8 +409,7 @@ func TestPineconeAsRetrieverWithMetadataFilters(t *testing.T) {
 		context.TODO(),
 		chains.NewRetrievalQAFromLLM(
 			llm,
-			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(
-				id), vectorstores.WithFilters(filter)),
+			vectorstores.ToRetriever(store, 5, vectorstores.WithNameSpace(id), vectorstores.WithFilters(filter)),
 		),
 		"What color is the lamp in each room?",
 	)

--- a/vectorstores/pinecone/restapi.go
+++ b/vectorstores/pinecone/restapi.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 
 	"github.com/google/uuid"
 	"github.com/tmc/langchaingo/schema"
@@ -72,7 +71,7 @@ func (s Store) restUpsert(
 	body, status, err := doRequest(
 		ctx,
 		payload,
-		getEndpoint(s.indexName, s.projectName, s.environment)+"/vectors/upsert",
+		s.host+"/vectors/upsert",
 		s.apiKey,
 		http.MethodPost,
 	)
@@ -135,7 +134,7 @@ func (s Store) restQuery(
 	body, statusCode, err := doRequest(
 		ctx,
 		payload,
-		getEndpoint(s.indexName, s.projectName, s.environment)+"/query",
+		s.host+"/query",
 		s.apiKey,
 		http.MethodPost,
 	)
@@ -206,16 +205,4 @@ func doRequest(ctx context.Context, payload any, url, apiKey, method string) (io
 		return nil, 0, err
 	}
 	return r.Body, r.StatusCode, err
-}
-
-func getEndpoint(index, project, environment string) string {
-	urlString := url.QueryEscape(
-		fmt.Sprintf(
-			"%s-%s.svc.%s.pinecone.io",
-			index,
-			project,
-			environment,
-		),
-	)
-	return "https://" + urlString
 }


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.


This pull request addresses two bugs identified in issue #779:

**1. Unexpected Status Code (400) Bug:**

- Users were encountering a status code 400 error indicating the need to provide a model parameter (openai.WithEmbeddingModel("text-embedding-ada-002")) when constructing the openai type from the openai package. This PR resolves this issue by updating the pinecone_test.go file to include the required model parameter.

**2. Unauthorized Response Bug:**

- After adding documents into Pinecone with the embedding option, users were receiving an unauthorized response. This was due to an incorrect API usage from the WithProjectName() function. Pinecone requires a projectID, not a projectName. The quickest way to fix this is to replace the option of WithProjectName() with WithProjectID(). But I think this construction is redundant when it is used together with WithIndexName() and WithEnvironment() solely for constructing the Pinecone's endpoints. So this PR introduced WithHost() option, which the host can be easily obtained when creating index database in Pinecone. 