### PR TITLE
Add user field in OpenAI requests for LiteLLM

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -74,6 +74,9 @@ type ChatRequest struct {
 
 	// Metadata allows you to specify additional information that will be passed to the model.
 	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// User is the user to use for the request. This is used for LiteLLM's end_user tracking.
+	User string `json:"user,omitempty"`
 }
 
 // ToolType is the type of a tool.

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -111,6 +111,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		FunctionCallBehavior: openaiclient.FunctionCallBehavior(opts.FunctionCallBehavior),
 		Seed:                 opts.Seed,
 		Metadata:             opts.Metadata,
+		User:                 opts.User,
 	}
 	if opts.JSONMode {
 		req.ResponseFormat = ResponseFormatJSON

--- a/llms/options.go
+++ b/llms/options.go
@@ -66,6 +66,9 @@ type CallOptions struct {
 	// Supported MIME types are: text/plain: (default) Text output.
 	// application/json: JSON response in the response candidates.
 	ResponseMIMEType string `json:"response_mime_type,omitempty"`
+
+	// User is the user to use for the request. This is used for LiteLLM's end_user tracking.
+	User string `json:"user,omitempty"`
 }
 
 // Tool is a tool that can be used by the model.


### PR DESCRIPTION
LiteLLM proxy server offers end-user customer level data tracking. To enable this functionality, we'll need to send the `user` field through the main request body.

### PR Checklist

- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
