### PR TITLE
Take genai.Client as argument for GoogleAI constructor

### DIFF
--- a/llms/googleai/new.go
+++ b/llms/googleai/new.go
@@ -20,6 +20,15 @@ type GoogleAI struct {
 
 var _ llms.Model = &GoogleAI{}
 
+// New creates a new GoogleAI client with provided client.
+func NewWithClient(client *genai.Client) (*GoogleAI, error) {
+	gi := &GoogleAI{
+		opts: DefaultOptions(),
+	}
+	gi.client = client
+	return gi, nil
+}
+
 // New creates a new GoogleAI client.
 func New(ctx context.Context, opts ...Option) (*GoogleAI, error) {
 	clientOptions := DefaultOptions()


### PR DESCRIPTION
The original google client has some other options to use besides the ones exposed via langchaingo. One of those is the option to verify a count of tokens in the prompt. 
Here tiktoken-go is outdated and does not support the google ai models.