### PR TITLE
fix(llms/marshaling): toolCall can not unmarshal

### DIFF
--- a/llms/marshaling.go
+++ b/llms/marshaling.go
@@ -245,10 +245,15 @@ func (tc *ToolCall) UnmarshalJSON(data []byte) error {
 	}
 	var fc FunctionCall
 	fcData, ok := toolCall["function"].(json.RawMessage)
-	if ok {
-		if err := json.Unmarshal(fcData, &fc); err != nil {
-			return fmt.Errorf("error unmarshalling function call: %w", err)
+	if !ok {
+		if b, err := json.Marshal(toolCall["function"]); err != nil {
+			return err
+		} else {
+			fcData = b
 		}
+	}
+	if err := json.Unmarshal(fcData, &fc); err != nil {
+		return fmt.Errorf("error unmarshalling function call: %w", err)
 	}
 	tc.ID = id
 	tc.Type = typ

--- a/llms/marshaling_test.go
+++ b/llms/marshaling_test.go
@@ -240,9 +240,12 @@ func TestUnmarshalJSONMessageContent(t *testing.T) {
 				Parts: []ContentPart{
 					TextContent{Text: "Hello there!"},
 					ToolCall{
-						ID:           "t42",
-						Type:         "function",
-						FunctionCall: &FunctionCall{Name: "get_current_weather", Arguments: `{ "location": "New York" }`},
+						ID:   "t42",
+						Type: "function",
+						FunctionCall: &FunctionCall{
+							Name:      "get_current_weather",
+							Arguments: `{ "location": "New York" }`,
+						},
 					},
 				},
 			},
@@ -397,7 +400,14 @@ role: user
 			in: MessageContent{
 				Role: "assistant",
 				Parts: []ContentPart{
-					ToolCall{Type: "function", ID: "t01", FunctionCall: &FunctionCall{Name: "get_current_weather", Arguments: `{ "location": "New York" }`}},
+					ToolCall{
+						Type: "function",
+						ID:   "t01",
+						FunctionCall: &FunctionCall{
+							Name:      "get_current_weather",
+							Arguments: `{ "location": "New York" }`,
+						},
+					},
 				},
 			},
 		},
@@ -406,8 +416,19 @@ role: user
 			in: MessageContent{
 				Role: "assistant",
 				Parts: []ContentPart{
-					ToolCall{Type: "function", ID: "tc01", FunctionCall: &FunctionCall{Name: "get_current_weather", Arguments: `{ "location": "New York" }`}},
-					ToolCall{Type: "function", ID: "tc02", FunctionCall: &FunctionCall{Name: "get_current_weather", Arguments: `{ "location": "Berlin" }`}},
+					ToolCall{
+						Type: "function",
+						ID:   "tc01",
+						FunctionCall: &FunctionCall{
+							Name:      "get_current_weather",
+							Arguments: `{ "location": "New York" }`,
+						},
+					},
+					ToolCall{
+						Type:         "function",
+						ID:           "tc02",
+						FunctionCall: &FunctionCall{Name: "get_current_weather", Arguments: `{ "location": "Berlin" }`},
+					},
 				},
 			},
 			assertedJSON: `{"role":"assistant","parts":[{"type":"tool_call","tool_call":{"function":{"name":"get_current_weather","arguments":"{ \"location\": \"New York\" }"},"id":"tc01","type":"function"}},{"type":"tool_call","tool_call":{"function":{"name":"get_current_weather","arguments":"{ \"location\": \"Berlin\" }"},"id":"tc02","type":"function"}}]}`,
@@ -443,7 +464,10 @@ role: assistant
 			in: MessageContent{
 				Role: "assistant",
 				Parts: []ContentPart{
-					ToolCall{Type: "hammer", FunctionCall: &FunctionCall{Name: "hit", Arguments: `{ "force": 10, "direction": "down" }`}},
+					ToolCall{
+						Type:         "hammer",
+						FunctionCall: &FunctionCall{Name: "hit", Arguments: `{ "force": 10, "direction": "down" }`},
+					},
 				},
 			},
 		},
@@ -531,5 +555,29 @@ role: assistant
 				t.Errorf("Roundtrip YAML mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestToolCallSerialization(t *testing.T) {
+	t.Parallel()
+	toolCall := ToolCall{
+		ID:   "test_id",
+		Type: "tool_call",
+		FunctionCall: &FunctionCall{
+			Name:      "getIpLocation",
+			Arguments: `{"ip":"8.8.8.8"}`,
+		},
+	}
+	b, err := json.Marshal(toolCall)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var unmarshalToolCall ToolCall
+	if e := json.Unmarshal(b, &unmarshalToolCall); e != nil {
+		t.Fatal(e)
+	}
+	if diff := cmp.Diff(toolCall, unmarshalToolCall); diff != "" {
+		t.Errorf("")
 	}
 }


### PR DESCRIPTION
The function parameter becomes map[string]any when unmarshal is applied.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
