### PR TITLE
feat(googleai): add support for array type in convertToolSchemaType

### DIFF
--- a/llms/googleai/googleai.go
+++ b/llms/googleai/googleai.go
@@ -425,6 +425,8 @@ func convertToolSchemaType(ty string) genai.Type {
 		return genai.TypeInteger
 	case "boolean":
 		return genai.TypeBoolean
+	case "array":
+		return genai.TypeArray
 	default:
 		return genai.TypeUnspecified
 	}


### PR DESCRIPTION
🔧 Added support for 'array' type in the convertToolSchemaType function to map it to genai.TypeArray. This enhances the functionality by enabling correct type handling for array types.

- Improved the type conversion logic by including the 'array' case.
- Ensures that 'array' types are not set to TypeUnspecified but correctly set to TypeArray.
- With this change you can now include Arrays in your Google JSON Schema tool definitions without error, like you could already with other LLMs
