### PR TITLE
fix(vectorstores:weaviate|pinecone): do not return error when zero documents are retrieved

### DIFF
--- a/vectorstores/pinecone/pinecone.go
+++ b/vectorstores/pinecone/pinecone.go
@@ -22,6 +22,7 @@ var (
 	ErrEmbedderWrongNumberVectors = errors.New(
 		"number of vectors from embedder does not match number of documents",
 	)
+	// Deprecated: ErrEmptyResponse is not used anymore and will be removed in the future.
 	// ErrEmptyResponse is returned if the API gives an empty response.
 	ErrEmptyResponse         = errors.New("empty response")
 	ErrInvalidScoreThreshold = errors.New(

--- a/vectorstores/pinecone/pinecone.go
+++ b/vectorstores/pinecone/pinecone.go
@@ -170,7 +170,7 @@ func (s Store) SimilaritySearch(ctx context.Context, query string, numDocuments 
 	}
 
 	if len(queryResult.Matches) == 0 {
-		return nil, ErrEmptyResponse
+		return []schema.Document{}, nil
 	}
 
 	return s.getDocumentsFromMatches(queryResult, scoreThreshold)

--- a/vectorstores/weaviate/weaviate.go
+++ b/vectorstores/weaviate/weaviate.go
@@ -232,10 +232,12 @@ func (s Store) parseDocumentsByGraphQLResponse(res *models.GraphQLResponse) ([]s
 		return nil, ErrEmptyResponse
 	}
 	items, ok := data.([]any)
+
+	var docs []schema.Document
 	if !ok || len(items) == 0 {
-		return nil, ErrEmptyResponse
+		return docs, nil
 	}
-	docs := make([]schema.Document, 0, len(items))
+	docs = make([]schema.Document, 0, len(items))
 	for _, item := range items {
 		itemMap, ok := item.(map[string]any)
 		if !ok {

--- a/vectorstores/weaviate/weaviate.go
+++ b/vectorstores/weaviate/weaviate.go
@@ -233,11 +233,10 @@ func (s Store) parseDocumentsByGraphQLResponse(res *models.GraphQLResponse) ([]s
 	}
 	items, ok := data.([]any)
 
-	var docs []schema.Document
+	docs := make([]schema.Document, 0, len(items))
 	if !ok || len(items) == 0 {
 		return docs, nil
 	}
-	docs = make([]schema.Document, 0, len(items))
 	for _, item := range items {
 		itemMap, ok := item.(map[string]any)
 		if !ok {


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

## What is this PR doing?
It reverse the logic in Weaviate and Pinecone stores to not return an error if zero docs are retrieved from a SimilaritySearch.

Closes https://github.com/tmc/langchaingo/issues/1065
