### PR TITLE
examples: replaced compose v1 with compose v2 in readme for pgvector example

### DIFF
--- a/examples/pgvector-vectorstore-example/README.md
+++ b/examples/pgvector-vectorstore-example/README.md
@@ -30,7 +30,7 @@ This example demonstrates how to use pgvector, a PostgreSQL extension for vector
 
 1. Start the PostgreSQL database:
    ```
-   docker-compose up -d
+   docker compose up -d
    ```
 
 2. Set your OpenAI API key:


### PR DESCRIPTION
A minor issue with pgvector example README:

https://docs.docker.com/compose/migrate/

Compose V1 used to be available as `docker-compose`. It reached its end of life last year.
Compose V2 is available as `docker compose` (no dash), and if you don't have an alias, the example will fail.

Related to https://github.com/tmc/langchaingo/issues/956