### PR TITLE
outputparser: use strings.Cut in structured parser

### DIFF
--- a/outputparser/structured.go
+++ b/outputparser/structured.go
@@ -63,17 +63,15 @@ var _ schema.OutputParser[any] = Structured{}
 func (p Structured) parse(text string) (map[string]string, error) {
 	// Remove the ```json that should be at the start of the text, and the ```
 	// that should be at the end of the text.
-	withoutJSONStart := strings.Split(text, "```json")
-	if !(len(withoutJSONStart) > 1) {
+	_, withoutJSONStart, ok := strings.Cut(text, "```json")
+	if !ok {
 		return nil, ParseError{Text: text, Reason: "no ```json at start of output"}
 	}
 
-	withoutJSONEnd := strings.Split(withoutJSONStart[1], "```")
-	if len(withoutJSONEnd) < 1 {
+	jsonString, _, ok := strings.Cut(withoutJSONStart, "```")
+	if !ok {
 		return nil, ParseError{Text: text, Reason: "no ``` at end of output"}
 	}
-
-	jsonString := withoutJSONEnd[0]
 
 	var parsed map[string]string
 	err := json.Unmarshal([]byte(jsonString), &parsed)


### PR DESCRIPTION
### PR Checklist

- [X] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [X] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [X] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [X] Describes the source of new concepts.
- [X] References existing implementations as appropriate.
- [X] Contains test coverage for new functions.
- [X] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

Replaces `strings.Split` of two-element splits to use the more modern `strings.Cut` which doesn't allocate a slice. The ergonomics are almost the same so while a small optimization, I feel it's a good idea to use it.