### PR TITLE
bugfix: incorrect error return in applyClientOptions function

### DIFF
--- a/vectorstores/opensearch/options.go
+++ b/vectorstores/opensearch/options.go
@@ -48,7 +48,7 @@ func applyClientOptions(s *Store, opts ...Option) error {
 	}
 
 	if s.client == nil {
-		return ErrMissingEmbedded
+		return ErrMissingOpensearchClient
 	}
 
 	return nil


### PR DESCRIPTION
This commit corrects an errors handling issue in the applyClientOptions function within the opensearch options module.

Previously, when the opensearch client was missing, the function erroneously returned ErrMissingEmbedded instead of ErrMissingOpensearchClient.

This update ensures that the current error is returned.


### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
