### PR TITLE
redisvector: fix score threshold option

### DIFF
--- a/vectorstores/redisvector/index_search.go
+++ b/vectorstores/redisvector/index_search.go
@@ -98,19 +98,19 @@ func (s IndexVectorSearch) AsCommand() []string {
 
 	const vectorField = "vector"
 	const vectorFieldAs = defaultDistanceFieldKey
-	const disThresholdFiled = "distance_threshold"
+	const disThresholdField = "distance_threshold"
 	const vectorKey = defaultContentVectorFieldKey
 	params := []string{vectorField, VectorString32(s.vector)}
 
 	if s.scoreThreshold > 0 && s.scoreThreshold < 1 {
 		// Range search
 		// "@content_vector:[VECTOR_RANGE $distance_threshold $vector]=>{$yield_distance_as: distance}"
-		filter := fmt.Sprintf("@%s:[VECTOR_RANGE $%s $%s]=>{$yield_distance_as: %s}", vectorKey, disThresholdFiled, vectorField, vectorFieldAs)
+		filter := fmt.Sprintf("@%s:[VECTOR_RANGE $%s $%s]=>{$yield_distance_as: %s}", vectorKey, disThresholdField, vectorField, vectorFieldAs)
 		if len(s.preFilters) > 0 {
 			filter = fmt.Sprintf("(%s) %s", s.preFilters, filter)
 		}
 		cmd = append(cmd, filter)
-		params = append(params, disThresholdFiled, strconv.FormatFloat(float64(s.scoreThreshold), 'f', -1, 32))
+		params = append(params, disThresholdField, strconv.FormatFloat(float64(1.0-s.scoreThreshold), 'f', -1, 32))
 	} else {
 		// KNN search
 		// "(*)=>[KNN n @content_vector $vector AS distance]"

--- a/vectorstores/redisvector/redis_vector_test.go
+++ b/vectorstores/redisvector/redis_vector_test.go
@@ -303,8 +303,8 @@ func TestSimilaritySearch(t *testing.T) {
 	assert.Len(t, docs[0].Metadata, 3)
 
 	// search with score threshold
-	docs, err = store.SimilaritySearch(ctx, "Tokyo", 2,
-		vectorstores.WithScoreThreshold(0.5),
+	docs, err = store.SimilaritySearch(ctx, "Tokyo", 10,
+		vectorstores.WithScoreThreshold(0.8),
 	)
 	require.NoError(t, err)
 	assert.Len(t, docs, 2)


### PR DESCRIPTION
* Redis vector range queries [expect a radius](https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/vectors/#vector-range-queries) rather than a score threshold.
* The existing code passed the score threshold through directly as the radius param. This means that a higher score threshold will result in in more matches than a lower score threshold which seems wrong. Instead this PR subtracts the score threshold from 1.
* The langchain project appears to have deprecated score threshold in favour of distance threshold. A future improvement would be to add a `WithDistanceThreshold` option for consistency.
* This PR is a breaking change for clients using redisvector and `WithScoreThreshold`. An alternative would be to keep the existing behaviour but add `WithDistanceThreshold` and guide users towards it.

### PR Checklist

- [X] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [X] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [X] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [X] ~~Describes the source of new concepts.~~
- [X] References existing implementations as appropriate.
- [X] ~~Contains test coverage for new functions.~~
- [X] Passes all [`golangci-lint`](https://golangci-lint.run/) checks. - There are some existing complaints about magic numbers not introduced by this PR.
