### PR TITLE
milvus: Avoid crashing when empty documents are supplied to AddDocuments

### DIFF
--- a/vectorstores/milvus/milvus.go
+++ b/vectorstores/milvus/milvus.go
@@ -195,6 +195,10 @@ func (s *Store) load(ctx context.Context) error {
 func (s Store) AddDocuments(ctx context.Context, docs []schema.Document,
 	_ ...vectorstores.Option,
 ) ([]string, error) {
+	if len(docs) == 0 {
+		return nil, nil
+	}
+
 	texts := make([]string, 0, len(docs))
 	for _, doc := range docs {
 		texts = append(texts, doc.PageContent)

--- a/vectorstores/milvus/milvus_test.go
+++ b/vectorstores/milvus/milvus_test.go
@@ -117,3 +117,14 @@ func TestMilvusConnection(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, japanRes, 1)
 }
+
+func TestEmptyDocuments(t *testing.T) {
+	t.Parallel()
+	storer, err := getNewStore(t, WithDropOld(), WithCollectionName("test"))
+	require.NoError(t, err)
+
+	data := []schema.Document{}
+
+	_, err = storer.AddDocuments(context.Background(), data)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
### PR Checklist

- [X] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [X] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [X] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [X] References existing implementations as appropriate.
- [X] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

### Explanation

When interacting with different ways to create documents and then proceeding to AddDocuments, sometimes you can create an empty list of documents. This currently generates a crash due to line 211 of `milvus.go`. Other vectorstores (like chroma's) do not have this restriction, and there is no clear assumption that the documents have to be nonempty in the interface.

This PR makes AddDocuments a noop when empty documents are passed into it.
