### PR TITLE
outputparser: improve BooleanOutputParser

### DIFF
--- a/outputparser/boolean_parser_test.go
+++ b/outputparser/boolean_parser_test.go
@@ -24,6 +24,7 @@ func TestBooleanParser(t *testing.T) {
 		},
 		{
 			input:    "YESNO",
+			err:      outputparser.ParseError{},
 			expected: false,
 		},
 		{
@@ -31,18 +32,62 @@ func TestBooleanParser(t *testing.T) {
 			err:      outputparser.ParseError{},
 			expected: false,
 		},
+		{
+			input:    "true",
+			expected: true,
+		},
+		{
+			input:    "false",
+			expected: false,
+		},
+		{
+			input:    "True",
+			expected: true,
+		},
+		{
+			input:    "False",
+			expected: false,
+		},
+		{
+			input:    "TRUE",
+			expected: true,
+		},
+		{
+			input:    "FALSE",
+			expected: false,
+		},
+		{
+			input:    "'TRUE'",
+			expected: true,
+		},
+		{
+			input:    "`TRUE`",
+			expected: true,
+		},
+		{
+			input:    "'TRUE`",
+			expected: true,
+		},
 	}
 
 	for _, tc := range testCases {
 		parser := outputparser.NewBooleanParser()
 
-		actual, err := parser.Parse(tc.input)
-		if tc.err != nil && err == nil {
-			t.Errorf("Expected error %v, got nil", tc.err)
-		}
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
 
-		if actual != tc.expected {
-			t.Errorf("Expected %v, got %v", tc.expected, actual)
-		}
+			result, err := parser.Parse(tc.input)
+			if err != nil && tc.err == nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if err == nil && tc.err != nil {
+				t.Errorf("Expected error %v, got nil", tc.err)
+			}
+
+			if result != tc.expected {
+				t.Errorf("Expected %v, but got %v", tc.expected, result)
+			}
+		})
 	}
 }


### PR DESCRIPTION
The BooleanOutputParser requests the LLM to respond with a boolean, and gives examples such as `true` or `false`. However, it only parsed respones that include YES or NO. This commits adds more values for parsing and changes the tests to fit them.


### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
