### PR TITLE
examples: Correct API key usage for Groq integration

### DIFF
--- a/examples/groq-completion-example/go.mod
+++ b/examples/groq-completion-example/go.mod
@@ -9,5 +9,6 @@ require github.com/tmc/langchaingo v0.1.10
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/pkoukk/tiktoken-go v0.1.6 // indirect
 )

--- a/examples/groq-completion-example/go.sum
+++ b/examples/groq-completion-example/go.sum
@@ -4,6 +4,8 @@ github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq
 github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/pkoukk/tiktoken-go v0.1.6 h1:JF0TlJzhTbrI30wCvFuiw6FzP2+/bR+FIxUdgEAcUsw=
 github.com/pkoukk/tiktoken-go v0.1.6/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/groq-completion-example/groq_completion_example.go
+++ b/examples/groq-completion-example/groq_completion_example.go
@@ -4,15 +4,25 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
+	"github.com/joho/godotenv"
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/openai"
 )
 
 func main() {
+	err := godotenv.Load()
+	if err != nil {
+		log.Fatalf("Error loading .env file")
+	}
+
+	apiKey := os.Getenv("GROQ_API_KEY")
+
 	llm, err := openai.New(
 		openai.WithModel("llama3-8b-8192"),
 		openai.WithBaseURL("https://api.groq.com/openai/v1"),
+		openai.WithToken(apiKey),
 	)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Related To: #890

- Added `godotenv` to load environment variables from `.env` file.
- Corrected the initialization of the OpenAI client to include `openai.WithToken(apiKey)` for proper Groq API key usage.
- Updated the example to reflect the correct usage and included necessary error handling for missing API keys.

This change addresses the confusion regarding the API key parameter and ensures proper integration with the Groq API.

I still think there should be a separate module to load models for Groq instead of OpenAI, for better readability.
