### PR TITLE
make inputVars of prompt of agents can be edited

### DIFF
--- a/agents/mrkl_prompt.go
+++ b/agents/mrkl_prompt.go
@@ -31,13 +31,23 @@ Question: {{.input}}
 {{.agent_scratchpad}}`
 )
 
-func createMRKLPrompt(tools []tools.Tool, prefix, instructions, suffix string) prompts.PromptTemplate {
-	template := strings.Join([]string{prefix, instructions, suffix}, "\n\n")
+type mrklTemplateBase struct {
+	Template       string
+	InputVariables []string
+}
 
+func createMRKLPrompt(tools []tools.Tool, prefix, instructions, suffix mrklTemplateBase) prompts.PromptTemplate {
+	template := strings.Join([]string{prefix.Template, instructions.Template, suffix.Template}, "\n\n")
+	inputVariables := make([]string, 0, len(prefix.InputVariables)+
+		len(instructions.InputVariables)+
+		len(suffix.InputVariables))
+	inputVariables = append(inputVariables, prefix.InputVariables...)
+	inputVariables = append(inputVariables, instructions.InputVariables...)
+	inputVariables = append(inputVariables, suffix.InputVariables...)
 	return prompts.PromptTemplate{
 		Template:       template,
 		TemplateFormat: prompts.TemplateFormatGoTemplate,
-		InputVariables: []string{"input", "agent_scratchpad", "today"},
+		InputVariables: inputVariables,
 		PartialVariables: map[string]any{
 			"tool_names":        toolNames(tools),
 			"tool_descriptions": toolDescriptions(tools),

--- a/agents/options.go
+++ b/agents/options.go
@@ -54,10 +54,13 @@ func mrklDefaultOptions() Options {
 
 func conversationalDefaultOptions() Options {
 	return Options{
-		promptPrefix:       _defaultConversationalPrefix,
-		formatInstructions: _defaultConversationalFormatInstructions,
-		promptSuffix:       _defaultConversationalSuffix,
-		outputKey:          _defaultOutputKey,
+		promptPrefix:                     _defaultConversationalPrefix,
+		formatInstructions:               _defaultConversationalFormatInstructions,
+		promptSuffix:                     _defaultConversationalSuffix,
+		outputKey:                        _defaultOutputKey,
+		promptPrefixInputVariables:       []string{},
+		formatInstructionsInputVariables: []string{},
+		promptSuffixInputVariables:       []string{"agent_scratchpad", "input"},
 	}
 }
 
@@ -88,9 +91,9 @@ func (co Options) getConversationalPrompt(tools []tools.Tool) prompts.PromptTemp
 
 	return createConversationalPrompt(
 		tools,
-		co.promptPrefix,
-		co.formatInstructions,
-		co.promptSuffix,
+		conversationalTemplateBase{co.promptPrefix, co.promptPrefixInputVariables},
+		conversationalTemplateBase{co.formatInstructions, co.formatInstructionsInputVariables},
+		conversationalTemplateBase{co.promptSuffix, co.promptSuffixInputVariables},
 	)
 }
 

--- a/agents/options.go
+++ b/agents/options.go
@@ -72,6 +72,7 @@ func (co Options) getMrklPrompt(tools []tools.Tool) prompts.PromptTemplate {
 	if co.prompt.Template != "" {
 		return co.prompt
 	}
+
 	return createMRKLPrompt(
 		tools,
 		mrklTemplateBase{co.promptPrefix, co.promptPrefixInputVariables},

--- a/agents/options.go
+++ b/agents/options.go
@@ -20,6 +20,9 @@ type Options struct {
 	formatInstructions      string
 	promptSuffix            string
 
+	promptPrefixInputVariables       []string
+	formatInstructionsInputVariables []string
+	promptSuffixInputVariables       []string
 	// openai
 	systemMessage string
 	extraMessages []prompts.MessageFormatter
@@ -39,10 +42,13 @@ func executorDefaultOptions() Options {
 
 func mrklDefaultOptions() Options {
 	return Options{
-		promptPrefix:       _defaultMrklPrefix,
-		formatInstructions: _defaultMrklFormatInstructions,
-		promptSuffix:       _defaultMrklSuffix,
-		outputKey:          _defaultOutputKey,
+		promptPrefix:                     _defaultMrklPrefix,
+		formatInstructions:               _defaultMrklFormatInstructions,
+		promptSuffix:                     _defaultMrklSuffix,
+		outputKey:                        _defaultOutputKey,
+		promptPrefixInputVariables:       []string{"today"},
+		formatInstructionsInputVariables: []string{},
+		promptSuffixInputVariables:       []string{"agent_scratchpad", "input"},
 	}
 }
 
@@ -66,12 +72,11 @@ func (co Options) getMrklPrompt(tools []tools.Tool) prompts.PromptTemplate {
 	if co.prompt.Template != "" {
 		return co.prompt
 	}
-
 	return createMRKLPrompt(
 		tools,
-		co.promptPrefix,
-		co.formatInstructions,
-		co.promptSuffix,
+		mrklTemplateBase{co.promptPrefix, co.promptPrefixInputVariables},
+		mrklTemplateBase{co.formatInstructions, co.formatInstructionsInputVariables},
+		mrklTemplateBase{co.promptSuffix, co.promptSuffixInputVariables},
 	)
 }
 
@@ -110,6 +115,13 @@ func WithPromptPrefix(prefix string) Option {
 	}
 }
 
+// WithPromptPrefixInputVariables is an option for setting the PrefixInputVariables of the prompt used by the agent.
+func WithPromptPrefixInputVariables(list []string) Option {
+	return func(co *Options) {
+		co.promptPrefixInputVariables = list
+	}
+}
+
 // WithPromptFormatInstructions is an option for setting the format instructions of the prompt
 // used by the agent.
 func WithPromptFormatInstructions(instructions string) Option {
@@ -118,10 +130,25 @@ func WithPromptFormatInstructions(instructions string) Option {
 	}
 }
 
+// WithPromptInstructionsInputVariables is an option for setting the format InstructionsInputVariables of the prompt
+// used by the agent.
+func WithPromptInstructionsInputVariables(list []string) Option {
+	return func(co *Options) {
+		co.formatInstructionsInputVariables = list
+	}
+}
+
 // WithPromptSuffix is an option for setting the suffix of the prompt used by the agent.
 func WithPromptSuffix(suffix string) Option {
 	return func(co *Options) {
 		co.promptSuffix = suffix
+	}
+}
+
+// WithPromptSuffixInputVariables is an option for setting the SuffixInputVariables of the prompt used by the agent.
+func WithPromptSuffixInputVariables(list []string) Option {
+	return func(co *Options) {
+		co.promptSuffixInputVariables = list
 	}
 }
 

--- a/agents/options_test.go
+++ b/agents/options_test.go
@@ -1,0 +1,92 @@
+package agents
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/prompts"
+	"github.com/tmc/langchaingo/tools"
+	"strings"
+	"testing"
+)
+
+func TestGetMrklPromptVars(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		promptPrefix                     string
+		formatInstructions               string
+		promptSuffix                     string
+		promptPrefixInputVariables       []string
+		formatInstructionsInputVariables []string
+		promptSuffixInputVariables       []string
+		expectPromptTemplate             prompts.PromptTemplate
+	}{
+		{
+			promptPrefix:                     "this {{.top}}",
+			formatInstructions:               "this {{instruction}}",
+			promptSuffix:                     "this {{.content}} and {{.end}}",
+			promptPrefixInputVariables:       []string{"top"},
+			formatInstructionsInputVariables: []string{"instruction"},
+			promptSuffixInputVariables:       []string{"content", "end"},
+			expectPromptTemplate: prompts.NewPromptTemplate(strings.Join([]string{"this {{.top}}",
+				"this {{instruction}}",
+				"this {{.content}} and {{.end}}"}, "\n\n"),
+				[]string{"top", "instruction", "content", "end"},
+			),
+		},
+		{
+			promptPrefix:                     "",
+			formatInstructions:               "",
+			promptSuffix:                     "",
+			promptPrefixInputVariables:       []string{},
+			formatInstructionsInputVariables: []string{},
+			promptSuffixInputVariables:       []string{},
+			expectPromptTemplate: prompts.NewPromptTemplate(strings.Join([]string{_defaultMrklPrefix,
+				_defaultMrklFormatInstructions,
+				_defaultMrklSuffix}, "\n\n"),
+				[]string{"today", "agent_scratchpad", "input"},
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		opt := mrklDefaultOptions()
+		if tc.promptPrefix != "" {
+			WithPromptPrefix(tc.promptPrefix)(&opt)
+		}
+		if tc.promptSuffix != "" {
+			WithPromptSuffix(tc.promptSuffix)(&opt)
+		}
+		if tc.formatInstructions != "" {
+			WithPromptFormatInstructions(tc.formatInstructions)(&opt)
+		}
+		if len(tc.promptPrefixInputVariables) != 0 {
+			WithPromptPrefixInputVariables(tc.promptPrefixInputVariables)(&opt)
+		}
+		if len(tc.promptSuffixInputVariables) != 0 {
+			WithPromptSuffixInputVariables(tc.promptSuffixInputVariables)(&opt)
+		}
+		if len(tc.formatInstructionsInputVariables) != 0 {
+			WithPromptInstructionsInputVariables(tc.formatInstructionsInputVariables)(&opt)
+		}
+
+		temp := opt.getMrklPrompt([]tools.Tool{})
+		fmt.Println("%%%####@@@@", temp.Template)
+		require.Equal(t, temp.Template, tc.expectPromptTemplate.Template)
+		tempVariables := make(map[string]struct{})
+		for _, v := range opt.promptPrefixInputVariables {
+			tempVariables[v] = struct{}{}
+		}
+		for _, v := range opt.promptSuffixInputVariables {
+			tempVariables[v] = struct{}{}
+		}
+		for _, v := range opt.formatInstructionsInputVariables {
+			tempVariables[v] = struct{}{}
+		}
+		for _, v := range tc.expectPromptTemplate.GetInputVariables() {
+			if _, ok := tempVariables[v]; !ok {
+				t.Error(v, "not found in Variables")
+			}
+		}
+	}
+
+}

--- a/agents/options_test.go
+++ b/agents/options_test.go
@@ -1,7 +1,6 @@
 package agents
 
 import (
-	"fmt"
 	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/prompts"
 	"github.com/tmc/langchaingo/tools"
@@ -70,7 +69,6 @@ func TestGetMrklPromptVars(t *testing.T) {
 		}
 
 		temp := opt.getMrklPrompt([]tools.Tool{})
-		fmt.Println("%%%####@@@@", temp.Template)
 		require.Equal(t, temp.Template, tc.expectPromptTemplate.Template)
 		tempVariables := make(map[string]struct{})
 		for _, v := range opt.promptPrefixInputVariables {

--- a/agents/options_test.go
+++ b/agents/options_test.go
@@ -1,6 +1,7 @@
 package agents
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/prompts"
 	"github.com/tmc/langchaingo/tools"
@@ -86,5 +87,14 @@ func TestGetMrklPromptVars(t *testing.T) {
 			}
 		}
 	}
+
+}
+func TestGetConversationPrompt(t *testing.T) {
+	opt := conversationalDefaultOptions()
+	WithPromptFormatInstructions("aaa{{.tool_names}}")(&opt)
+	WithPromptPrefix("bbb{{.tool_descriptions}}")(&opt)
+	WithPromptSuffix("ccc{{.history}}")(&opt)
+	temp := opt.getConversationalPrompt([]tools.Tool{})
+	fmt.Println(temp.Format(map[string]any{}))
 
 }

--- a/agents/options_test.go
+++ b/agents/options_test.go
@@ -1,7 +1,6 @@
 package agents
 
 import (
-	"fmt"
 	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/prompts"
 	"github.com/tmc/langchaingo/tools"
@@ -9,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestGetMrklPromptVars(t *testing.T) {
+func TestMrklPromptEdit(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		promptPrefix                     string
@@ -22,13 +21,13 @@ func TestGetMrklPromptVars(t *testing.T) {
 	}{
 		{
 			promptPrefix:                     "this {{.top}}",
-			formatInstructions:               "this {{instruction}}",
+			formatInstructions:               "this {{.instruction}}",
 			promptSuffix:                     "this {{.content}} and {{.end}}",
 			promptPrefixInputVariables:       []string{"top"},
 			formatInstructionsInputVariables: []string{"instruction"},
 			promptSuffixInputVariables:       []string{"content", "end"},
 			expectPromptTemplate: prompts.NewPromptTemplate(strings.Join([]string{"this {{.top}}",
-				"this {{instruction}}",
+				"this {{.instruction}}",
 				"this {{.content}} and {{.end}}"}, "\n\n"),
 				[]string{"top", "instruction", "content", "end"},
 			),
@@ -89,12 +88,84 @@ func TestGetMrklPromptVars(t *testing.T) {
 	}
 
 }
-func TestGetConversationPrompt(t *testing.T) {
-	opt := conversationalDefaultOptions()
-	WithPromptFormatInstructions("aaa{{.tool_names}}")(&opt)
-	WithPromptPrefix("bbb{{.tool_descriptions}}")(&opt)
-	WithPromptSuffix("ccc{{.history}}")(&opt)
-	temp := opt.getConversationalPrompt([]tools.Tool{})
-	fmt.Println(temp.Format(map[string]any{}))
+
+func TestConversationPromptEdit(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		promptPrefix                     string
+		formatInstructions               string
+		promptSuffix                     string
+		promptPrefixInputVariables       []string
+		formatInstructionsInputVariables []string
+		promptSuffixInputVariables       []string
+		expectPromptTemplate             prompts.PromptTemplate
+	}{
+		{
+			promptPrefix:                     "this {{.top}}",
+			formatInstructions:               "this {{.instruction}}",
+			promptSuffix:                     "this {{.history}} and {{.end}}",
+			promptPrefixInputVariables:       []string{"top"},
+			formatInstructionsInputVariables: []string{"instruction"},
+			promptSuffixInputVariables:       []string{"content", "end"},
+			expectPromptTemplate: prompts.NewPromptTemplate(strings.Join([]string{"this {{.top}}",
+				"this {{.instruction}}",
+				"this {{.history}} and {{.end}}"}, "\n\n"),
+				[]string{"top", "instruction", "content", "end"},
+			),
+		},
+		{
+			promptPrefix:                     "",
+			formatInstructions:               "",
+			promptSuffix:                     "",
+			promptPrefixInputVariables:       []string{},
+			formatInstructionsInputVariables: []string{},
+			promptSuffixInputVariables:       []string{},
+			expectPromptTemplate: prompts.NewPromptTemplate(strings.Join([]string{_defaultConversationalPrefix,
+				_defaultConversationalFormatInstructions,
+				_defaultConversationalSuffix}, "\n\n"),
+				[]string{"agent_scratchpad", "input"},
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		opt := conversationalDefaultOptions()
+		if tc.promptPrefix != "" {
+			WithPromptPrefix(tc.promptPrefix)(&opt)
+		}
+		if tc.promptSuffix != "" {
+			WithPromptSuffix(tc.promptSuffix)(&opt)
+		}
+		if tc.formatInstructions != "" {
+			WithPromptFormatInstructions(tc.formatInstructions)(&opt)
+		}
+		if len(tc.promptPrefixInputVariables) != 0 {
+			WithPromptPrefixInputVariables(tc.promptPrefixInputVariables)(&opt)
+		}
+		if len(tc.promptSuffixInputVariables) != 0 {
+			WithPromptSuffixInputVariables(tc.promptSuffixInputVariables)(&opt)
+		}
+		if len(tc.formatInstructionsInputVariables) != 0 {
+			WithPromptInstructionsInputVariables(tc.formatInstructionsInputVariables)(&opt)
+		}
+
+		temp := opt.getConversationalPrompt([]tools.Tool{})
+		require.Equal(t, temp.Template, tc.expectPromptTemplate.Template)
+		tempVariables := make(map[string]struct{})
+		for _, v := range opt.promptPrefixInputVariables {
+			tempVariables[v] = struct{}{}
+		}
+		for _, v := range opt.promptSuffixInputVariables {
+			tempVariables[v] = struct{}{}
+		}
+		for _, v := range opt.formatInstructionsInputVariables {
+			tempVariables[v] = struct{}{}
+		}
+		for _, v := range tc.expectPromptTemplate.GetInputVariables() {
+			if _, ok := tempVariables[v]; !ok {
+				t.Error(v, "not found in Variables")
+			}
+		}
+	}
 
 }


### PR DESCRIPTION
when i edited prompt of agents and couldn't edit the inputVars of prompt ,so i added some func to make the inputVars of MrklPrompt and ConversationalPrompt  can be edited.
and The parameter of createConversationalPrompt  and createMRKLPrompt is adjusted


### PR Checklist

- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
