### PR TITLE
textsplitter: add an optional lenFunc to MarkdownTextSplitter

### DIFF
--- a/textsplitter/markdown_splitter_test.go
+++ b/textsplitter/markdown_splitter_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/pkoukk/tiktoken-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/schema"
@@ -577,5 +578,49 @@ func TestMarkdownHeaderTextSplitter_SplitInline(t *testing.T) {
 			rq.NoError(err)
 			rq.Equal(tc.expectedDocs, docs)
 		})
+	}
+}
+
+func TestMarkdownHeaderTextSplitter_LenFunc(t *testing.T) {
+	t.Parallel()
+
+	tokenEncoder, _ := tiktoken.GetEncoding("cl100k_base")
+
+	sampleText := "The quick brown fox jumped over the lazy dog."
+	tokensPerChunk := len(tokenEncoder.Encode(sampleText, nil, nil))
+
+	type testCase struct {
+		markdown     string
+		expectedDocs []schema.Document
+	}
+
+	testCases := []testCase{
+		{
+			markdown: `# Title` + "\n" + sampleText + "\n" + sampleText,
+			expectedDocs: []schema.Document{
+				{
+					PageContent: "# Title" + "\n" + sampleText,
+					Metadata:    map[string]any{},
+				},
+				{
+					PageContent: "# Title" + "\n" + sampleText,
+					Metadata:    map[string]any{},
+				},
+			},
+		},
+	}
+
+	splitter := NewMarkdownTextSplitter(
+		WithChunkSize(tokensPerChunk+1),
+		WithChunkOverlap(0),
+		WithLenFunc(func(s string) int {
+			return len(tokenEncoder.Encode(s, nil, nil))
+		}),
+	)
+
+	for _, tc := range testCases {
+		docs, err := CreateDocuments(splitter, []string{tc.markdown}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, tc.expectedDocs, docs)
 	}
 }


### PR DESCRIPTION
Based on the custom lenFuc already supported in `RecursiveCharacter` splitter in [8734b6](https://github.com/tmc/langchaingo/commit/8734b60555715d08b6255b4731dc9bc3317227d2).


### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
