### PR TITLE
examples: replace deprecated agents.Initialize

### DIFF
--- a/examples/mrkl-agent-example/mrkl_agent.go
+++ b/examples/mrkl-agent-example/mrkl_agent.go
@@ -32,15 +32,12 @@ func run() error {
 		tools.Calculator{},
 		search,
 	}
-	executor, err := agents.Initialize(
-		llm,
+
+	agent := agents.NewOneShotAgent(llm,
 		agentTools,
-		agents.ZeroShotReactDescription,
-		agents.WithMaxIterations(3),
-	)
-	if err != nil {
-		return err
-	}
+		agents.WithMaxIterations(3))
+	executor := agents.NewExecutor(agent)
+
 	question := "Who is Olivia Wilde's boyfriend? What is his current age raised to the 0.23 power?"
 	answer, err := chains.Run(context.Background(), executor, question)
 	fmt.Println(answer)

--- a/examples/zapier-llm-example/main.go
+++ b/examples/zapier-llm-example/main.go
@@ -37,15 +37,10 @@ func main() {
 	agentTools = append(agentTools, tks...)
 
 	// Initialize the agent
-	executor, err := agents.Initialize(
-		llm,
+	agent := agents.NewOneShotAgent(llm,
 		agentTools,
-		agents.ZeroShotReactDescription,
-		agents.WithMaxIterations(3),
-	)
-	if err != nil {
-		panic(err)
-	}
+		agents.WithMaxIterations(3))
+	executor := agents.NewExecutor(agent)
 
 	// run a chain with the executor and defined input
 	input := "Get the last email from noreply@github.com"


### PR DESCRIPTION
Replace deprecated `agents.Initialize` calls by  `agents.NewOneShotAgent` in `mrkl-agent-example` and `zapier-llm-example` examples.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
