### PR TITLE
openai: support for "reasoning_effort" for o1/o3 models

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -74,6 +74,9 @@ type ChatRequest struct {
 
 	// Metadata allows you to specify additional information that will be passed to the model.
 	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// ReasoningEffort constrains effort on reasoning for reasoning models
+	ReasoningEffort ReasoningEffort `json:"reasoning_effort,omitempty"`
 }
 
 // ToolType is the type of a tool.
@@ -378,6 +381,16 @@ type FunctionCall struct {
 	// Arguments is the set of arguments to pass to the function.
 	Arguments string `json:"arguments"`
 }
+
+// ReasoningEffort is the reasoning effort to use for the model.
+// Defaults to "medium".
+type ReasoningEffort string
+
+const (
+	ReasoningEffortLow    ReasoningEffort = "low"
+	ReasoningEffortMedium ReasoningEffort = "medium"
+	ReasoningEffortHigh   ReasoningEffort = "high"
+)
 
 func (c *Client) createChat(ctx context.Context, payload *ChatRequest) (*ChatCompletionResponse, error) {
 	if payload.StreamingFunc != nil {

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -111,6 +111,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		FunctionCallBehavior: openaiclient.FunctionCallBehavior(opts.FunctionCallBehavior),
 		Seed:                 opts.Seed,
 		Metadata:             opts.Metadata,
+		ReasoningEffort:      openaiclient.ReasoningEffort(opts.ReasoningEffort),
 	}
 	if opts.JSONMode {
 		req.ResponseFormat = ResponseFormatJSON

--- a/llms/options.go
+++ b/llms/options.go
@@ -66,6 +66,9 @@ type CallOptions struct {
 	// Supported MIME types are: text/plain: (default) Text output.
 	// application/json: JSON response in the response candidates.
 	ResponseMIMEType string `json:"response_mime_type,omitempty"`
+
+	// ReasoningEffort constrains effort on reasoning for reasoning models
+	ReasoningEffort ReasoningEffort `json:"reasoning_effort,omitempty"`
 }
 
 // Tool is a tool that can be used by the model.
@@ -110,6 +113,16 @@ const (
 	FunctionCallBehaviorNone FunctionCallBehavior = "none"
 	// FunctionCallBehaviorAuto will call functions automatically.
 	FunctionCallBehaviorAuto FunctionCallBehavior = "auto"
+)
+
+// ReasoningEffort is the reasoning effort to use for the model.
+// Defaults to "medium".
+type ReasoningEffort string
+
+const (
+	ReasoningEffortLow    ReasoningEffort = "low"
+	ReasoningEffortMedium ReasoningEffort = "medium"
+	ReasoningEffortHigh   ReasoningEffort = "high"
 )
 
 // WithModel specifies which model name to use.
@@ -278,5 +291,13 @@ func WithMetadata(metadata map[string]interface{}) CallOption {
 func WithResponseMIMEType(responseMIMEType string) CallOption {
 	return func(o *CallOptions) {
 		o.ResponseMIMEType = responseMIMEType
+	}
+}
+
+// WithReasoningEffort sets the reasoning effort for the model, if it supports it.
+// Currently only supported by openai llms.
+func WithReasoningEffort(reasoningEffort ReasoningEffort) CallOption {
+	return func(o *CallOptions) {
+		o.ReasoningEffort = reasoningEffort
 	}
 }


### PR DESCRIPTION
Adds support of the reasoning effort field for reasoning models.

See https://platform.openai.com/docs/api-reference/chat/create#chat-create-reasoning_effort

Fixes #1122

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
