### PR TITLE
docs: fix text_splitters mdx code example never closed

### DIFF
--- a/docs/docs/modules/data_connection/text_splitters/examples/index.mdx
+++ b/docs/docs/modules/data_connection/text_splitters/examples/index.mdx
@@ -32,6 +32,7 @@ func textToSplit() []schema.Document {
 
 	log.Println("Document loaded: ", len(docs))
 }
+```
 <DocCardList />
 
 


### PR DESCRIPTION
just fixing this page: https://tmc.github.io/langchaingo/docs/modules/data_connection/text_splitters/examples/ with a little bug in the example code preview.
### PR Checklist
- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks. (really needed for this case ?)
