### PR TITLE
fix: Fixed the issue where only the first layer was processed when co…

### DIFF
--- a/llms/googleai/vertex/vertex_test.go
+++ b/llms/googleai/vertex/vertex_test.go
@@ -1,0 +1,67 @@
+package vertex
+
+import (
+	"fmt"
+	"github.com/tmc/langchaingo/llms"
+	"testing"
+)
+
+/*
+Description:
+Author: xsl
+Date: 2025/2/7
+
+Modification History:
+Date			Author		Description
+-----------------------------------------
+2025/2/7		    xsl			创建文件
+*/
+
+func TestConvertTools(t *testing.T) {
+	availableTools := []llms.Tool{
+		{
+			Type: "function",
+			Function: &llms.FunctionDefinition{
+				Name:        "BookCalendarSchedule",
+				Description: "Useful when user want you to add event to calendar.\\nAdd event to USER'S CALENDAR by sending email.\\nOnly use this function when user EXPLICITLY ask you to add event to calendar.",
+				Parameters: map[string]any{
+					"type":     "object",
+					"required": []string{"events"},
+					"properties": map[string]any{
+						"events": map[string]any{
+							"type": "array",
+							"items": map[string]any{
+								"type":     "object",
+								"required": []string{"summary", "start", "end"},
+								"properties": map[string]any{
+									"end": map[string]any{
+										"type":        "string",
+										"description": "Event end time\\nFormat: 2023-10-03 23:10:03",
+									},
+									"start": map[string]any{
+										"type":        "string",
+										"description": "Event start time\\nFormat: 2023-10-03 23:10:03",
+									},
+									"summary": map[string]any{
+										"type": "string",
+									},
+									"location": map[string]any{
+										"type": "string",
+									},
+									"description": map[string]any{
+										"type": "string",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	tools, err := convertTools(availableTools)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("%+v\n", tools)
+}


### PR DESCRIPTION
# Fix Multi-level Conversion for OpenAI Tool Structure

## Problem
The current tool structure conversion logic only processes the first level of OpenAI tool definitions, resulting in information loss when handling deeply nested tool structures. This affects the integrity and correctness of complex tool definitions.

## Improvements
- Refactored tool structure conversion logic by introducing an iterative processing mechanism
- Implemented complete traversal and conversion of nested structures
- Added `schemaWorkItem` struct to manage the conversion process
- Utilized queue-based approach for multi-level property conversion

## Technical Details
- Introduced `schemaWorkItem` type to track conversion progress
- Implemented work queue (workQueue) for level-by-level processing
- Enhanced handling of various properties:
  - Object type properties
  - Array type items
  - Required fields
  - Description information
  - Enum values

## Impact
This improvement ensures that complex tool definitions maintain complete structural information during the conversion process, enhancing compatibility with the OpenAI API.

## Testing
- Added relevant unit tests
- Verified correct conversion of multi-level nested structures
