### PR TITLE
chore(vectorstore:redis): use testcontainers-go Redis module properly

### DIFF
--- a/vectorstores/redisvector/redis_vector_test.go
+++ b/vectorstores/redisvector/redis_vector_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	tcredis "github.com/testcontainers/testcontainers-go/modules/redis"
-	"github.com/testcontainers/testcontainers-go/wait"
 	"github.com/tmc/langchaingo/chains"
 	"github.com/tmc/langchaingo/embeddings"
 	"github.com/tmc/langchaingo/llms"
@@ -37,22 +36,11 @@ func getValues(t *testing.T) (string, string) {
 	if uri == "" {
 		ctx := context.Background()
 
-		genericContainerReq := testcontainers.GenericContainerRequest{
-			ContainerRequest: testcontainers.ContainerRequest{
-				Image:        "docker.io/redis/redis-stack:7.2.0-v10",
-				ExposedPorts: []string{"6379/tcp"},
-				WaitingFor:   wait.ForLog("* Ready to accept connections"),
-			},
-			Started: true,
-		}
-
-		container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
+		redisContainer, err := tcredis.RunContainer(ctx, testcontainers.WithImage("redis/redis-stack:7.2.0-v10"))
 		if err != nil && strings.Contains(err.Error(), "Cannot connect to the Docker daemon") {
 			t.Skip("Docker not available")
 		}
 		require.NoError(t, err)
-
-		redisContainer := &tcredis.RedisContainer{Container: container}
 		t.Cleanup(func() {
 			require.NoError(t, redisContainer.Terminate(context.Background()))
 		})


### PR DESCRIPTION

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

## What does this PR do?
It uses the Redis module of Testcontainers, instead of creation a generic container. This simplifies the test code.
