### PR TITLE
bedrock: Fix unchecked error when stream channel is closed

### DIFF
--- a/llms/bedrock/internal/bedrockclient/provider_anthropic.go
+++ b/llms/bedrock/internal/bedrockclient/provider_anthropic.go
@@ -267,6 +267,9 @@ func parseStreamingCompletionResponse(ctx context.Context, client *bedrockruntim
 			}
 		}
 	}
+	if err = stream.Err(); err != nil {
+		return nil, err
+	}
 
 	return &llms.ContentResponse{
 		Choices: contentchoices,


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

As you can see in the aws sdk, when an error is set then stream channel is closed:
- https://github.com/aws/aws-sdk-go-v2/blob/main/service/bedrockruntime/eventstream.go#L84
- https://github.com/aws/aws-sdk-go-v2/blob/main/service/bedrockruntime/eventstream.go#L85
- https://github.com/aws/aws-sdk-go-v2/blob/main/service/bedrockruntime/eventstream.go#L71

The stream channel was read, but once closed, the error was not checked.
You can reproduce a bug triggering a streaming completion response and cancelling the context. The `context.Canceled` error is not returned.
I'm adding it just for anthropic provider because is the only one that supports streaming at present.