### PR TITLE
openai: enable optional return of usage data while streaming

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -19,6 +19,14 @@ const (
 
 var ErrContentExclusive = errors.New("only one of Content / MultiContent allowed in message")
 
+type StreamOptions struct {
+	// If set, an additional chunk will be streamed before the data: [DONE] message.
+	// The usage field on this chunk shows the token usage statistics for the entire request,
+	// and the choices field will always be an empty array.
+	// All other chunks will also include a usage field, but with a null value.
+	IncludeUsage bool `json:"include_usage,omitempty"`
+}
+
 // ChatRequest is a request to complete a chat completion..
 type ChatRequest struct {
 	Model            string         `json:"model"`
@@ -49,6 +57,9 @@ type ChatRequest struct {
 	// This can be either a string or a ToolChoice object.
 	// If it is a string, it should be one of 'none', or 'auto', otherwise it should be a ToolChoice object specifying a specific tool to use.
 	ToolChoice any `json:"tool_choice,omitempty"`
+
+	// Options for streaming response. Only set this when you set stream: true.
+	StreamOptions *StreamOptions `json:"stream_options,omitempty"`
 
 	// StreamingFunc is a function to be called for each chunk of a streaming response.
 	// Return an error to stop streaming early.
@@ -265,6 +276,12 @@ type ChatCompletionResponse struct {
 	SystemFingerprint string                  `json:"system_fingerprint"`
 }
 
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
 // StreamedChatResponsePayload is a chunk from the stream.
 type StreamedChatResponsePayload struct {
 	ID      string  `json:"id,omitempty"`
@@ -282,7 +299,12 @@ type StreamedChatResponsePayload struct {
 		} `json:"delta,omitempty"`
 		FinishReason FinishReason `json:"finish_reason,omitempty"`
 	} `json:"choices,omitempty"`
-	Error error `json:"-"` // use for error handling only
+	SystemFingerprint string `json:"system_fingerprint"`
+	// An optional field that will only be present when you set stream_options: {"include_usage": true} in your request.
+	// When present, it contains a null value except for the last chunk which contains the token usage statistics
+	// for the entire request.
+	Usage *Usage `json:"usage,omitempty"`
+	Error error  `json:"-"` // use for error handling only
 }
 
 // FunctionDefinition is a definition of a function that can be called by the model.
@@ -318,6 +340,9 @@ type FunctionCall struct {
 func (c *Client) createChat(ctx context.Context, payload *ChatRequest) (*ChatCompletionResponse, error) {
 	if payload.StreamingFunc != nil {
 		payload.Stream = true
+		if payload.StreamOptions == nil {
+			payload.StreamOptions = &StreamOptions{IncludeUsage: true}
+		}
 	}
 	// Build request payload
 
@@ -365,7 +390,8 @@ func (c *Client) createChat(ctx context.Context, payload *ChatRequest) (*ChatCom
 	return &response, json.NewDecoder(r.Body).Decode(&response)
 }
 
-func parseStreamingChatResponse(ctx context.Context, r *http.Response, payload *ChatRequest) (*ChatCompletionResponse, error) { //nolint:cyclop,lll
+func parseStreamingChatResponse(ctx context.Context, r *http.Response, payload *ChatRequest) (*ChatCompletionResponse,
+	error) { //nolint:cyclop,lll
 	scanner := bufio.NewScanner(r.Body)
 	responseChan := make(chan StreamedChatResponsePayload)
 	go func() {
@@ -399,7 +425,11 @@ func parseStreamingChatResponse(ctx context.Context, r *http.Response, payload *
 	return combineStreamingChatResponse(ctx, payload, responseChan)
 }
 
-func combineStreamingChatResponse(ctx context.Context, payload *ChatRequest, responseChan chan StreamedChatResponsePayload) (*ChatCompletionResponse, error) {
+func combineStreamingChatResponse(
+	ctx context.Context,
+	payload *ChatRequest,
+	responseChan chan StreamedChatResponsePayload,
+) (*ChatCompletionResponse, error) {
 	response := ChatCompletionResponse{
 		Choices: []*ChatCompletionChoice{
 			{},
@@ -409,6 +439,12 @@ func combineStreamingChatResponse(ctx context.Context, payload *ChatRequest, res
 	for streamResponse := range responseChan {
 		if streamResponse.Error != nil {
 			return nil, streamResponse.Error
+		}
+
+		if streamResponse.Usage != nil {
+			response.Usage.CompletionTokens = streamResponse.Usage.CompletionTokens
+			response.Usage.PromptTokens = streamResponse.Usage.PromptTokens
+			response.Usage.TotalTokens = streamResponse.Usage.TotalTokens
 		}
 
 		if len(streamResponse.Choices) == 0 {
@@ -424,7 +460,8 @@ func combineStreamingChatResponse(ctx context.Context, payload *ChatRequest, res
 		}
 
 		if len(choice.Delta.ToolCalls) > 0 {
-			chunk, response.Choices[0].Message.ToolCalls = updateToolCalls(response.Choices[0].Message.ToolCalls, choice.Delta.ToolCalls)
+			chunk, response.Choices[0].Message.ToolCalls = updateToolCalls(response.Choices[0].Message.ToolCalls,
+				choice.Delta.ToolCalls)
 		}
 
 		if payload.StreamingFunc != nil {

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -391,7 +391,8 @@ func (c *Client) createChat(ctx context.Context, payload *ChatRequest) (*ChatCom
 }
 
 func parseStreamingChatResponse(ctx context.Context, r *http.Response, payload *ChatRequest) (*ChatCompletionResponse,
-	error) { //nolint:cyclop,lll
+	error,
+) { //nolint:cyclop,lll
 	scanner := bufio.NewScanner(r.Body)
 	responseChan := make(chan StreamedChatResponsePayload)
 	go func() {


### PR DESCRIPTION
OPENAI stream return usage info

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
