### PR TITLE
milvus: Honor WithEmbedder option in AddDocuments

### DIFF
--- a/vectorstores/milvus/milvus.go
+++ b/vectorstores/milvus/milvus.go
@@ -194,8 +194,10 @@ func (s *Store) load(ctx context.Context) error {
 // AddDocuments adds the text and metadata from the documents to the Milvus collection associated with 'Store'.
 // and returns the ids of the added documents.
 func (s Store) AddDocuments(ctx context.Context, docs []schema.Document,
-	_ ...vectorstores.Option,
+	opts ...vectorstores.Option,
 ) ([]string, error) {
+	s.applyOptions(opts)
+
 	texts := make([]string, 0, len(docs))
 	for _, doc := range docs {
 		texts = append(texts, doc.PageContent)
@@ -346,4 +348,16 @@ func (s Store) getFilters(opts vectorstores.Options) (string, error) {
 		return "", ErrInvalidFilters
 	}
 	return "", nil
+}
+
+// applyOptions applies the options to the store.
+func (s *Store) applyOptions(opts []vectorstores.Option) {
+	var options vectorstores.Options
+	for _, o := range opts {
+		o(&options)
+	}
+
+	if options.Embedder != nil {
+		s.embedder = options.Embedder
+	}
 }

--- a/vectorstores/milvus/milvus_test.go
+++ b/vectorstores/milvus/milvus_test.go
@@ -2,6 +2,7 @@ package milvus
 
 import (
 	"context"
+	"errors"
 	"log"
 	"os"
 	"strings"
@@ -102,6 +103,15 @@ func TestMilvusConnection(t *testing.T) {
 	_, err = storer.AddDocuments(context.Background(), data)
 	require.NoError(t, err)
 
+	unusedData := []schema.Document{
+		{PageContent: "MockCity", Metadata: map[string]any{"population": 100, "area": 100}},
+	}
+
+	embedderM := &mockEmbedder{}
+
+	_, err = storer.AddDocuments(context.Background(), unusedData, vectorstores.WithEmbedder(embedderM))
+	require.ErrorIs(t, err, errEmbeddingDocuments)
+
 	// search docs with filter
 	filterRes, err := storer.SimilaritySearch(context.Background(),
 		"Tokyo", 10,
@@ -117,3 +127,18 @@ func TestMilvusConnection(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, japanRes, 1)
 }
+
+type mockEmbedder struct{}
+
+func (m *mockEmbedder) EmbedDocuments(ctx context.Context, texts []string) ([][]float32, error) {
+	return nil, errEmbeddingDocuments
+}
+
+func (m *mockEmbedder) EmbedQuery(ctx context.Context, text string) ([]float32, error) {
+	return nil, errEmbeddingQuery
+}
+
+var (
+	errEmbeddingDocuments = errors.New("error embedding documents")
+	errEmbeddingQuery     = errors.New("error embedding query")
+)


### PR DESCRIPTION
### Overview
This PR changes `store.AddDocuments(...)` to honor `vectorestores.WithEmbedder(e)` option. 

### PR Checklist

- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
