### PR TITLE
Chroma: Replace existing documents with newer versions

### DIFF
--- a/vectorstores/chroma/chroma.go
+++ b/vectorstores/chroma/chroma.go
@@ -114,9 +114,8 @@ func (s Store) AddDocuments(ctx context.Context,
 			metadatas[docIdx][s.nameSpaceKey] = nameSpace
 		}
 	}
-
 	col := s.collection
-	if _, addErr := col.Add(ctx, nil, metadatas, texts, ids); addErr != nil {
+	if _, addErr := col.Upsert(ctx, nil, metadatas, texts, ids); addErr != nil {
 		return nil, fmt.Errorf("%w: %w", ErrAddDocument, addErr)
 	}
 	return ids, nil

--- a/vectorstores/chroma/chroma.go
+++ b/vectorstores/chroma/chroma.go
@@ -105,7 +105,7 @@ func (s Store) AddDocuments(ctx context.Context,
 	texts := make([]string, len(docs))
 	metadatas := make([]map[string]any, len(docs))
 	for docIdx, doc := range docs {
-		ids[docIdx] = opts.GenerateDoumentID(ctx, doc, ids)
+		ids[docIdx] = opts.GenerateDocumentID(ctx, doc, ids)
 		texts[docIdx] = doc.PageContent
 		mc := make(map[string]any, 0)
 		maps.Copy(mc, doc.Metadata)

--- a/vectorstores/chroma/chroma.go
+++ b/vectorstores/chroma/chroma.go
@@ -105,6 +105,11 @@ func (s Store) AddDocuments(ctx context.Context,
 	texts := make([]string, len(docs))
 	metadatas := make([]map[string]any, len(docs))
 	for docIdx, doc := range docs {
+		if opts.Deduplicater != nil {
+			if opts.Deduplicater(ctx, doc) {
+				continue
+			}
+		}
 		ids[docIdx] = opts.GenerateDocumentID(ctx, doc, ids)
 		texts[docIdx] = doc.PageContent
 		mc := make(map[string]any, 0)

--- a/vectorstores/chroma/chroma.go
+++ b/vectorstores/chroma/chroma.go
@@ -8,7 +8,6 @@ import (
 	chromago "github.com/amikos-tech/chroma-go"
 	"github.com/amikos-tech/chroma-go/openai"
 	chromatypes "github.com/amikos-tech/chroma-go/types"
-	"github.com/google/uuid"
 	"github.com/tmc/langchaingo/embeddings"
 	"github.com/tmc/langchaingo/schema"
 	"github.com/tmc/langchaingo/vectorstores"
@@ -106,7 +105,7 @@ func (s Store) AddDocuments(ctx context.Context,
 	texts := make([]string, len(docs))
 	metadatas := make([]map[string]any, len(docs))
 	for docIdx, doc := range docs {
-		ids[docIdx] = uuid.New().String() // TODO (noodnik2): find & use something more meaningful
+		ids[docIdx] = opts.GenerateDoumentID(ctx, doc, ids)
 		texts[docIdx] = doc.PageContent
 		mc := make(map[string]any, 0)
 		maps.Copy(mc, doc.Metadata)

--- a/vectorstores/opensearch/opensearch.go
+++ b/vectorstores/opensearch/opensearch.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/google/uuid"
 	opensearchgo "github.com/opensearch-project/opensearch-go"
 	"github.com/opensearch-project/opensearch-go/opensearchapi"
 	"github.com/tmc/langchaingo/embeddings"
@@ -75,7 +74,7 @@ func (s Store) AddDocuments(
 	}
 
 	for i, doc := range docs {
-		id := uuid.NewString()
+		id := opts.GenerateDocumentID(ctx, doc, ids)
 		_, err := s.documentIndexing(ctx, id, opts.NameSpace, doc.PageContent, vectors[i], doc.Metadata)
 		if err != nil {
 			return ids, err

--- a/vectorstores/options.go
+++ b/vectorstores/options.go
@@ -76,8 +76,8 @@ func (o Options) generateDummyDoumentID(_ context.Context) string {
 	return uuid.NewString()
 }
 
-// GenerateDoumentID calls the provided ID generator or creates a new UUID if not provided or the generated ID is not unique
-func (o Options) GenerateDoumentID(ctx context.Context, doc schema.Document, ids []string) string {
+// GenerateDocumentID calls the provided ID generator or creates a new UUID if not provided or the generated ID is not unique
+func (o Options) GenerateDocumentID(ctx context.Context, doc schema.Document, ids []string) string {
 	if o.DocumentIDGenerater == nil {
 		return o.generateDummyDoumentID(ctx)
 	}

--- a/vectorstores/pgvector/pgvector.go
+++ b/vectorstores/pgvector/pgvector.go
@@ -261,7 +261,7 @@ func (s Store) AddDocuments(
 
 	ids := make([]string, len(docs))
 	for docIdx, doc := range docs {
-		id := uuid.New().String()
+		id := opts.GenerateDocumentID(ctx, doc, ids)
 		ids[docIdx] = id
 		b.Queue(sql, id, doc.PageContent, pgvector.NewVector(vectors[docIdx]), doc.Metadata, s.collectionUUID)
 	}

--- a/vectorstores/pinecone/pinecone.go
+++ b/vectorstores/pinecone/pinecone.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/google/uuid"
 	"github.com/pinecone-io/go-pinecone/pinecone"
 	"github.com/tmc/langchaingo/embeddings"
 	"github.com/tmc/langchaingo/schema"
@@ -104,7 +103,7 @@ func (s Store) AddDocuments(ctx context.Context,
 			return nil, err
 		}
 
-		id := uuid.New().String()
+		id := opts.GenerateDocumentID(ctx, docs[i], ids)
 		ids[i] = id
 		pineconeVectors = append(
 			pineconeVectors,

--- a/vectorstores/weaviate/weaviate.go
+++ b/vectorstores/weaviate/weaviate.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/google/uuid"
 	"github.com/tmc/langchaingo/embeddings"
 	"github.com/tmc/langchaingo/schema"
 	"github.com/tmc/langchaingo/vectorstores"
@@ -133,7 +132,7 @@ func (s Store) AddDocuments(ctx context.Context,
 	objects := make([]*models.Object, 0, len(docs))
 	ids := make([]string, len(docs))
 	for i := range docs {
-		id := strfmt.UUID(uuid.New().String())
+		id := strfmt.UUID(opts.GenerateDocumentID(ctx, docs[i], ids))
 		ids[i] = id.String()
 		objects = append(objects, &models.Object{
 			Class:      s.indexName,


### PR DESCRIPTION
I am planing to index our confluence wiki with go langchain.
Therefore I had to be able to replace existing documents in chroma.

This needed the following changes:

- Introcude a `vectorstores.WithIDGenerater` option and the according `GenerateDocumentID` func defaulting to `uuid.NewString()`
- Use the new `GenerateDocumentID` func in chroma (and implemented to the best of my abilites for the rest of the stores).

While at it I realised that the chroma vectorstore did not call the `Deduplicater` so I fixed this as well.


### PR Checklist

- [x ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ x] Describes the source of new concepts.
- [ x] References existing implementations as appropriate.
- [ x] Contains test coverage for new functions.
- [ x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

