### PR TITLE
openai: reflect max_token field deprecation

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -29,17 +29,19 @@ type StreamOptions struct {
 
 // ChatRequest is a request to complete a chat completion..
 type ChatRequest struct {
-	Model            string         `json:"model"`
-	Messages         []*ChatMessage `json:"messages"`
-	Temperature      float64        `json:"temperature"`
-	TopP             float64        `json:"top_p,omitempty"`
-	MaxTokens        int            `json:"max_tokens,omitempty"`
-	N                int            `json:"n,omitempty"`
-	StopWords        []string       `json:"stop,omitempty"`
-	Stream           bool           `json:"stream,omitempty"`
-	FrequencyPenalty float64        `json:"frequency_penalty,omitempty"`
-	PresencePenalty  float64        `json:"presence_penalty,omitempty"`
-	Seed             int            `json:"seed,omitempty"`
+	Model       string         `json:"model"`
+	Messages    []*ChatMessage `json:"messages"`
+	Temperature float64        `json:"temperature"`
+	TopP        float64        `json:"top_p,omitempty"`
+	// Deprecated: Use MaxCompletionTokens
+	MaxTokens           int      `json:"-,omitempty"`
+	MaxCompletionTokens int      `json:"max_completion_tokens,omitempty"`
+	N                   int      `json:"n,omitempty"`
+	StopWords           []string `json:"stop,omitempty"`
+	Stream              bool     `json:"stream,omitempty"`
+	FrequencyPenalty    float64  `json:"frequency_penalty,omitempty"`
+	PresencePenalty     float64  `json:"presence_penalty,omitempty"`
+	Seed                int      `json:"seed,omitempty"`
 
 	// ResponseFormat is the format of the response.
 	ResponseFormat *ResponseFormat `json:"response_format,omitempty"`

--- a/llms/openai/internal/openaiclient/completions.go
+++ b/llms/openai/internal/openaiclient/completions.go
@@ -6,16 +6,18 @@ import (
 
 // CompletionRequest is a request to complete a completion.
 type CompletionRequest struct {
-	Model            string   `json:"model"`
-	Prompt           string   `json:"prompt"`
-	Temperature      float64  `json:"temperature"`
-	MaxTokens        int      `json:"max_tokens,omitempty"`
-	N                int      `json:"n,omitempty"`
-	FrequencyPenalty float64  `json:"frequency_penalty,omitempty"`
-	PresencePenalty  float64  `json:"presence_penalty,omitempty"`
-	TopP             float64  `json:"top_p,omitempty"`
-	StopWords        []string `json:"stop,omitempty"`
-	Seed             int      `json:"seed,omitempty"`
+	Model       string  `json:"model"`
+	Prompt      string  `json:"prompt"`
+	Temperature float64 `json:"temperature"`
+	// Deprecated: Use MaxCompletionTokens
+	MaxTokens           int      `json:"-,omitempty"`
+	MaxCompletionTokens int      `json:"max_completion_tokens,omitempty"`
+	N                   int      `json:"n,omitempty"`
+	FrequencyPenalty    float64  `json:"frequency_penalty,omitempty"`
+	PresencePenalty     float64  `json:"presence_penalty,omitempty"`
+	TopP                float64  `json:"top_p,omitempty"`
+	StopWords           []string `json:"stop,omitempty"`
+	Seed                int      `json:"seed,omitempty"`
 
 	// StreamingFunc is a function to be called for each chunk of a streaming response.
 	// Return an error to stop streaming early.
@@ -78,14 +80,14 @@ func (c *Client) createCompletion(ctx context.Context, payload *CompletionReques
 		Messages: []*ChatMessage{
 			{Role: "user", Content: payload.Prompt},
 		},
-		Temperature:      payload.Temperature,
-		TopP:             payload.TopP,
-		MaxTokens:        payload.MaxTokens,
-		N:                payload.N,
-		StopWords:        payload.StopWords,
-		FrequencyPenalty: payload.FrequencyPenalty,
-		PresencePenalty:  payload.PresencePenalty,
-		StreamingFunc:    payload.StreamingFunc,
-		Seed:             payload.Seed,
+		Temperature:         payload.Temperature,
+		TopP:                payload.TopP,
+		MaxCompletionTokens: payload.MaxTokens,
+		N:                   payload.N,
+		StopWords:           payload.StopWords,
+		FrequencyPenalty:    payload.FrequencyPenalty,
+		PresencePenalty:     payload.PresencePenalty,
+		StreamingFunc:       payload.StreamingFunc,
+		Seed:                payload.Seed,
 	})
 }

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -101,10 +101,11 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		Messages:         chatMsgs,
 		StreamingFunc:    opts.StreamingFunc,
 		Temperature:      opts.Temperature,
-		MaxTokens:        opts.MaxTokens,
 		N:                opts.N,
 		FrequencyPenalty: opts.FrequencyPenalty,
 		PresencePenalty:  opts.PresencePenalty,
+
+		MaxCompletionTokens: opts.MaxTokens,
 
 		ToolChoice:           opts.ToolChoice,
 		FunctionCallBehavior: openaiclient.FunctionCallBehavior(opts.FunctionCallBehavior),


### PR DESCRIPTION
The max_tokens field has been deprecated: https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens

I have not yet changed the high level API as that will require a bit more thought, but this changes the payload representation to not send this deprecated field. This is important for the o1 models which do not support that max_tokens.