### PR TITLE
googleai: Settle on GOOGLE_API_KEY for google auth env var name

### DIFF
--- a/examples/googleai-completion-example/googleai-completion-example.go
+++ b/examples/googleai-completion-example/googleai-completion-example.go
@@ -1,4 +1,4 @@
-// Set the API_KEY env var to your API key taken from ai.google.dev
+// Set the GOOGLE_API_KEY env var to your API key taken from ai.google.dev
 package main
 
 import (
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	apiKey := os.Getenv("API_KEY")
+	apiKey := os.Getenv("GOOGLE_API_KEY")
 	llm, err := googleai.New(ctx, googleai.WithAPIKey(apiKey))
 	if err != nil {
 		log.Fatal(err)

--- a/examples/googleai-tool-call-example/googleai-tool-call-example.go
+++ b/examples/googleai-tool-call-example/googleai-tool-call-example.go
@@ -13,9 +13,9 @@ import (
 )
 
 func main() {
-	genaiKey := os.Getenv("GENAI_API_KEY")
+	genaiKey := os.Getenv("GOOGLE_API_KEY")
 	if genaiKey == "" {
-		log.Fatal("please set GENAI_API_KEY")
+		log.Fatal("please set GOOGLE_API_KEY")
 	}
 
 	ctx := context.Background()

--- a/examples/json-mode-example/json_mode_example.go
+++ b/examples/json-mode-example/json_mode_example.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/anthropic"
@@ -43,9 +42,9 @@ func initBackend(ctx context.Context) (llms.Model, error) {
 	case "ollama":
 		return ollama.New(ollama.WithModel("mistral"))
 	case "anthropic":
-		return anthropic.New(anthropic.WithModel("claude-2.1"))
+		return anthropic.New(anthropic.WithModel("claude-3-5-sonnet-20240620"))
 	case "googleai":
-		return googleai.New(ctx, googleai.WithAPIKey(os.Getenv("GOOGLE_AI_API_KEY")))
+		return googleai.New(ctx, googleai.WithDefaultModel("gemini-1.5-flash"))
 	default:
 		return nil, fmt.Errorf("unknown backend: %s", *flagBackend)
 	}

--- a/llms/googleai/new.go
+++ b/llms/googleai/new.go
@@ -25,6 +25,7 @@ func New(ctx context.Context, opts ...Option) (*GoogleAI, error) {
 	for _, opt := range opts {
 		opt(&clientOptions)
 	}
+	clientOptions.EnsureAuthPresent()
 
 	gi := &GoogleAI{
 		opts: clientOptions,

--- a/llms/googleai/option.go
+++ b/llms/googleai/option.go
@@ -2,6 +2,8 @@ package googleai
 
 import (
 	"net/http"
+	"os"
+	"reflect"
 
 	"cloud.google.com/go/vertexai/genai"
 	"google.golang.org/api/option"
@@ -35,6 +37,15 @@ func DefaultOptions() Options {
 		DefaultTopK:           3,
 		DefaultTopP:           0.95,
 		HarmThreshold:         HarmBlockOnlyHigh,
+	}
+}
+
+// EnsureAuthPresent attempts to ensure that the client has authentication information. If it does not, it will attempt to use the GOOGLE_API_KEY environment variable.
+func (o *Options) EnsureAuthPresent() {
+	if !hasAuthOptions(o.ClientOptions) {
+		if key := os.Getenv("GOOGLE_API_KEY"); key != "" {
+			WithAPIKey(key)(o)
+		}
 	}
 }
 
@@ -177,3 +188,23 @@ const (
 	// HarmBlockNone means all content will be allowed.
 	HarmBlockNone HarmBlockThreshold = 4
 )
+
+// helper to inspect incoming client options for auth options.
+func hasAuthOptions(opts []option.ClientOption) bool {
+	for _, opt := range opts {
+		v := reflect.ValueOf(opt)
+		ts := v.Type().String()
+
+		switch ts {
+		case "option.withAPIKey":
+			return v.String() != ""
+
+		case "option.withHTTPClient",
+			"option.withTokenSource",
+			"option.withCredentialsFile",
+			"option.withCredentialsJSON":
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This is the env var name the gemini examples typically use, as far as I can tell.