### PR TITLE
fix: handle nil pointer exception in chat_prompt_template

### DIFF
--- a/prompts/chat_prompt_template.go
+++ b/prompts/chat_prompt_template.go
@@ -48,6 +48,9 @@ func (p ChatPromptTemplate) Format(values map[string]any) (string, error) {
 // FormatMessages formats the messages with the values and returns the formatted messages.
 func (p ChatPromptTemplate) FormatMessages(values map[string]any) ([]llms.ChatMessage, error) {
 	promptValue, err := p.FormatPrompt(values)
+	if promptValue == nil {
+		return nil, err
+	}
 	return promptValue.Messages(), err
 }
 


### PR DESCRIPTION
There may be situation where promptValue is nil which will cause panic while accessing promptValue.Messages()

```
func (p ChatPromptTemplate) FormatMessages(values map[string]any) ([]llms.ChatMessage, error) {
	promptValue, err := p.FormatPrompt(values)
	if promptValue == nil {
		return nil, err
	}
	return promptValue.Messages(), err
}
```


### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
