### PR TITLE
Add replacement opt

### DIFF
--- a/vectorstores/options.go
+++ b/vectorstores/options.go
@@ -17,6 +17,7 @@ type Options struct {
 	Filters        any
 	Embedder       embeddings.Embedder
 	Deduplicater   func(context.Context, schema.Document) bool
+	Replacement    bool
 }
 
 // WithNameSpace returns an Option for setting the name space.
@@ -57,5 +58,11 @@ func WithEmbedder(embedder embeddings.Embedder) Option {
 func WithDeduplicater(fn func(ctx context.Context, doc schema.Document) bool) Option {
 	return func(o *Options) {
 		o.Deduplicater = fn
+	}
+}
+
+func WithReplacement(replacement bool) Option {
+	return func(o *Options) {
+		o.Replacement = replacement
 	}
 }

--- a/vectorstores/options.go
+++ b/vectorstores/options.go
@@ -61,6 +61,10 @@ func WithDeduplicater(fn func(ctx context.Context, doc schema.Document) bool) Op
 	}
 }
 
+// WithReplacement returns an Option for setting the replacement flag that could be used
+// when adding documents. If set to true, the existing document with the **Metadata** will
+// be replaced with the new document. If set to false(default case), the new document will
+// be added to the store and the existing document will be kept.
 func WithReplacement(replacement bool) Option {
 	return func(o *Options) {
 		o.Replacement = replacement

--- a/vectorstores/pgvector/pgvector.go
+++ b/vectorstores/pgvector/pgvector.go
@@ -256,6 +256,14 @@ func (s Store) AddDocuments(
 	}
 
 	b := &pgx.Batch{}
+
+	if opts.Replacement {
+		replaceSql := fmt.Sprintf(`DELETE FROM %s WHERE collection_id = $1 AND cmetadata::jsonb = $2::jsonb`, s.embeddingTableName)
+		for _, doc := range docs {
+			b.Queue(replaceSql, s.collectionUUID, doc.Metadata)
+		}
+	}
+
 	sql := fmt.Sprintf(`INSERT INTO %s (uuid, document, embedding, cmetadata, collection_id)
 		VALUES($1, $2, $3, $4, $5)`, s.embeddingTableName)
 

--- a/vectorstores/pgvector/pgvector_test.go
+++ b/vectorstores/pgvector/pgvector_test.go
@@ -615,6 +615,66 @@ func TestDeduplicater(t *testing.T) {
 	require.Equal(t, "vegetable", docs[0].Metadata["type"])
 }
 
+func TestReplacement(t *testing.T) {
+	t.Parallel()
+	pgvectorURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New()
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	conn, err := pgx.Connect(ctx, pgvectorURL)
+	require.NoError(t, err)
+
+	store, err := pgvector.New(
+		ctx,
+		pgvector.WithConn(conn),
+		pgvector.WithEmbedder(e),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, pgvectorURL)
+
+	_, err = store.AddDocuments(context.Background(), []schema.Document{
+		{PageContent: "Math", Metadata: map[string]any{
+			"courseID": "foo",
+		}},
+		{PageContent: "Physics", Metadata: map[string]any{
+			"courseID": "bar",
+		}},
+	})
+	require.NoError(t, err)
+
+	_, err = store.AddDocuments(context.Background(), []schema.Document{
+		{PageContent: "Discrete Math", Metadata: map[string]any{
+			"courseID": "foo",
+		}},
+	}, vectorstores.WithReplacement(true))
+	require.NoError(t, err)
+
+	docs, err := store.Search(ctx, 2, vectorstores.WithFilters(map[string]any{
+		"courseID": "foo",
+	}))
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.Equal(t, "Discrete Math", docs[0].PageContent)
+
+	_, err = store.AddDocuments(context.Background(), []schema.Document{
+		{PageContent: "Calculus", Metadata: map[string]any{
+			"courseID": "foo",
+		}},
+	}, vectorstores.WithReplacement(false))
+	require.NoError(t, err)
+
+	docs, err = store.Search(ctx, 2, vectorstores.WithFilters(map[string]any{
+		"courseID": "foo",
+	}))
+	require.NoError(t, err)
+	require.Len(t, docs, 2)
+}
+
 func TestWithAllOptions(t *testing.T) {
 	t.Parallel()
 	pgvectorURL := preCheckEnvSetting(t)


### PR DESCRIPTION
vectorstores: add `Replacement` option
    
This PR introduce a `Replacement` member to the vectorstores options. This option can be used in `AddDocuments` function. 
When Replacement is set to `true`, AddDocuments function will delete old record with **the same Metadata attribute**. (i.e  to replace).
When Replacement is set to `false` (_default case_) , AddDocuments
function will simply add documents without checking existing
document records.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
