### PR TITLE
milvus: add skipFlushOnWrite option

### DIFF
--- a/vectorstores/milvus/milvus.go
+++ b/vectorstores/milvus/milvus.go
@@ -36,6 +36,7 @@ type Store struct {
 	metricType       entity.MetricType
 	searchParameters entity.SearchParam
 	schema           *entity.Schema
+	skipFlushOnWrite bool
 }
 
 var (
@@ -226,8 +227,10 @@ func (s Store) AddDocuments(ctx context.Context, docs []schema.Document,
 	if err != nil {
 		return nil, err
 	}
-	if err = s.client.Flush(ctx, s.collectionName, false); err != nil {
-		return nil, err
+	if !s.skipFlushOnWrite {
+		if err = s.client.Flush(ctx, s.collectionName, false); err != nil {
+			return nil, err
+		}
 	}
 	return nil, nil
 }

--- a/vectorstores/milvus/options.go
+++ b/vectorstores/milvus/options.go
@@ -131,6 +131,13 @@ func WithMetricType(metricType entity.MetricType) Option {
 	}
 }
 
+// WithSkipFlushOnWrite disables flushing on write.
+func WithSkipFlushOnWrite() Option {
+	return func(s *Store) {
+		s.skipFlushOnWrite = true
+	}
+}
+
 func applyClientOptions(opts ...Option) (Store, error) {
 	s := Store{
 		metricType:       entity.L2,


### PR DESCRIPTION
When importing a large number of documents at once, flushing during each `AddDocuments` can significantly increase the time taken.

In my scenario, I create a new collection, insert datas, and then replace the original collection, so there is no need to flush every time data is inserted.

Add an option `skipFlushOnWrite` to optimize this scenario. In my test scenario, the total time was reduced from 38 minutes to 5 minutes.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
