### PR TITLE
Chat Memory History: add sqlite3 backend

### DIFF
--- a/examples/chains-conversation-memory-sqlite/chains_conversation_memory_sqlite.go
+++ b/examples/chains-conversation-memory-sqlite/chains_conversation_memory_sqlite.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+
+	"github.com/tmc/langchaingo/chains"
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/openai"
+	"github.com/tmc/langchaingo/memory"
+	"github.com/tmc/langchaingo/memory/sqlite3"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func prepare(ctx context.Context, db *sql.DB) error {
+	// check if db has any records
+	var count int
+	res := db.QueryRowContext(ctx, "SELECT count(id) FROM langchaingo_messages")
+	if err := res.Err(); err != nil {
+		return err
+	}
+
+	if err := res.Scan(&count); err != nil {
+		return err
+	}
+
+	if count > 0 {
+		return nil
+	}
+
+	_, err := db.ExecContext(
+		ctx,
+		"INSERT INTO langchaingo_messages(session, content, type) VALUES (?, ?, ?)",
+		"example",
+		"Hi there, my name is Murilo!",
+		llms.ChatMessageTypeHuman,
+	)
+	return err
+}
+
+func run() error {
+	llm, err := openai.New()
+	if err != nil {
+		return err
+	}
+
+	db, err := sql.Open("sqlite3", "history_example.db")
+	if err != nil {
+		return err
+	}
+
+	chatHistory := sqlite3.NewSqliteChatMessageHistory(
+		sqlite3.WithSession("example"),
+		sqlite3.WithDB(db),
+	)
+	conversationBuffer := memory.NewConversationBuffer(memory.WithChatHistory(chatHistory))
+	llmChain := chains.NewConversation(llm, conversationBuffer)
+	ctx := context.Background()
+
+	// prepare the db with some sample data
+	if err := prepare(ctx, db); err != nil {
+		return err
+	}
+
+	out, err := chains.Run(ctx, llmChain, "What's my name? How many times did I ask this?")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(out)
+	return nil
+}

--- a/memory/sqlite3/sqlite3_history.go
+++ b/memory/sqlite3/sqlite3_history.go
@@ -1,0 +1,160 @@
+// Package sqlite3 adds support for
+// chat message history using sqlite3.
+package sqlite3
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"strings"
+
+	_ "github.com/mattn/go-sqlite3" // sqlite3 driver.
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/schema"
+)
+
+// SqliteChatMessageHistory is a struct that stores chat messages.
+type SqliteChatMessageHistory struct {
+	// DB is the database connection.
+	DB *sql.DB
+	// Ctx is a context that can be used for the schema exec.
+	//nolint:containedctx // This is used only when execing schema.
+	Ctx context.Context
+	// DBAddress is the address or file path for connecting the db.
+	DBAddress string
+	// TableName is the name of the messages table.
+	TableName string
+	// Limit is the max number of records per select.
+	Limit int
+	// Session defines a session name or id for a conversation.
+	Session string
+	// Schema defines a initial schema to be run.
+	Schema []byte
+	// Overwrite is a safety flag used for SetMessages and Clear functions.
+	Overwrite bool
+}
+
+// Statically assert that SqliteChatMessageHistory implement the chat message history interface.
+var _ schema.ChatMessageHistory = &SqliteChatMessageHistory{}
+
+// NewSqliteChatMessageHistory creates a new SqliteChatMessageHistory using chat message options.
+func NewSqliteChatMessageHistory(options ...SqliteChatMessageHistoryOption) *SqliteChatMessageHistory {
+	return applyChatOptions(options...)
+}
+
+// Messages returns all messages stored.
+func (h *SqliteChatMessageHistory) Messages(ctx context.Context) ([]llms.ChatMessage, error) {
+	querytpl := []string{
+		"SELECT content,type,created FROM ",
+		" WHERE session = ? ORDER BY created ASC LIMIT ?;",
+	}
+	query := strings.Join(querytpl, h.TableName)
+	res, err := h.DB.QueryContext(ctx, query, h.Session, h.Limit)
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Close()
+
+	var msgs []llms.ChatMessage
+	for res.Next() {
+		var content, msgtype string
+		var created interface{}
+
+		if err = res.Scan(&content, &msgtype, &created); err != nil {
+			return nil, err
+		}
+
+		switch msgtype {
+		case string(llms.ChatMessageTypeAI):
+			msgs = append(msgs, llms.AIChatMessage{Content: content})
+		case string(llms.ChatMessageTypeHuman):
+			msgs = append(msgs, llms.HumanChatMessage{Content: content})
+		case string(llms.ChatMessageTypeSystem):
+			msgs = append(msgs, llms.SystemChatMessage{Content: content})
+		default:
+		}
+	}
+
+	if err := res.Err(); err != nil {
+		return nil, err
+	}
+
+	return msgs, nil
+}
+
+func (h *SqliteChatMessageHistory) addMessage(ctx context.Context, text string, role llms.ChatMessageType) error {
+	querytpl := []string{
+		"INSERT INTO ",
+		" (session, content, type) VALUES (?, ?, ?);",
+	}
+	query := strings.Join(querytpl, h.TableName)
+	_, err := h.DB.ExecContext(ctx, query, h.Session, text, role)
+	return err
+}
+
+// AddMessage adds a message to the chat message history.
+func (h *SqliteChatMessageHistory) AddMessage(ctx context.Context, message llms.ChatMessage) error {
+	return h.addMessage(ctx, message.GetContent(), message.GetType())
+}
+
+// AddAIMessage adds an AIMessage to the chat message history.
+func (h *SqliteChatMessageHistory) AddAIMessage(ctx context.Context, text string) error {
+	return h.addMessage(ctx, text, llms.ChatMessageTypeAI)
+}
+
+// AddUserMessage adds a user to the chat message history.
+func (h *SqliteChatMessageHistory) AddUserMessage(ctx context.Context, text string) error {
+	return h.addMessage(ctx, text, llms.ChatMessageTypeHuman)
+}
+
+// Clear resets messages.
+func (h *SqliteChatMessageHistory) Clear(ctx context.Context) error {
+	if !h.Overwrite {
+		return nil
+	}
+
+	querytpl := []string{
+		"DELETE FROM ",
+		" WHERE session = ?;",
+	}
+	query := strings.Join(querytpl, h.TableName)
+	_, err := h.DB.ExecContext(ctx, query, h.Session)
+	return err
+}
+
+// SetMessages resets chat history and bulk insert new messages into it.
+func (h *SqliteChatMessageHistory) SetMessages(ctx context.Context, messages []llms.ChatMessage) error {
+	if !h.Overwrite {
+		return nil
+	}
+
+	/*
+	 BEGIN TRANSACTION;
+	 DELETE FROM table WHERE session = ?;
+	 INSERT INTO table (session, content, type)
+	 VALUES (?, ?, ?), ...;
+	 COMMIT;`
+	*/
+	buf := bytes.NewBufferString("BEGIN TRANSACTION;")
+	buf.WriteString(" DELETE FROM ")
+	buf.WriteString(h.TableName)
+	buf.WriteString(" WHERE session = ?;")
+	buf.WriteString(" INSERT INTO ")
+	buf.WriteString(h.TableName)
+	buf.WriteString(" (session, content, type) VALUES ")
+
+	inputs := make([]string, len(messages))
+	values := []interface{}{h.Session}
+
+	for i, msg := range messages {
+		inputs[i] = "(?, ?, ?)"
+		values = append(values, h.Session, msg.GetContent(), string(msg.GetType()))
+	}
+
+	buf.WriteString(strings.Join(inputs, ", "))
+	buf.WriteString("; COMMIT;")
+
+	_, err := h.DB.ExecContext(ctx, buf.String(), values...)
+	return err
+}

--- a/memory/sqlite3/sqlite3_history_options.go
+++ b/memory/sqlite3/sqlite3_history_options.go
@@ -1,0 +1,141 @@
+package sqlite3
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	_ "github.com/mattn/go-sqlite3" // sqlite3 driver.
+)
+
+// DefaultLimit sets a default limit for select queries.
+const DefaultLimit = 1000
+
+// DefaultTableName sets a default table name.
+const DefaultTableName = "langchaingo_messages"
+
+// DefaultSchema sets a default schema to be run after connecting.
+const DefaultSchema = `CREATE TABLE IF NOT EXISTS %s (
+		id INTEGER PRIMARY KEY,
+		name TEXT,
+		session TEXT NOT NULL,
+		content TEXT NOT NULL,
+		type TEXT NOT NULL,
+		created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_langchaingo_id ON %s (id);
+CREATE INDEX IF NOT EXISTS idx_langchaingo_session ON %s (session);`
+
+// SqliteChatMessageHistoryOption is a function for creating new
+// chat message history with other than the default values.
+type SqliteChatMessageHistoryOption func(m *SqliteChatMessageHistory)
+
+// WithDB is an option for NewSqliteChatMessageHistory for adding
+// a database connection.
+func WithDB(db *sql.DB) SqliteChatMessageHistoryOption {
+	return func(m *SqliteChatMessageHistory) {
+		m.DB = db
+	}
+}
+
+// WithContext is an option for NewSqliteChatMessageHistory
+// to use a context internally when running Schema.
+func WithContext(ctx context.Context) SqliteChatMessageHistoryOption {
+	return func(m *SqliteChatMessageHistory) {
+		m.Ctx = ctx
+	}
+}
+
+// WithLimit is an option for NewSqliteChatMessageHistory for
+// defining a limit number for select queries.
+func WithLimit(limit int) SqliteChatMessageHistoryOption {
+	return func(m *SqliteChatMessageHistory) {
+		m.Limit = limit
+	}
+}
+
+// WithSchema is an option for NewSqliteChatMessageHistory for
+// running a schema when connected. Useful for migrations for example.
+func WithSchema(schema []byte) SqliteChatMessageHistoryOption {
+	return func(m *SqliteChatMessageHistory) {
+		m.Schema = schema
+	}
+}
+
+// WithOverwrite is an option for NewSqliteChatMessageHistory for
+// allowing dangerous operations like SetMessages or Clear.
+func WithOverwrite() SqliteChatMessageHistoryOption {
+	return func(m *SqliteChatMessageHistory) {
+		m.Overwrite = true
+	}
+}
+
+// WithDBAddress is an option for NewSqliteChatMessageHistory for
+// specifying an address or file path for when connecting the db.
+func WithDBAddress(addr string) SqliteChatMessageHistoryOption {
+	return func(m *SqliteChatMessageHistory) {
+		m.DBAddress = addr
+	}
+}
+
+// WithTableName is an option for NewSqliteChatMessageHistory for
+// running a schema when connected. Useful for migrations for example.
+func WithTableName(name string) SqliteChatMessageHistoryOption {
+	return func(m *SqliteChatMessageHistory) {
+		m.TableName = name
+	}
+}
+
+// WithSession is an option for NewSqliteChatMessageHistory for
+// setting a session name or id for the history.
+func WithSession(session string) SqliteChatMessageHistoryOption {
+	return func(m *SqliteChatMessageHistory) {
+		m.Session = session
+	}
+}
+
+func applyChatOptions(options ...SqliteChatMessageHistoryOption) *SqliteChatMessageHistory {
+	h := &SqliteChatMessageHistory{}
+
+	for _, option := range options {
+		option(h)
+	}
+
+	if h.TableName == "" {
+		h.TableName = DefaultTableName
+	}
+
+	if h.Limit < 1 {
+		h.Limit = DefaultLimit
+	}
+
+	if h.Schema == nil {
+		h.Schema = []byte(fmt.Sprintf(DefaultSchema, h.TableName, h.TableName, h.TableName))
+	}
+
+	if h.Ctx == nil {
+		h.Ctx = context.Background()
+	}
+
+	if h.DBAddress == "" {
+		h.DBAddress = ":memory:"
+	}
+
+	if h.Session == "" {
+		h.Session = "default"
+	}
+
+	if h.DB == nil {
+		db, err := sql.Open("sqlite3", h.DBAddress)
+		if err != nil {
+			panic(err)
+		}
+		h.DB = db
+	}
+
+	if _, err := h.DB.ExecContext(h.Ctx, string(h.Schema)); err != nil {
+		panic(err)
+	}
+
+	return h
+}

--- a/memory/sqlite3/sqlite3_history_test.go
+++ b/memory/sqlite3/sqlite3_history_test.go
@@ -1,0 +1,56 @@
+package sqlite3_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/memory/sqlite3"
+)
+
+func TestSqliteChatMessageHistory(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	h := sqlite3.NewSqliteChatMessageHistory(sqlite3.WithContext(ctx))
+
+	err := h.AddAIMessage(ctx, "foo")
+	require.NoError(t, err)
+
+	err = h.AddUserMessage(ctx, "bar")
+	require.NoError(t, err)
+
+	messages, err := h.Messages(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, []llms.ChatMessage{
+		llms.AIChatMessage{Content: "foo"},
+		llms.HumanChatMessage{Content: "bar"},
+	}, messages)
+
+	h = sqlite3.NewSqliteChatMessageHistory(
+		sqlite3.WithContext(ctx),
+		sqlite3.WithOverwrite(),
+	)
+
+	err = h.SetMessages(ctx,
+		[]llms.ChatMessage{
+			llms.AIChatMessage{Content: "foo"},
+			llms.SystemChatMessage{Content: "bar"},
+		})
+	require.NoError(t, err)
+
+	err = h.AddUserMessage(ctx, "zoo")
+	require.NoError(t, err)
+
+	messages, err = h.Messages(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, []llms.ChatMessage{
+		llms.AIChatMessage{Content: "foo"},
+		llms.SystemChatMessage{Content: "bar"},
+		llms.HumanChatMessage{Content: "zoo"},
+	}, messages)
+}


### PR DESCRIPTION
Add sqlite3 support for chat memory history.


### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

