### PR TITLE
googleai: add support for JSONMode and ResponseMIMEType

### DIFF
--- a/examples/vertex-completion-example/go.mod
+++ b/examples/vertex-completion-example/go.mod
@@ -8,7 +8,7 @@ require github.com/tmc/langchaingo v0.1.12
 
 require (
 	cloud.google.com/go v0.114.0 // indirect
-	cloud.google.com/go/ai v0.6.0 // indirect
+	cloud.google.com/go/ai v0.7.0 // indirect
 	cloud.google.com/go/aiplatform v1.68.0 // indirect
 	cloud.google.com/go/auth v0.5.1 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.2 // indirect
@@ -22,7 +22,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/generative-ai-go v0.14.0 // indirect
+	github.com/google/generative-ai-go v0.15.1 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect

--- a/examples/vertex-completion-example/go.sum
+++ b/examples/vertex-completion-example/go.sum
@@ -3,6 +3,7 @@ cloud.google.com/go v0.114.0 h1:OIPFAdfrFDFO2ve2U7r/H5SwSbBzEdrBdE7xkgwc+kY=
 cloud.google.com/go v0.114.0/go.mod h1:ZV9La5YYxctro1HTPug5lXH/GefROyW8PPD4T8n9J8E=
 cloud.google.com/go/ai v0.6.0 h1:QWjb2UoaM15e51IMeLuIUFyWxooKOKDb66Mk47zZ2/g=
 cloud.google.com/go/ai v0.6.0/go.mod h1:6/mrRq6aJdK7MZH76ZvcMpESiAiha5aRvurmroiOrgI=
+cloud.google.com/go/ai v0.7.0/go.mod h1:7ozuEcraovh4ABsPbrec3o4LmFl9HigNI3D5haxYeQo=
 cloud.google.com/go/aiplatform v1.68.0 h1:EPPqgHDJpBZKRvv+OsB3cr0jYz3EL2pZ+802rBPcG8U=
 cloud.google.com/go/aiplatform v1.68.0/go.mod h1:105MFA3svHjC3Oazl7yjXAmIR89LKhRAeNdnDKJczME=
 cloud.google.com/go/auth v0.5.1 h1:0QNO7VThG54LUzKiQxv8C6x1YX7lUrzlAa1nVLF8CIw=
@@ -55,6 +56,7 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/generative-ai-go v0.14.0 h1:2GwFKXui9LmG+PukQwYk9KpJUIemmQ9NJ46BV9VIw38=
 github.com/google/generative-ai-go v0.14.0/go.mod h1:hOzbW3cB5hRV2x05McOwJS4GsqSluYwejjk5tSfb6YY=
+github.com/google/generative-ai-go v0.15.1/go.mod h1:AAucpWZjXsDKhQYWvCYuP6d0yB1kX998pJlOW1rAesw=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/llms/googleai/googleai.go
+++ b/llms/googleai/googleai.go
@@ -22,12 +22,13 @@ var (
 )
 
 const (
-	CITATIONS  = "citations"
-	SAFETY     = "safety"
-	RoleSystem = "system"
-	RoleModel  = "model"
-	RoleUser   = "user"
-	RoleTool   = "tool"
+	CITATIONS            = "citations"
+	SAFETY               = "safety"
+	RoleSystem           = "system"
+	RoleModel            = "model"
+	RoleUser             = "user"
+	RoleTool             = "tool"
+	ResponseMIMETypeJson = "application/json"
 )
 
 // Call implements the [llms.Model] interface.
@@ -85,6 +86,16 @@ func (g *GoogleAI) GenerateContent(
 	var err error
 	if model.Tools, err = convertTools(opts.Tools); err != nil {
 		return nil, err
+	}
+
+	// set model.ResponseMIMEType from either opts.JSONMode or opts.ResponseMIMEType
+	switch {
+	case opts.ResponseMIMEType != "" && opts.JSONMode:
+		return nil, fmt.Errorf("conflicting options, can't use JSONMode and ResponseMIMEType together")
+	case opts.ResponseMIMEType != "" && !opts.JSONMode:
+		model.ResponseMIMEType = opts.ResponseMIMEType
+	case opts.ResponseMIMEType == "" && opts.JSONMode:
+		model.ResponseMIMEType = ResponseMIMETypeJson
 	}
 
 	var response *llms.ContentResponse

--- a/llms/googleai/vertex/vertex.go
+++ b/llms/googleai/vertex/vertex.go
@@ -25,12 +25,13 @@ var (
 )
 
 const (
-	CITATIONS  = "citations"
-	SAFETY     = "safety"
-	RoleSystem = "system"
-	RoleModel  = "model"
-	RoleUser   = "user"
-	RoleTool   = "tool"
+	CITATIONS            = "citations"
+	SAFETY               = "safety"
+	RoleSystem           = "system"
+	RoleModel            = "model"
+	RoleUser             = "user"
+	RoleTool             = "tool"
+	ResponseMIMETypeJson = "application/json"
 )
 
 // Call implements the [llms.Model] interface.
@@ -88,6 +89,16 @@ func (g *Vertex) GenerateContent(
 	var err error
 	if model.Tools, err = convertTools(opts.Tools); err != nil {
 		return nil, err
+	}
+
+	// set model.ResponseMIMEType from either opts.JSONMode or opts.ResponseMIMEType
+	switch {
+	case opts.ResponseMIMEType != "" && opts.JSONMode:
+		return nil, fmt.Errorf("conflicting options, can't use JSONMode and ResponseMIMEType together")
+	case opts.ResponseMIMEType != "" && !opts.JSONMode:
+		model.ResponseMIMEType = opts.ResponseMIMEType
+	case opts.ResponseMIMEType == "" && opts.JSONMode:
+		model.ResponseMIMEType = ResponseMIMETypeJson
 	}
 
 	var response *llms.ContentResponse

--- a/llms/options.go
+++ b/llms/options.go
@@ -61,6 +61,11 @@ type CallOptions struct {
 	// Metadata is a map of metadata to include in the request.
 	// The meaning of this field is specific to the backend in use.
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
+
+	// ResponseMIMEType MIME type of the generated candidate text.
+	// Supported MIME types are: text/plain: (default) Text output.
+	// application/json: JSON response in the response candidates.
+	ResponseMIMEType string `json:"response_mime_type,omitempty"`
 }
 
 // Tool is a tool that can be used by the model.
@@ -263,5 +268,13 @@ func WithJSONMode() CallOption {
 func WithMetadata(metadata map[string]interface{}) CallOption {
 	return func(o *CallOptions) {
 		o.Metadata = metadata
+	}
+}
+
+// WithResponseMIMEType will add an option to set the ResponseMIMEType
+// Currently only supported by googleai llms
+func WithResponseMIMEType(responseMIMEType string) CallOption {
+	return func(o *CallOptions) {
+		o.ResponseMIMEType = responseMIMEType
 	}
 }

--- a/llms/options.go
+++ b/llms/options.go
@@ -272,7 +272,7 @@ func WithMetadata(metadata map[string]interface{}) CallOption {
 }
 
 // WithResponseMIMEType will add an option to set the ResponseMIMEType
-// Currently only supported by googleai llms
+// Currently only supported by googleai llms.
 func WithResponseMIMEType(responseMIMEType string) CallOption {
 	return func(o *CallOptions) {
 		o.ResponseMIMEType = responseMIMEType


### PR DESCRIPTION
### PR Checklist

This PR fixes #905. It allows using the already existing _CallOption_ `WithJSONMode()` for _googleai_ and _vertex_ by setting the `ResponseMIMEType` field of the request to `application/json`. Additionally, it introduces a new _CallOption_ `WithResponseMIMEType(string)` that can be used to directly set the `ResponseMIMEType` field on requests for _googlai_ and _vertex_. An error is returned when both _CallOptions_ are set by the user.
