### PR TITLE
llms: GenerateFromSinglePrompt struct literal uses unkeyed fields

### DIFF
--- a/llms/llms.go
+++ b/llms/llms.go
@@ -35,7 +35,7 @@ type Model interface {
 func GenerateFromSinglePrompt(ctx context.Context, llm Model, prompt string, options ...CallOption) (string, error) {
 	msg := MessageContent{
 		Role:  ChatMessageTypeHuman,
-		Parts: []ContentPart{TextContent{prompt}},
+		Parts: []ContentPart{TextContent{Text: prompt}},
 	}
 
 	resp, err := llm.GenerateContent(ctx, []MessageContent{msg}, options...)


### PR DESCRIPTION
This is not a bug right now (rather a slight optimization), because llms/llms.go (func GenerateFromSinglePrompt) uses unkeyed fields (at llms.TextContent{prompt}), which could potentially lead to a bug in the future. 

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
