### PR TITLE
fix decoding err with : keep-alive

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -442,7 +442,7 @@ func parseStreamingChatResponse(ctx context.Context, r *http.Response, payload *
 		defer close(responseChan)
 		for scanner.Scan() {
 			line := scanner.Text()
-			if line == "" {
+			if line == "" || line == ": keep-alive" {
 				continue
 			}
 


### PR DESCRIPTION
https://api-docs.deepseek.com/quick_start/rate_limit

Streaming requests: Continuously return SSE keep-alive comments (: keep-alive)


![image](https://github.com/user-attachments/assets/ba6f6f5e-a5da-4153-91a9-1d147202fefa)
