### PR TITLE
fix(docs): Type method missing from OutputParser

### DIFF
--- a/docs/docs/modules/model_io/output_parsers/index.mdx
+++ b/docs/docs/modules/model_io/output_parsers/index.mdx
@@ -22,5 +22,7 @@ type OutputParser[T any] interface {
 	ParseWithPrompt(text string, prompt PromptValue) (T, error)
 	// GetFormatInstructions returns a string describing the format of the output.
 	GetFormatInstructions() string
+	// Type returns the string type key uniquely identifying this class of parser
+	Type() string
 }
 ```


### PR DESCRIPTION
Added missing Type method, interface `OutputParser` in documentation is now identical to the `/schema/output_parser.go`


### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
