### PR TITLE
Fix: Specify embedding model when instantiating LLM in Pinecone example code

### DIFF
--- a/examples/pinecone-vectorstore-example/pinecone_vectorstore_example.go
+++ b/examples/pinecone-vectorstore-example/pinecone_vectorstore_example.go
@@ -15,9 +15,12 @@ import (
 
 func main() {
 	// Create an embeddings client using the OpenAI API. Requires environment variable OPENAI_API_KEY to be set.
-	llm, err := openai.New()
+	
+	mbeddingModelName := "text-embedding-3-small" // Specify your preferred embedding model
+	// Instantiate LLM with embedding model
+	llm, err := openai.New(openai.WithEmbeddingModel(embeddingModelName))
 	if err != nil {
-		log.Fatal(err)
+       		log.Fatal(err)
 	}
 
 	e, err := embeddings.NewEmbedder(llm)


### PR DESCRIPTION
Title: Fix: Specify embedding model when instantiating LLM in Pinecone example code

Description:
This PR addresses an issue in the example code for the Pinecone vector store in the langchaingo package. The current code does not specify an embedding model when instantiating the Language Model (LLM), resulting in the API returning an unexpected status code: 400 - "you must provide a model parameter." This can lead to unexpected behavior or errors. The proposed change adds a line to specify the embedding model, ensuring the code runs correctly and aligns with best practices.

Changes:

Added a line to specify the embedding model when instantiating LLM in the Pinecone example code.
Please review and merge at your earliest convenience.

Thank you!