### PR TITLE
llms: add googleai llm option `WithHTTPClient`

### DIFF
--- a/llms/googleai/new.go
+++ b/llms/googleai/new.go
@@ -31,7 +31,11 @@ func New(ctx context.Context, opts ...Option) (*GoogleAI, error) {
 		opts: clientOptions,
 	}
 
-	client, err := genai.NewClient(ctx, option.WithAPIKey(clientOptions.APIKey))
+	initOpts := []option.ClientOption{option.WithAPIKey(clientOptions.APIKey)}
+	if clientOptions.HttpClient != nil {
+		initOpts = append(initOpts, option.WithHTTPClient(clientOptions.HttpClient))
+	}
+	client, err := genai.NewClient(ctx, initOpts...)
 	if err != nil {
 		return gi, err
 	}

--- a/llms/googleai/new.go
+++ b/llms/googleai/new.go
@@ -32,8 +32,8 @@ func New(ctx context.Context, opts ...Option) (*GoogleAI, error) {
 	}
 
 	initOpts := []option.ClientOption{option.WithAPIKey(clientOptions.APIKey)}
-	if clientOptions.HttpClient != nil {
-		initOpts = append(initOpts, option.WithHTTPClient(clientOptions.HttpClient))
+	if clientOptions.HTTPClient != nil {
+		initOpts = append(initOpts, option.WithHTTPClient(clientOptions.HTTPClient))
 	}
 	client, err := genai.NewClient(ctx, initOpts...)
 	if err != nil {

--- a/llms/googleai/option.go
+++ b/llms/googleai/option.go
@@ -1,5 +1,7 @@
 package googleai
 
+import "net/http"
+
 // Options is a set of options for GoogleAI and Vertex clients.
 type Options struct {
 	APIKey                string
@@ -13,6 +15,7 @@ type Options struct {
 	DefaultTopK           int
 	DefaultTopP           float64
 	HarmThreshold         HarmBlockThreshold
+	HttpClient            *http.Client
 }
 
 func DefaultOptions() Options {
@@ -113,6 +116,13 @@ func WithDefaultTopP(defaultTopP float64) Option {
 func WithHarmThreshold(ht HarmBlockThreshold) Option {
 	return func(opts *Options) {
 		opts.HarmThreshold = ht
+	}
+}
+
+// WithHttpClient passes a custom http client which will be used to communicate with the remote model.
+func WithHttpClient(client *http.Client) Option {
+	return func(opts *Options) {
+		opts.HttpClient = client
 	}
 }
 

--- a/llms/googleai/option.go
+++ b/llms/googleai/option.go
@@ -15,7 +15,7 @@ type Options struct {
 	DefaultTopK           int
 	DefaultTopP           float64
 	HarmThreshold         HarmBlockThreshold
-	HttpClient            *http.Client
+	HTTPClient            *http.Client
 }
 
 func DefaultOptions() Options {
@@ -119,10 +119,10 @@ func WithHarmThreshold(ht HarmBlockThreshold) Option {
 	}
 }
 
-// WithHttpClient passes a custom http client which will be used to communicate with the remote model.
-func WithHttpClient(client *http.Client) Option {
+// WithHTTPClient passes a custom http client which will be used to communicate with the remote model.
+func WithHTTPClient(client *http.Client) Option {
 	return func(opts *Options) {
-		opts.HttpClient = client
+		opts.HTTPClient = client
 	}
 }
 

--- a/llms/googleai/vertex/new.go
+++ b/llms/googleai/vertex/new.go
@@ -38,8 +38,8 @@ func New(ctx context.Context, opts ...googleai.Option) (*Vertex, error) {
 	if clientOptions.HTTPClient != nil {
 		initOpts = append(initOpts, option.WithHTTPClient(clientOptions.HTTPClient))
 	}
-	client, err := genai.NewClient(ctx, clientOptions.CloudProject, clientOptions.CloudLocation, initOpts...)
 
+	client, err := genai.NewClient(ctx, clientOptions.CloudProject, clientOptions.CloudLocation, initOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/llms/googleai/vertex/new.go
+++ b/llms/googleai/vertex/new.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/googleai"
 	"github.com/tmc/langchaingo/llms/googleai/internal/palmclient"
+	"google.golang.org/api/option"
 )
 
 // Vertex is a type that represents a Vertex AI API client.
@@ -33,12 +34,17 @@ func New(ctx context.Context, opts ...googleai.Option) (*Vertex, error) {
 		opt(&clientOptions)
 	}
 
-	client, err := genai.NewClient(ctx, clientOptions.CloudProject, clientOptions.CloudLocation)
+	initOpts := []option.ClientOption{}
+	if clientOptions.HTTPClient != nil {
+		initOpts = append(initOpts, option.WithHTTPClient(clientOptions.HTTPClient))
+	}
+	client, err := genai.NewClient(ctx, clientOptions.CloudProject, clientOptions.CloudLocation, initOpts...)
+
 	if err != nil {
 		return nil, err
 	}
 
-	palmClient, err := palmclient.New(clientOptions.CloudProject) //nolint:contextcheck
+	palmClient, err := palmclient.New(clientOptions.CloudProject, initOpts...) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Changes
- Adds an option `WithHTTPClient` to Google AI LLM implementation, which passes a consumer provided `http.Client` to the underlying vendor maintained client. The new option is used also by the vertex llm implementation.
- The new option can be used for troubleshooting (example using `httputil.DebugHTTPClient`) or providing flexibility to consume LLM services behind proxies, set additional headers etc.
- Similar options are already available on the [OpenAI LLM](https://github.com/tmc/langchaingo/blob/main/llms/openai/openaillm_option.go#L113) options as well as the existing [PaLM legacy LLM](https://github.com/tmc/langchaingo/blob/main/llms/googleai/palm/palm_llm_option.go#L73)

Issue: fixes https://github.com/tmc/langchaingo/issues/838

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] ~~Describes the source of new concepts.~~
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
