### PR TITLE
textsplitter: add option to join table rows

### DIFF
--- a/textsplitter/options.go
+++ b/textsplitter/options.go
@@ -17,6 +17,7 @@ type Options struct {
 	CodeBlocks           bool
 	ReferenceLinks       bool
 	KeepHeadingHierarchy bool // Persist hierarchy of markdown headers in each chunk
+	JoinTableRows        bool
 }
 
 // DefaultOptions returns the default options for all text splitter.
@@ -143,5 +144,16 @@ func WithKeepSeparator(keepSeparator bool) Option {
 func WithHeadingHierarchy(trackHeadingHierarchy bool) Option {
 	return func(o *Options) {
 		o.KeepHeadingHierarchy = trackHeadingHierarchy
+	}
+}
+
+// WithJoinTableRows sets whether tables should be split by row or not. When it is set to True,
+// table rows are joined until the chunksize. When it is set to False (the default), tables are
+// split by row.
+//
+// The default behavior is to split tables by row, so that each row is in a separate chunk.
+func WithJoinTableRows(join bool) Option {
+	return func(o *Options) {
+		o.JoinTableRows = join
 	}
 }


### PR DESCRIPTION
Originally the MarkdownTextSplitter would split tables into chunks
for each row (producing a header + single row) in each chunk. This
change adds an option to join multiple rows into a single chunk.

Fixes: #938


### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
