### PR TITLE
fixes #1031

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -460,12 +460,14 @@ func combineStreamingChatResponse(
 			chunk = updateFunctionCall(response.Choices[0].Message, choice.Delta.FunctionCall)
 		}
 
+		outputToTextStream := true
 		if len(choice.Delta.ToolCalls) > 0 {
 			chunk, response.Choices[0].Message.ToolCalls = updateToolCalls(response.Choices[0].Message.ToolCalls,
 				choice.Delta.ToolCalls)
+			outputToTextStream = false
 		}
 
-		if payload.StreamingFunc != nil {
+		if payload.StreamingFunc != nil && outputToTextStream {
 			err := payload.StreamingFunc(ctx, chunk)
 			if err != nil {
 				return nil, fmt.Errorf("streaming func returned an error: %w", err)


### PR DESCRIPTION
Adds a check whether the tool response has a tool use component, and if it exists, don't send to output channel