### PR TITLE
openai: use gpt-4o-mini by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -213,7 +213,7 @@ require (
 	github.com/opensearch-project/opensearch-go v1.1.0
 	github.com/pgvector/pgvector-go v0.1.1
 	github.com/pinecone-io/go-pinecone v0.4.1
-	github.com/pkoukk/tiktoken-go v0.1.6
+	github.com/pkoukk/tiktoken-go v0.1.7
 	github.com/redis/rueidis v1.0.34
 	github.com/weaviate/weaviate v1.24.1
 	github.com/weaviate/weaviate-go-client/v4 v4.13.1

--- a/go.sum
+++ b/go.sum
@@ -591,8 +591,8 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkoukk/tiktoken-go v0.1.6 h1:JF0TlJzhTbrI30wCvFuiw6FzP2+/bR+FIxUdgEAcUsw=
-github.com/pkoukk/tiktoken-go v0.1.6/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
+github.com/pkoukk/tiktoken-go v0.1.7 h1:qOBHXX4PHtvIvmOtyg1EeKlwFRiMKAcoMp4Q+bLQDmw=
+github.com/pkoukk/tiktoken-go v0.1.7/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=

--- a/llms/count_tokens.go
+++ b/llms/count_tokens.go
@@ -14,6 +14,7 @@ const (
 	_gpt35TurboContextSize   = 4096
 	_gpt432KContextSize      = 32768
 	_gpt4ContextSize         = 8192
+	_gpt4OMiniContextSize    = 128000
 	_textDavinci3ContextSize = 4097
 	_textBabbage1ContextSize = 2048
 	_textAda1ContextSize     = 2048
@@ -30,6 +31,7 @@ var modelToContextSize = map[string]int{
 	"gpt-3.5-turbo":    _gpt35TurboContextSize,
 	"gpt-4-32k":        _gpt432KContextSize,
 	"gpt-4":            _gpt4ContextSize,
+	"gpt-4o-mini":      _gpt4OMiniContextSize,
 	"text-davinci-003": _textDavinci3ContextSize,
 	"text-curie-001":   _textCurie1ContextSize,
 	"text-babbage-001": _textBabbage1ContextSize,

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultChatModel = "gpt-3.5-turbo"
+	defaultChatModel = "gpt-4o-mini"
 )
 
 var ErrContentExclusive = errors.New("only one of Content / MultiContent allowed in message")

--- a/textsplitter/token_splitter.go
+++ b/textsplitter/token_splitter.go
@@ -8,8 +8,8 @@ import (
 
 const (
 	// nolint:gosec
-	_defaultTokenModelName    = "gpt-3.5-turbo"
-	_defaultTokenEncoding     = "cl100k_base"
+	_defaultTokenModelName    = "gpt-4o-mini"
+	_defaultTokenEncoding     = "o200k_base"
 	_defaultTokenChunkSize    = 512
 	_defaultTokenChunkOverlap = 100
 )

--- a/textsplitter/token_splitter_test.go
+++ b/textsplitter/token_splitter_test.go
@@ -76,7 +76,7 @@ Bye!
 			},
 		},
 	}
-	splitter := NewTokenSplitter()
+	splitter := NewTokenSplitter(WithEncodingName("cl100k_base"))
 	for _, tc := range testCases {
 		splitter.ChunkOverlap = tc.chunkOverlap
 		splitter.ChunkSize = tc.chunkSize


### PR DESCRIPTION
> As of July 2024, gpt-4o-mini should be used in place of gpt-3.5-turbo,
> as it is cheaper, more capable, multimodal, and just as fast.

https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4


### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
