### PR TITLE
ollamaclient: add scanner error checking in stream function for handling context cancellation

### DIFF
--- a/llms/ollama/internal/ollamaclient/ollamaclient.go
+++ b/llms/ollama/internal/ollamaclient/ollamaclient.go
@@ -180,6 +180,10 @@ func (c *Client) stream(ctx context.Context, method, path string, data any, fn f
 		}
 	}
 
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
When using `ollamaclient`, if the application triggers a context cancel for some reason(i.e. handling user cancellation in case of chatbot), and the cancel signal propagates before making the HTTP call (146 line in ollamaclient.go), an error is returned correctly.

However, if the cancel signal propagates after the HTTP call and response.Body is closed, a nil pointer exception occurs at line 152 of `ollamallm.go` because the scanner loop is not entered and ollamaclient.ChatResponse is not created.

Therefore, while I considered pre-creating ollamaclient.ChatResponse in the oolamallm package, I decided that propagating the context.Canceled error would be a better approach.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
