### PR TITLE
Add metadata fields in OpenAI calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tmc/langchaingo
+module github.com/lowjiansheng/langchaingo
 
 go 1.22.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/lowjiansheng/langchaingo
+module github.com/tmc/langchaingo
 
 go 1.22.0
 

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -59,7 +59,11 @@ type ChatRequest struct {
 	Functions []FunctionDefinition `json:"functions,omitempty"`
 	// Deprecated: use ToolChoice instead.
 	FunctionCallBehavior FunctionCallBehavior `json:"function_call,omitempty"`
+
+	Kwargs RequestKWARGS
 }
+
+type RequestKWARGS map[string]interface{}
 
 // ToolType is the type of a tool.
 type ToolType string

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -63,8 +63,6 @@ type ChatRequest struct {
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
-type RequestKWARGS map[string]interface{}
-
 // ToolType is the type of a tool.
 type ToolType string
 

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -60,7 +60,8 @@ type ChatRequest struct {
 	// Deprecated: use ToolChoice instead.
 	FunctionCallBehavior FunctionCallBehavior `json:"function_call,omitempty"`
 
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	// Metadata allows you to specify additional information that will be passed to the model.
+	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
 // ToolType is the type of a tool.

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -60,7 +60,7 @@ type ChatRequest struct {
 	// Deprecated: use ToolChoice instead.
 	FunctionCallBehavior FunctionCallBehavior `json:"function_call,omitempty"`
 
-	Kwargs RequestKWARGS
+	RequestKWARGS
 }
 
 type RequestKWARGS map[string]interface{}

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -60,7 +60,7 @@ type ChatRequest struct {
 	// Deprecated: use ToolChoice instead.
 	FunctionCallBehavior FunctionCallBehavior `json:"function_call,omitempty"`
 
-	RequestKWARGS
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
 type RequestKWARGS map[string]interface{}

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -108,7 +108,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 
 		FunctionCallBehavior: openaiclient.FunctionCallBehavior(opts.FunctionCallBehavior),
 		Seed:                 opts.Seed,
-		Kwargs:               opts.Kwargs,
+		RequestKWARGS:        opts.Kwargs,
 	}
 	if opts.JSONMode {
 		req.ResponseFormat = ResponseFormatJSON

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -108,7 +108,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 
 		FunctionCallBehavior: openaiclient.FunctionCallBehavior(opts.FunctionCallBehavior),
 		Seed:                 opts.Seed,
-		RequestKWARGS:        opts.Kwargs,
+		Metadata:             opts.Metadata,
 	}
 	if opts.JSONMode {
 		req.ResponseFormat = ResponseFormatJSON

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -108,6 +108,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 
 		FunctionCallBehavior: openaiclient.FunctionCallBehavior(opts.FunctionCallBehavior),
 		Seed:                 opts.Seed,
+		Kwargs:               opts.Kwargs,
 	}
 	if opts.JSONMode {
 		req.ResponseFormat = ResponseFormatJSON

--- a/llms/options.go
+++ b/llms/options.go
@@ -56,8 +56,11 @@ type CallOptions struct {
 	// If a specific function should be invoked, use the format:
 	// `{"name": "my_function"}`
 	// Deprecated: Use ToolChoice instead.
-	FunctionCallBehavior FunctionCallBehavior   `json:"function_call,omitempty"`
-	Metadata             map[string]interface{} `json:"metadata,omitempty"`
+	FunctionCallBehavior FunctionCallBehavior `json:"function_call,omitempty"`
+
+	// Metadata is a map of metadata to include in the request.
+	// The meaning of this field is specific to the backend in use.
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // Tool is a tool that can be used by the model.
@@ -255,6 +258,8 @@ func WithJSONMode() CallOption {
 	}
 }
 
+// WithMetadata will add an option to set metadata to include in the request.
+// The meaning of this field is specific to the backend in use.
 func WithMetadata(metadata map[string]interface{}) CallOption {
 	return func(o *CallOptions) {
 		o.Metadata = metadata

--- a/llms/options.go
+++ b/llms/options.go
@@ -56,7 +56,8 @@ type CallOptions struct {
 	// If a specific function should be invoked, use the format:
 	// `{"name": "my_function"}`
 	// Deprecated: Use ToolChoice instead.
-	FunctionCallBehavior FunctionCallBehavior `json:"function_call,omitempty"`
+	FunctionCallBehavior FunctionCallBehavior   `json:"function_call,omitempty"`
+	Kwargs               map[string]interface{} `json:"kwargs,omitempty"`
 }
 
 // Tool is a tool that can be used by the model.
@@ -251,5 +252,11 @@ func WithTools(tools []Tool) CallOption {
 func WithJSONMode() CallOption {
 	return func(o *CallOptions) {
 		o.JSONMode = true
+	}
+}
+
+func WithKwargs(kwargs map[string]interface{}) CallOption {
+	return func(o *CallOptions) {
+		o.Kwargs = kwargs
 	}
 }

--- a/llms/options.go
+++ b/llms/options.go
@@ -57,7 +57,7 @@ type CallOptions struct {
 	// `{"name": "my_function"}`
 	// Deprecated: Use ToolChoice instead.
 	FunctionCallBehavior FunctionCallBehavior   `json:"function_call,omitempty"`
-	Kwargs               map[string]interface{} `json:"kwargs,omitempty"`
+	Metadata             map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // Tool is a tool that can be used by the model.
@@ -255,8 +255,8 @@ func WithJSONMode() CallOption {
 	}
 }
 
-func WithKwargs(kwargs map[string]interface{}) CallOption {
+func WithMetadata(metadata map[string]interface{}) CallOption {
 	return func(o *CallOptions) {
-		o.Kwargs = kwargs
+		o.Metadata = metadata
 	}
 }


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

There are OpenAI servers (like LiteLLM) that takes in additional `metadata` in their requests to log additional information. In LiteLLM's case, the metadata field is used to store information like custom tags and trace ids which will be propagated to Langfuse. 

In [Langchain Python](https://api.python.langchain.com/en/latest/chat_models/langchain_community.chat_models.openai.ChatOpenAI.html#langchain_community.chat_models.openai.ChatOpenAI.model_kwargs), there are model_kwargs argument to achieve this, however it's difficult to add kwargs to structs for deserialization in Go. Therefore we'll need to hardcode a metadata field here.
