### PR TITLE
Fix typos map key value of the modelToContextSize

### DIFF
--- a/llms/count_tokens.go
+++ b/llms/count_tokens.go
@@ -33,7 +33,7 @@ var modelToContextSize = map[string]int{
 	"text-davinci-003": _textDavinci3ContextSize,
 	"text-curie-001":   _textCurie1ContextSize,
 	"text-babbage-001": _textBabbage1ContextSize,
-	"text-ada-001":     _textBabbage1ContextSize,
+	"text-ada-001":     _textAda1ContextSize,
 	"code-davinci-002": _codeDavinci2ContextSize,
 	"code-cushman-001": _codeCushman1ContextSize,
 }


### PR DESCRIPTION
/kind cleanup

Fix typos map key value of the modelToContextSize.