### PR TITLE
anthropicllm: Allow env var ANTHROPIC_MODEL for setting Claude model

### DIFF
--- a/llms/anthropic/anthropicllm.go
+++ b/llms/anthropic/anthropicllm.go
@@ -49,6 +49,7 @@ func New(opts ...Option) (*LLM, error) {
 func newClient(opts ...Option) (*anthropicclient.Client, error) {
 	options := &options{
 		token:      os.Getenv(tokenEnvVarName),
+		model:      os.Getenv(modelEnvVarName),
 		baseURL:    anthropicclient.DefaultBaseURL,
 		httpClient: http.DefaultClient,
 	}

--- a/llms/anthropic/anthropicllm_option.go
+++ b/llms/anthropic/anthropicllm_option.go
@@ -6,6 +6,7 @@ import (
 
 const (
 	tokenEnvVarName = "ANTHROPIC_API_KEY" //nolint:gosec
+	modelEnvVarName = "ANTHROPIC_MODEL"   //nolint:gosec
 )
 
 // MaxTokensAnthropicSonnet35 is the header value for specifying the maximum number of tokens
@@ -34,7 +35,9 @@ func WithToken(token string) Option {
 	}
 }
 
-// WithModel passes the Anthropic model to the client.
+// WithModel passes the Anthropic model to the client. If not set, the model
+// is read from the ANTHROPIC_MODEL environment variable. If that is not set,
+// `defaultModel` in the anthropicclient package is used.
 func WithModel(model string) Option {
 	return func(opts *options) {
 		opts.model = model

--- a/llms/anthropic/internal/anthropicclient/anthropicclient.go
+++ b/llms/anthropic/internal/anthropicclient/anthropicclient.go
@@ -22,8 +22,8 @@ var ErrEmptyResponse = errors.New("empty response")
 // Client is a client for the Anthropic API.
 type Client struct {
 	token   string
-	Model   string
 	baseURL string
+	model   string
 
 	httpClient Doer
 
@@ -69,9 +69,9 @@ func WithAnthropicBetaHeader(val string) Option {
 // New returns a new Anthropic client.
 func New(token string, model string, baseURL string, opts ...Option) (*Client, error) {
 	c := &Client{
-		Model:   model,
 		token:   token,
 		baseURL: strings.TrimSuffix(baseURL, "/"),
+		model:   model,
 	}
 
 	for _, opt := range opts {

--- a/llms/anthropic/internal/anthropicclient/completions.go
+++ b/llms/anthropic/internal/anthropicclient/completions.go
@@ -46,8 +46,8 @@ func (c *Client) setCompletionDefaults(payload *completionPayload) {
 	case payload.Model != "":
 
 	// If no model is set in the payload, take the one specified in the client.
-	case c.Model != "":
-		payload.Model = c.Model
+	case c.model != "":
+		payload.Model = c.model
 	// Fallback: use the default model
 	default:
 		payload.Model = defaultModel

--- a/llms/anthropic/internal/anthropicclient/messages.go
+++ b/llms/anthropic/internal/anthropicclient/messages.go
@@ -157,8 +157,8 @@ func (c *Client) setMessageDefaults(payload *messagePayload) {
 	case payload.Model != "":
 
 	// If no model is set in the payload, take the one specified in the client.
-	case c.Model != "":
-		payload.Model = c.Model
+	case c.model != "":
+		payload.Model = c.model
 	// Fallback: use the default model
 	default:
 		payload.Model = defaultModel


### PR DESCRIPTION
There was no way to set the Anthropic model via env var, this adds that.

I made `model` lowercase in the Anthropic options because I was following the patterns in the Cohere LLM and there's no need for it to be public.

## Demo

Slower with Opus set via env var

<img width="894" alt="image" src="https://github.com/user-attachments/assets/82d5020f-350f-4b10-b871-7a5d2681b1c3">

---

Faster with Haiku set via env var

<img width="788" alt="image" src="https://github.com/user-attachments/assets/badcb2de-bd7c-4919-a9dc-a77fb8e915e5">

---

404 as expected with invalid value sent to Anthropic

<img width="795" alt="image" src="https://github.com/user-attachments/assets/801bfe30-96bc-4fb3-abde-a06ee208e0ed">

---

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
