### PR TITLE
readme: add scheme to vectorstores/chroma URL

### DIFF
--- a/vectorstores/chroma/README.md
+++ b/vectorstores/chroma/README.md
@@ -31,12 +31,12 @@ and development workflows. An example invocation scenario is presented below:
 ### Starting the Chroma Server
 
 As of this writing, the newest release of the Chroma docker image is
-[chroma:0.4.24](https://github.com/chroma-core/chroma/pkgs/container/chroma/184319417?tag=0.4.24).
+[chroma:0.5.0](https://github.com/chroma-core/chroma/pkgs/container/chroma/184319417?tag=0.5.0).
 Running it directly while exposing its port to your local machine can be
 accomplished with:
 
 ```shell
-$ docker run -p 8000:8000 ghcr.io/chroma-core/chroma:0.4.24
+$ docker run -p 8000:8000 ghcr.io/chroma-core/chroma:0.5.0
 ```
 
 ### Running an Example `langchaingo` Application
@@ -45,7 +45,7 @@ With the "Simple Docker Server" running (see above), running the included
 example `langchaingo` app should produce the following result:
 
 ```shell
-$ export CHROMA_URL=localhost:8000
+$ export CHROMA_URL=http://localhost:8000
 $ export OPENAI_API_KEY=YourOpenApiKeyGoesHere
 $ go run ./examples/chroma-vectorstore-example/chroma_vectorstore_example.go
 Results:


### PR DESCRIPTION
Perhaps this worked before, but now if you omit the protocol in the URL, you'll get an error like this:

```
2024/05/21 10:15:43 new: Get "localhost:8000/api/v1/heartbeat": unsupported protocol scheme "localhost"
```

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [n/a] Describes the source of new concepts.
- [n/a] References existing implementations as appropriate.
- [n/a] Contains test coverage for new functions.
- [n/a] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
