### PR TITLE
llms: Add improved yaml and json marshaling

### DIFF
--- a/llms/generatecontent.go
+++ b/llms/generatecontent.go
@@ -123,6 +123,23 @@ type ToolCall struct {
 	FunctionCall *FunctionCall `json:"function,omitempty"`
 }
 
+func (bc ToolCall) MarshalJSON() ([]byte, error) {
+	fc, err := json.Marshal(bc.FunctionCall)
+	if err != nil {
+		return nil, err
+	}
+
+	m := map[string]any{
+		"type": "tool_call",
+		"tool_call": map[string]any{
+			"id":   bc.ID,
+			"type": bc.Type,
+			"fc":   json.RawMessage(fc),
+		},
+	}
+	return json.Marshal(m)
+}
+
 func (ToolCall) isPart() {}
 
 // ToolCallResponse is the response returned by a tool call.
@@ -133,6 +150,18 @@ type ToolCallResponse struct {
 	Name string `json:"name"`
 	// Content is the textual content of the response.
 	Content string `json:"content"`
+}
+
+func (tc ToolCallResponse) MarshalJSON() ([]byte, error) {
+	m := map[string]any{
+		"type": "tool_response",
+		"tool_response": map[string]string{
+			"tool_call_id": tc.ToolCallID,
+			"name":         tc.Name,
+			"content":      tc.Content,
+		},
+	}
+	return json.Marshal(m)
 }
 
 func (ToolCallResponse) isPart() {}

--- a/llms/marshaling.go
+++ b/llms/marshaling.go
@@ -8,43 +8,128 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	partTypeText       = "text"
+	partTypeImageURL   = "image_url"
+	partTypeBinary     = "binary"
+	partTypeToolCall   = "tool_call"
+	partTypeToolResult = "tool_response"
+)
+
+// MarshalYAML custom marshaling logic for MessageContent.
+func (mc MessageContent) MarshalYAML() (interface{}, error) {
+	// Special case: handle single text part directly
+	if len(mc.Parts) == 1 {
+		if content, ok := mc.Parts[0].(TextContent); ok {
+			return map[string]interface{}{
+				"role": mc.Role,
+				"text": content.Text,
+			}, nil
+		}
+	}
+
+	var parts []map[string]interface{}
+	for _, part := range mc.Parts {
+		switch content := part.(type) {
+		case TextContent:
+			parts = append(parts, map[string]interface{}{
+				"type": partTypeText,
+				"text": content.Text,
+			})
+		case ImageURLContent:
+			parts = append(parts, map[string]interface{}{
+				"type": partTypeImageURL,
+				"url":  content.URL,
+			})
+		case BinaryContent:
+			parts = append(parts, map[string]interface{}{
+				"type":      partTypeBinary,
+				"mime_type": content.MIMEType,
+				"data":      base64.StdEncoding.EncodeToString(content.Data),
+			})
+		case ToolCall:
+			parts = append(parts, map[string]interface{}{
+				"type":      partTypeToolCall,
+				"tool_call": content,
+			})
+		case ToolCallResponse:
+			parts = append(parts, map[string]interface{}{
+				"type":          partTypeToolResult,
+				"tool_response": content,
+			})
+		default:
+			return nil, fmt.Errorf("unknown content type: %T", content)
+		}
+	}
+
+	raw := make(map[string]interface{})
+	raw["role"] = mc.Role
+	raw["parts"] = parts
+	return raw, nil
+}
+
+func (mc MessageContent) MarshalJSON() ([]byte, error) {
+	hasSingleTextPart := false
+	if len(mc.Parts) == 1 {
+		_, hasSingleTextPart = mc.Parts[0].(TextContent)
+	}
+	if hasSingleTextPart {
+		tp, _ := mc.Parts[0].(TextContent)
+		return json.Marshal(struct {
+			Role ChatMessageType `json:"role"`
+			Text string          `json:"text"`
+		}{Role: mc.Role, Text: tp.Text})
+	}
+
+	return json.Marshal(struct {
+		Role  ChatMessageType `json:"role"`
+		Parts []ContentPart   `json:"parts"`
+	}{
+		Role:  mc.Role,
+		Parts: mc.Parts,
+	})
+}
+
 // UnmarshalYAML custom unmarshaling logic for MessageContent.
+// Single-part text parts are handled as a special case.
 func (mc *MessageContent) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var singleText struct {
 		Role ChatMessageType `yaml:"role"`
 		Text string          `yaml:"text"`
 	}
-
 	if err := unmarshal(&singleText); err == nil && singleText.Text != "" {
 		mc.Role = singleText.Role
 		mc.Parts = []ContentPart{TextContent{Text: singleText.Text}}
 		return nil
 	}
-
 	var raw struct {
 		Role  ChatMessageType          `yaml:"role"`
 		Parts []map[string]interface{} `yaml:"parts"`
 	}
-
 	if err := unmarshal(&raw); err != nil {
 		return err
 	}
-
 	mc.Role = raw.Role
+	if err := mc.unmarshalParts(raw.Parts); err != nil {
+		return err
+	}
+	return nil
+}
 
-	for _, part := range raw.Parts {
+func (mc *MessageContent) unmarshalParts(parts []map[string]interface{}) error { //nolint:cyclop
+	for _, part := range parts {
 		switch part["type"] {
-		case "text", nil:
+		case partTypeText, nil:
 			var content TextContent
 			if err := mapToStruct(part, &content); err != nil {
 				return err
 			}
 			mc.Parts = append(mc.Parts, content)
-		case "image_url":
+		case partTypeImageURL:
 			var content ImageURLContent
 			content.URL, _ = part["url"].(string)
 			mc.Parts = append(mc.Parts, content)
-		case "binary":
+		case partTypeBinary:
 			var content BinaryContent
 			data, err := base64.StdEncoding.DecodeString(part["data"].(string))
 			if err != nil {
@@ -53,7 +138,7 @@ func (mc *MessageContent) UnmarshalYAML(unmarshal func(interface{}) error) error
 			content.MIMEType, _ = part["mime_type"].(string)
 			content.Data = data
 			mc.Parts = append(mc.Parts, content)
-		case "tool_call":
+		case partTypeToolCall:
 			var content ToolCall
 			tc, ok := part["tool_call"].(map[string]interface{})
 			if !ok {
@@ -63,7 +148,7 @@ func (mc *MessageContent) UnmarshalYAML(unmarshal func(interface{}) error) error
 				return err
 			}
 			mc.Parts = append(mc.Parts, content)
-		case "tool_response":
+		case partTypeToolResult:
 			var content ToolCallResponse
 			tr, ok := part["tool_response"].(map[string]interface{})
 			if !ok {
@@ -77,7 +162,6 @@ func (mc *MessageContent) UnmarshalYAML(unmarshal func(interface{}) error) error
 			return fmt.Errorf("unknown content type: %s", part["type"])
 		}
 	}
-
 	return nil
 }
 
@@ -135,7 +219,7 @@ func (mc *MessageContent) UnmarshalJSON(data []byte) error {
 			mc.Parts = append(mc.Parts, ToolCallResponse{
 				ToolCallID: part.ToolResponse.ToolCallID,
 				Name:       part.ToolResponse.Name,
-				Content:    string(part.ToolResponse.Content),
+				Content:    part.ToolResponse.Content,
 			})
 		default:
 			return fmt.Errorf("unknown content type: %s", part.Type)
@@ -148,80 +232,6 @@ func (mc *MessageContent) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalYAML custom marshaling logic for MessageContent.
-func (mc MessageContent) MarshalYAML() (interface{}, error) {
-	// Special case: handle single text part directly
-	if len(mc.Parts) == 1 {
-		if content, ok := mc.Parts[0].(TextContent); ok {
-			return map[string]interface{}{
-				"role": mc.Role,
-				"text": content.Text,
-			}, nil
-		}
-	}
-
-	var parts []map[string]interface{}
-	for _, part := range mc.Parts {
-		switch content := part.(type) {
-		case TextContent:
-			parts = append(parts, map[string]interface{}{
-				"type": "text",
-				"text": content.Text,
-			})
-		case ImageURLContent:
-			parts = append(parts, map[string]interface{}{
-				"type": "image_url",
-				"url":  content.URL,
-			})
-		case BinaryContent:
-			parts = append(parts, map[string]interface{}{
-				"type":      "binary",
-				"mime_type": content.MIMEType,
-				"data":      base64.StdEncoding.EncodeToString(content.Data),
-			})
-		case ToolCall:
-			parts = append(parts, map[string]interface{}{
-				"type":      "tool_call",
-				"tool_call": content,
-			})
-		case ToolCallResponse:
-			parts = append(parts, map[string]interface{}{
-				"type":          "tool_response",
-				"tool_response": content,
-			})
-		default:
-			return nil, fmt.Errorf("unknown content type: %T", content)
-		}
-	}
-
-	raw := make(map[string]interface{})
-	raw["role"] = mc.Role
-	raw["parts"] = parts
-	return raw, nil
-}
-
-func (mc MessageContent) MarshalJSON() ([]byte, error) {
-	hasSingleTextPart := false
-	if len(mc.Parts) == 1 {
-		_, hasSingleTextPart = mc.Parts[0].(TextContent)
-	}
-	if hasSingleTextPart {
-		tp, _ := mc.Parts[0].(TextContent)
-		return json.Marshal(struct {
-			Role ChatMessageType `json:"role"`
-			Text string          `json:"text"`
-		}{Role: mc.Role, Text: tp.Text})
-	}
-
-	return json.Marshal(struct {
-		Role  ChatMessageType `json:"role"`
-		Parts []ContentPart   `json:"parts"`
-	}{
-		Role:  mc.Role,
-		Parts: mc.Parts,
-	})
-}
-
 // Helper function to map raw data to struct.
 func mapToStruct(data map[string]interface{}, target interface{}) error {
 	bytes, err := yaml.Marshal(data)
@@ -229,4 +239,146 @@ func mapToStruct(data map[string]interface{}, target interface{}) error {
 		return err
 	}
 	return yaml.Unmarshal(bytes, target)
+}
+
+func (tc TextContent) MarshalJSON() ([]byte, error) {
+	m := map[string]string{
+		"type": "text",
+		"text": tc.Text,
+	}
+	return json.Marshal(m)
+}
+
+func (iuc ImageURLContent) MarshalJSON() ([]byte, error) {
+	m := map[string]any{
+		"type": "image_url",
+		"image_url": map[string]string{
+			"url": iuc.URL,
+		},
+	}
+	return json.Marshal(m)
+}
+
+func (iuc *ImageURLContent) UnmarshalJSON(data []byte) error {
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	_, ok := m["type"].(string)
+	if !ok {
+		return fmt.Errorf(`missing "type" field in ImageURLContent`)
+	}
+	imageURL, ok := m["image_url"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("invalid image_url field in ImageURLContent")
+	}
+	url, ok := imageURL["url"].(string)
+	if !ok {
+		return fmt.Errorf("invalid url field in ImageURLContent")
+	}
+	iuc.URL = url
+	return nil
+}
+
+func (bc BinaryContent) MarshalJSON() ([]byte, error) {
+	m := map[string]any{
+		"type": "binary",
+		"binary": map[string]string{
+			"mime_type": bc.MIMEType,
+			"data":      base64.StdEncoding.EncodeToString(bc.Data),
+		},
+	}
+	return json.Marshal(m)
+}
+
+func (bc *BinaryContent) UnmarshalJSON(data []byte) error {
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	if m["type"] != "binary" {
+		return fmt.Errorf("invalid type for BinaryContent: %v", m["type"])
+	}
+	binary, ok := m["binary"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("invalid binary field in BinaryContent")
+	}
+	mimeType, ok := binary["mime_type"].(string)
+	if !ok {
+		return fmt.Errorf("invalid mime_type field in BinaryContent")
+	}
+	encodedData, ok := binary["data"].(string)
+	if !ok {
+		return fmt.Errorf("invalid data field in BinaryContent")
+	}
+	enc, err := base64.StdEncoding.DecodeString(encodedData)
+	if err != nil {
+		return fmt.Errorf("error decoding base64 data: %w", err)
+	}
+	bc.MIMEType = mimeType
+	bc.Data = enc
+	return nil
+}
+
+func (tc ToolCall) MarshalJSON() ([]byte, error) {
+	fc, err := json.Marshal(tc.FunctionCall)
+	if err != nil {
+		return nil, err
+	}
+
+	m := map[string]any{
+		"type": "tool_call",
+		"tool_call": map[string]any{
+			"id":       tc.ID,
+			"type":     tc.Type,
+			"function": json.RawMessage(fc),
+		},
+	}
+	return json.Marshal(m)
+}
+
+func (tc *ToolCall) UnmarshalJSON(data []byte) error {
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	_, ok := m["type"].(string)
+	if !ok {
+		return fmt.Errorf(`missing "type" field in ToolCall`)
+	}
+	toolCall, ok := m["tool_call"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("invalid tool_call field in ToolCall")
+	}
+	id, ok := toolCall["id"].(string)
+	if !ok {
+		return fmt.Errorf("invalid id field in ToolCall")
+	}
+	typ, ok := toolCall["type"].(string)
+	if !ok {
+		return fmt.Errorf("invalid type field in ToolCall")
+	}
+	var fc FunctionCall
+	fcData, ok := toolCall["function"].(json.RawMessage)
+	if ok {
+		if err := json.Unmarshal(fcData, &fc); err != nil {
+			return fmt.Errorf("error unmarshalling function call: %w", err)
+		}
+	}
+	tc.ID = id
+	tc.Type = typ
+	tc.FunctionCall = &fc
+	return nil
+}
+
+func (tc ToolCallResponse) MarshalJSON() ([]byte, error) {
+	m := map[string]any{
+		"type": "tool_response",
+		"tool_response": map[string]string{
+			"tool_call_id": tc.ToolCallID,
+			"name":         tc.Name,
+			"content":      tc.Content,
+		},
+	}
+	return json.Marshal(m)
 }

--- a/llms/marshaling.go
+++ b/llms/marshaling.go
@@ -1,0 +1,115 @@
+package llms
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// UnmarshalYAML custom unmarshaling logic for MessageContent.
+func (mc *MessageContent) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var singleText struct {
+		Role ChatMessageType `yaml:"role"`
+		Text string          `yaml:"text"`
+	}
+
+	if err := unmarshal(&singleText); err == nil && singleText.Text != "" {
+		mc.Role = singleText.Role
+		mc.Parts = []ContentPart{TextContent{Text: singleText.Text}}
+		return nil
+	}
+
+	var raw struct {
+		Role  ChatMessageType          `yaml:"role"`
+		Parts []map[string]interface{} `yaml:"parts"`
+	}
+
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+
+	mc.Role = raw.Role
+
+	for _, part := range raw.Parts {
+		switch part["type"] {
+		case "text", nil:
+			var content TextContent
+			if err := mapToStruct(part, &content); err != nil {
+				return err
+			}
+			mc.Parts = append(mc.Parts, content)
+		case "image_url":
+			var content ImageURLContent
+			if err := mapToStruct(part, &content); err != nil {
+				return err
+			}
+			mc.Parts = append(mc.Parts, content)
+		case "binary":
+			var content BinaryContent
+			data, err := base64.StdEncoding.DecodeString(part["data"].(string))
+			if err != nil {
+				return err
+			}
+			content.MIMEType, _ = part["mime_type"].(string)
+			content.Data = data
+			mc.Parts = append(mc.Parts, content)
+		default:
+			return fmt.Errorf("unknown content type: %s", part["type"])
+		}
+	}
+
+	return nil
+}
+
+// MarshalYAML custom marshaling logic for MessageContent.
+func (mc MessageContent) MarshalYAML() (interface{}, error) {
+	// Special case: handle single text part directly
+	if len(mc.Parts) == 1 {
+		if content, ok := mc.Parts[0].(TextContent); ok {
+			return map[string]interface{}{
+				"role": mc.Role,
+				"text": content.Text,
+			}, nil
+		}
+	}
+
+	var parts []map[string]interface{}
+	for _, part := range mc.Parts {
+		switch content := part.(type) {
+		case TextContent:
+			parts = append(parts, map[string]interface{}{
+				"type": "text",
+				"text": content.Text,
+			})
+		case ImageURLContent:
+			parts = append(parts, map[string]interface{}{
+				"type": "image_url",
+				"url":  content.URL,
+			})
+		case BinaryContent:
+			parts = append(parts, map[string]interface{}{
+				"type":      "binary",
+				"mime_type": content.MIMEType,
+				"data":      base64.StdEncoding.EncodeToString(content.Data),
+			})
+		default:
+			return nil, fmt.Errorf("unknown content type")
+		}
+	}
+
+	raw := make(map[string]interface{})
+	raw["role"] = mc.Role
+	raw["parts"] = parts
+
+	return raw, nil
+}
+
+// Helper function to map raw data to struct.
+func mapToStruct(data map[string]interface{}, target interface{}) error {
+	bytes, err := yaml.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal(bytes, target)
+}

--- a/llms/marshaling_test.go
+++ b/llms/marshaling_test.go
@@ -1,0 +1,172 @@
+package llms
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
+)
+
+type unknownContent struct{}
+
+func (unknownContent) isPart() {}
+
+func TestUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		want    MessageContent
+		wantErr bool
+	}{
+		{
+			name: "Single text part",
+			input: `
+role: user
+text: Hello, world!
+`,
+			want: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+					TextContent{Text: "Hello, world!"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Multiple parts",
+			input: `role: user
+parts:
+- type: text
+  text: Hello!, world!
+- type: image_url
+  url: http://example.com/image.png
+- type: binary
+  mime_type: application/octet-stream
+  data: SGVsbG8sIHdvcmxkIQ==
+`,
+			want: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+					TextContent{Text: "Hello!, world!"},
+					ImageURLContent{URL: "http://example.com/image.png"},
+					BinaryContent{
+						MIMEType: "application/octet-stream",
+						Data:     []byte("Hello, world!"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Unknown content type",
+			input: `
+role: user
+parts:
+  - type: unknown
+    data: some data
+`,
+			want: MessageContent{
+				Role: "user",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var mc MessageContent
+			err := yaml.Unmarshal([]byte(tt.input), &mc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, mc); diff != "" {
+				t.Errorf("UnmarshalYAML() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMarshalYAML(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   MessageContent
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Single text part",
+			input: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+					TextContent{Text: "Hello, world!"},
+				},
+			},
+			want: `role: user
+text: Hello, world!
+`,
+			wantErr: false,
+		},
+		{
+			name: "Multiple parts",
+			input: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+					TextContent{Text: "Hello, world!"},
+					ImageURLContent{URL: "http://example.com/image.png"},
+					BinaryContent{
+						MIMEType: "application/octet-stream",
+						Data:     []byte("Hello, world!"),
+					},
+				},
+			},
+			want: `parts:
+    - text: Hello, world!
+      type: text
+    - type: image_url
+      url: http://example.com/image.png
+    - data: SGVsbG8sIHdvcmxkIQ==
+      mime_type: application/octet-stream
+      type: binary
+role: user
+`,
+			wantErr: false,
+		},
+		{
+			name: "Unknown content type",
+			input: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+					unknownContent{},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tt.input.MarshalYAML()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err == nil {
+				gotBytes, err := yaml.Marshal(got)
+				if err != nil {
+					t.Errorf("yaml.Marshal() error = %v", err)
+					return
+				}
+				gotStr := string(gotBytes)
+				if diff := cmp.Diff(tt.want, gotStr); diff != "" {
+					t.Errorf("MarshalYAML() mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/llms/marshaling_test.go
+++ b/llms/marshaling_test.go
@@ -202,7 +202,6 @@ func TestUnmarshalJSONMessageContent(t *testing.T) {
 			want: MessageContent{
 				Role: "user",
 				Parts: []ContentPart{
-
 					TextContent{Text: "Hello, world!"},
 				},
 			},
@@ -243,7 +242,8 @@ func TestUnmarshalJSONMessageContent(t *testing.T) {
 					ToolCall{
 						ID:           "t42",
 						Type:         "function",
-						FunctionCall: &FunctionCall{Name: "get_current_weather", Arguments: `{ "location": "New York" }`}},
+						FunctionCall: &FunctionCall{Name: "get_current_weather", Arguments: `{ "location": "New York" }`},
+					},
 				},
 			},
 			wantErr: false,
@@ -263,7 +263,7 @@ func TestUnmarshalJSONMessageContent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			//t.Parallel()
+			t.Parallel()
 			var mc MessageContent
 			err := mc.UnmarshalJSON([]byte(tt.input))
 			if (err != nil) != tt.wantErr {
@@ -343,16 +343,15 @@ func TestMarshalJSONMessageContent(t *testing.T) {
 	}
 }
 
-// Test roundtripping for both JSON and YAML
-
-func TestRoundtripping(t *testing.T) {
-	//t.Parallel()
+// Test roundtripping for both JSON and YAML representations.
+func TestRoundtripping(t *testing.T) { // nolint:funlen // We make an exception given the number of test cases.
+	t.Parallel()
 	tests := []struct {
 		name string
 		in   any
 	}{
 		{
-			name: "Single text part",
+			name: "single text part",
 			in: MessageContent{
 				Role: "user",
 				Parts: []ContentPart{
@@ -361,7 +360,7 @@ func TestRoundtripping(t *testing.T) {
 			},
 		},
 		{
-			name: "Multiple parts",
+			name: "multiple parts",
 			in: MessageContent{
 				Role: "user",
 				Parts: []ContentPart{
@@ -383,7 +382,6 @@ func TestRoundtripping(t *testing.T) {
 				},
 			},
 		},
-		// multiple tool uses:
 		{
 			name: "multiple tool uses",
 			in: MessageContent{
@@ -408,7 +406,6 @@ func TestRoundtripping(t *testing.T) {
 			in: MessageContent{
 				Role: "assistant",
 				Parts: []ContentPart{
-
 					ToolCall{Type: "hammer", FunctionCall: &FunctionCall{Name: "hit", Arguments: `{ "force": 10, "direction": "down" }`}},
 				},
 			},
@@ -442,12 +439,10 @@ func TestRoundtripping(t *testing.T) {
 			},
 		},
 		{
-
 			name: "multi-tool response with arguments",
 			in: MessageContent{
 				Role: "user",
 				Parts: []ContentPart{
-
 					ToolCallResponse{ToolCallID: "123", Name: "hammer", Content: "hit"},
 					ToolCallResponse{ToolCallID: "456", Name: "screwdriver", Content: "turn"},
 				},
@@ -455,10 +450,10 @@ func TestRoundtripping(t *testing.T) {
 		},
 	}
 
-	// round-trip both JSON and YAML:
+	// Round-trip both JSON and YAML:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			//t.Parallel()
+			t.Parallel()
 			// JSON
 			jsonBytes, err := json.Marshal(tt.in)
 			if err != nil {

--- a/llms/marshaling_test.go
+++ b/llms/marshaling_test.go
@@ -1,6 +1,7 @@
 package llms
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -44,6 +45,11 @@ parts:
 - type: binary
   mime_type: application/octet-stream
   data: SGVsbG8sIHdvcmxkIQ==
+- tool_response:
+    toolcallid: "123"
+    name: hammer
+    content: hit
+  type: tool_response
 `,
 			want: MessageContent{
 				Role: "user",
@@ -54,6 +60,7 @@ parts:
 						MIMEType: "application/octet-stream",
 						Data:     []byte("Hello, world!"),
 					},
+					ToolCallResponse{ToolCallID: "123", Name: "hammer", Content: "hit"},
 				},
 			},
 			wantErr: false,
@@ -121,6 +128,11 @@ text: Hello, world!
 						MIMEType: "application/octet-stream",
 						Data:     []byte("Hello, world!"),
 					},
+					ToolCallResponse{
+						ToolCallID: "123",
+						Name:       "hammer",
+						Content:    "hit",
+					},
 				},
 			},
 			want: `parts:
@@ -131,6 +143,11 @@ text: Hello, world!
     - data: SGVsbG8sIHdvcmxkIQ==
       mime_type: application/octet-stream
       type: binary
+    - tool_response:
+        toolcallid: "123"
+        name: hammer
+        content: hit
+      type: tool_response
 role: user
 `,
 			wantErr: false,
@@ -166,6 +183,313 @@ role: user
 				if diff := cmp.Diff(tt.want, gotStr); diff != "" {
 					t.Errorf("MarshalYAML() mismatch (-want +got):\n%s", diff)
 				}
+			}
+		})
+	}
+}
+
+func TestUnmarshalJSONMessageContent(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		want    MessageContent
+		wantErr bool
+	}{
+		{
+			name:  "Single text part",
+			input: `{"role":"user","text":"Hello, world!"}`,
+			want: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+
+					TextContent{Text: "Hello, world!"},
+				},
+			},
+
+			wantErr: false,
+		},
+		{
+			name:  "Multiple parts",
+			input: `{"role":"user","parts":[{"type":"text","text":"Hello!, world!"},{"type":"image_url","image_url":{"url":"http://example.com/image.png"}},{"type":"binary","binary":{"mime_type":"application/octet-stream","data":"SGVsbG8sIHdvcmxkIQ=="}}]}`,
+			want: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+					TextContent{Text: "Hello!, world!"},
+					ImageURLContent{URL: "http://example.com/image.png"},
+					BinaryContent{
+						MIMEType: "application/octet-stream",
+						Data:     []byte("Hello, world!"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "Unknown content type",
+			input: `{"role":"user","parts":[{"type":"unknown","data":"some data"}]}`,
+			want: MessageContent{
+				Role: "user",
+			},
+			wantErr: true,
+		},
+		{
+			name:  "tool use",
+			input: `{"role":"assistant","parts":[{"type":"text","text":"Hello there!"},{"type":"tool_call","tool_call":{"id":"t42","type":"function","function":{"name":"get_current_weather","arguments":"{ \"location\": \"New York\" }"}}}]}`,
+			want: MessageContent{
+				Role: "assistant",
+				Parts: []ContentPart{
+					TextContent{Text: "Hello there!"},
+					ToolCall{
+						ID:           "t42",
+						Type:         "function",
+						FunctionCall: &FunctionCall{Name: "get_current_weather", Arguments: `{ "location": "New York" }`}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "tool response",
+			input: `{"role":"user","parts":[{"type":"tool_response","tool_response":{"tool_call_id":"123","name":"hammer","content":"hit"}}]}`,
+			want: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+					ToolCallResponse{ToolCallID: "123", Name: "hammer", Content: "hit"},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//t.Parallel()
+			var mc MessageContent
+			err := mc.UnmarshalJSON([]byte(tt.input))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, mc); diff != "" {
+				t.Errorf("UnmarshalJSON() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMarshalJSONMessageContent(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   MessageContent
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Single text part",
+			input: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+					TextContent{Text: "Hello, world!"},
+				},
+			},
+			want:    `{"role":"user","text":"Hello, world!"}`,
+			wantErr: false,
+		},
+		{
+			name: "Multiple parts",
+			input: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+					TextContent{Text: "Hello, world!"},
+					ImageURLContent{URL: "http://example.com/image.png"},
+					BinaryContent{
+						MIMEType: "application/octet-stream",
+						Data:     []byte("Hello, world!"),
+					},
+				},
+			},
+			want:    `{"role":"user","parts":[{"text":"Hello, world!","type":"text"},{"image_url":{"url":"http://example.com/image.png"},"type":"image_url"},{"binary":{"data":"SGVsbG8sIHdvcmxkIQ==","mime_type":"application/octet-stream"},"type":"binary"}]}`,
+			wantErr: false,
+		},
+		{
+			name: "Unknown content type",
+			input: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+					unknownContent{},
+				},
+			},
+			want:    `{"role":"user","parts":[{}]}`,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tt.input.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err == nil {
+				gotStr := string(got)
+				if diff := cmp.Diff(tt.want, gotStr); diff != "" {
+					t.Errorf("MarshalJSON() mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+// Test roundtripping for both JSON and YAML
+
+func TestRoundtripping(t *testing.T) {
+	//t.Parallel()
+	tests := []struct {
+		name string
+		in   any
+	}{
+		{
+			name: "Single text part",
+			in: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+					TextContent{Text: "Hello, world!"},
+				},
+			},
+		},
+		{
+			name: "Multiple parts",
+			in: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+					TextContent{Text: "Hello!, world!"},
+					ImageURLContent{URL: "http://example.com/image.png"},
+					BinaryContent{
+						MIMEType: "application/octet-stream",
+						Data:     []byte("Hello, world!"),
+					},
+				},
+			},
+		},
+		{
+			name: "tool use",
+			in: MessageContent{
+				Role: "assistant",
+				Parts: []ContentPart{
+					ToolCall{Type: "function", ID: "t01", FunctionCall: &FunctionCall{Name: "get_current_weather", Arguments: `{ "location": "New York" }`}},
+				},
+			},
+		},
+		// multiple tool uses:
+		{
+			name: "multiple tool uses",
+			in: MessageContent{
+				Role: "assistant",
+				Parts: []ContentPart{
+					ToolCall{Type: "function", FunctionCall: &FunctionCall{Name: "get_current_weather", Arguments: `{ "location": "New York" }`}},
+					ToolCall{Type: "function", FunctionCall: &FunctionCall{Name: "get_current_weather", Arguments: `{ "location": "Berlin" }`}},
+				},
+			},
+		},
+		{
+			name: "tool use with arguments",
+			in: MessageContent{
+				Role: "assistant",
+				Parts: []ContentPart{
+					ToolCall{Type: "hammer", FunctionCall: &FunctionCall{Name: "hit", Arguments: `{ "force": 10 }`}},
+				},
+			},
+		},
+		{
+			name: "tool use with multiple arguments",
+			in: MessageContent{
+				Role: "assistant",
+				Parts: []ContentPart{
+
+					ToolCall{Type: "hammer", FunctionCall: &FunctionCall{Name: "hit", Arguments: `{ "force": 10, "direction": "down" }`}},
+				},
+			},
+		},
+		{
+			name: "tool response",
+			in: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+					ToolCallResponse{ToolCallID: "123", Name: "hammer", Content: "hit"},
+				},
+			},
+		},
+		{
+			name: "multi-tool response",
+			in: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+					ToolCallResponse{ToolCallID: "123", Name: "hammer", Content: "hit"},
+					ToolCallResponse{ToolCallID: "456", Name: "screwdriver", Content: "turn"},
+				},
+			},
+		},
+		{
+			name: "tool response with arguments",
+			in: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+					ToolCallResponse{ToolCallID: "123", Name: "hammer", Content: "hit"},
+				},
+			},
+		},
+		{
+
+			name: "multi-tool response with arguments",
+			in: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+
+					ToolCallResponse{ToolCallID: "123", Name: "hammer", Content: "hit"},
+					ToolCallResponse{ToolCallID: "456", Name: "screwdriver", Content: "turn"},
+				},
+			},
+		},
+	}
+
+	// round-trip both JSON and YAML:
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//t.Parallel()
+			// JSON
+			jsonBytes, err := json.Marshal(tt.in)
+			if err != nil {
+				t.Errorf("MarshalJSON() error = %v", err)
+				return
+			}
+			var mc MessageContent
+			err = mc.UnmarshalJSON(jsonBytes)
+			if err != nil {
+				t.Errorf("UnmarshalJSON() error = %v", err)
+				return
+			}
+			if diff := cmp.Diff(tt.in, mc); diff != "" {
+				t.Errorf("Roundtrip JSON mismatch (-want +got):\n%s", diff)
+				t.Logf("JSON: %s", jsonBytes)
+			}
+
+			// YAML
+			yamlBytes, err := yaml.Marshal(tt.in)
+			if err != nil {
+				t.Errorf("MarshalYAML() error = %v", err)
+				return
+			}
+			mc = MessageContent{}
+			err = yaml.Unmarshal(yamlBytes, &mc)
+			if err != nil {
+				t.Errorf("UnmarshalYAML() error = %v", err)
+				return
+			}
+			if diff := cmp.Diff(tt.in, mc); diff != "" {
+				t.Errorf("Roundtrip YAML mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
This adds standard yaml marshaling of `llm.MessageContent` types with special casing for single-text-part messages.