### PR TITLE
feat: add openai text to speech api

### DIFF
--- a/llms/openai/internal/openaiclient/openaitts.go
+++ b/llms/openai/internal/openaiclient/openaitts.go
@@ -1,0 +1,139 @@
+package openaiclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type TTSRequest struct {
+	// Model specifies the TTS model to use. "tts-1" is the default model and tts-1-hd is the high definition model.
+	Model string `json:"model" binding:"required" default:"tts-1"`
+
+	// Input is the text that will be converted to speech. This field is required.
+	Input string `json:"input" binding:"required"`
+
+	// Voice determines which voice style to use for synthesis. "alloy" is the default option and other options are "ash", "coral", "echo", "fable", "onyx", "nova", "sage" and "shimmer".
+	Voice string `json:"voice" binding:"required" default:"alloy"`
+
+	// ResponseFormat specifies the output format of the audio file.
+	// Defaults to "mp3" but other formats may be supported like "opus", "aac", "flac", "wav", and "pcm".
+	ResponseFormat string `json:"response_format"`
+
+	// Speed controls the speaking rate of the generated audio.
+	// Acceptable range is 0.25 to 4.0, with 1.0 as the default normal speed.
+	Speed float64 `json:"speed"`
+}
+
+type TTSModel string
+
+const (
+	TTS1   TTSModel = "tts-1"
+	TTS1HD TTSModel = "tts-1-hd"
+)
+
+const (
+	defaultTTSModel = TTS1
+)
+
+type TTSVoice string
+
+const (
+	Alloy   TTSVoice = "alloy"
+	Ash     TTSVoice = "ash"
+	Coral   TTSVoice = "coral"
+	Echo    TTSVoice = "echo"
+	Fable   TTSVoice = "fable"
+	Onyx    TTSVoice = "onyx"
+	Nova    TTSVoice = "nova"
+	Sage    TTSVoice = "sage"
+	Shimmer TTSVoice = "shimmer"
+)
+
+type TTSResponseFormat string
+
+const (
+	MP3  TTSResponseFormat = "mp3"
+	WAV  TTSResponseFormat = "wav"
+	OPUS TTSResponseFormat = "opus"
+	AAC  TTSResponseFormat = "aac"
+	FLAC TTSResponseFormat = "flac"
+	PCM  TTSResponseFormat = "pcm"
+)
+
+func (c *Client) setTTSDefaults(payload *TTSRequest) {
+	// Set defaults
+
+	switch {
+	// Prefer the model specified in the payload.
+	case payload.Model != "":
+
+	// If no model is set in the payload, take the one specified in the client.
+	case c.Model != "":
+		payload.Model = c.Model
+	// Fallback: use the default model
+	default:
+		payload.Model = string(defaultTTSModel)
+	}
+
+	if payload.ResponseFormat == "" {
+		payload.ResponseFormat = string(MP3)
+	}
+
+	if payload.Speed == 0 {
+		payload.Speed = 1.0
+	}
+
+	if payload.Voice == "" {
+		payload.Voice = string(Alloy)
+	}
+}
+
+func (c *Client) CreateTTS(ctx context.Context, payload *TTSRequest) ([]byte, error) {
+	c.setTTSDefaults(payload)
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build request
+	body := bytes.NewReader(payloadBytes)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.buildURL("/audio/speech", payload.Model), body)
+	if err != nil {
+		return nil, err
+	}
+
+	c.setHeaders(req)
+
+	// Send request
+	response, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		msg := fmt.Sprintf("API returned unexpected status code: %d", response.StatusCode)
+
+		// No need to check the error here: if it fails, we'll just return the
+		// status code.
+		var errResp errorMessage
+		if err := json.NewDecoder(response.Body).Decode(&errResp); err != nil {
+			return nil, errors.New(msg) // nolint:goerr113
+		}
+
+		return nil, fmt.Errorf("%s: %s", msg, errResp.Error.Message) // nolint:goerr113
+	}
+
+	responseData, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %w", err)
+	}
+
+	return responseData, nil
+
+}

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -43,6 +43,39 @@ func (o *LLM) Call(ctx context.Context, prompt string, options ...llms.CallOptio
 	return llms.GenerateFromSinglePrompt(ctx, o, prompt, options...)
 }
 
+// Create Text to Speech
+func (o *LLM) GenerateTTS(ctx context.Context, input string, options ...llms.CallOption) ([]byte, error) {
+
+	if input == "" {
+		return nil, fmt.Errorf("input is empty")
+	}
+
+	opts := llms.CallOptions{}
+	for _, opt := range options {
+		opt(&opts)
+	}
+
+	req := &openaiclient.TTSRequest{
+		Input:          input,
+		Model:          opts.Model,
+		Voice:          opts.Voice,
+		ResponseFormat: opts.ResponseFormat,
+		Speed:          opts.Speed,
+	}
+
+	if req.Model != string(openaiclient.TTS1) && req.Model != string(openaiclient.TTS1HD) {
+		req.Model = string(openaiclient.TTS1)
+	}
+
+	result, err := o.client.CreateTTS(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+
+}
+
 // GenerateContent implements the Model interface.
 func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) { //nolint: lll, cyclop, goerr113, funlen
 	if o.CallbacksHandler != nil {

--- a/llms/options.go
+++ b/llms/options.go
@@ -66,6 +66,11 @@ type CallOptions struct {
 	// Supported MIME types are: text/plain: (default) Text output.
 	// application/json: JSON response in the response candidates.
 	ResponseMIMEType string `json:"response_mime_type,omitempty"`
+
+	//TTS options
+	Voice          string  `json:"voice,omitempty"`
+	Speed          float64 `json:"speed,omitempty"`
+	ResponseFormat string  `json:"response_format,omitempty"`
 }
 
 // Tool is a tool that can be used by the model.
@@ -278,5 +283,26 @@ func WithMetadata(metadata map[string]interface{}) CallOption {
 func WithResponseMIMEType(responseMIMEType string) CallOption {
 	return func(o *CallOptions) {
 		o.ResponseMIMEType = responseMIMEType
+	}
+}
+
+// WithVoice will add an option to set the voice to use
+func WithVoice(voice string) CallOption {
+	return func(o *CallOptions) {
+		o.Voice = voice
+	}
+}
+
+// WithSpeed will add an option to set the speed of the voice
+func WithSpeed(speed float64) CallOption {
+	return func(o *CallOptions) {
+		o.Speed = speed
+	}
+}
+
+// WithResponseFormat will add an option to set the response format
+func WithResponseFormat(responseFormat string) CallOption {
+	return func(o *CallOptions) {
+		o.ResponseFormat = responseFormat
 	}
 }


### PR DESCRIPTION
What
This PR adds an example implementation of OpenAI's Text-to-Speech (TTS) API using Go. It includes setting up the API client, converting text to speech, saving the output, and playing the generated audio.

Why
This feature provides a simple and practical way to integrate OpenAI's TTS capabilities into Go applications, enabling AI-driven voice synthesis.

How

Establishes a connection to OpenAI's TTS API.
Sends text input for speech synthesis.
Saves the generated speech as an audio file.
Includes optional playback functionality.
Let me know if any changes are needed! 🚀


### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
