### PR TITLE
refactor: rename mongovector defaultPath

### DIFF
--- a/vectorstores/mongovector/mongovector.go
+++ b/vectorstores/mongovector/mongovector.go
@@ -15,7 +15,7 @@ import (
 const (
 	defaultIndex               = "vector_index"
 	pageContentName            = "pageContent"
-	defaultPath                = "plot_embedding"
+	defaultPath                = "embeddings"
 	metadataName               = "metadata"
 	scoreName                  = "score"
 	defaultNumCandidatesScalar = 10

--- a/vectorstores/mongovector/mongovector_test.go
+++ b/vectorstores/mongovector/mongovector_test.go
@@ -161,30 +161,30 @@ func TestNew(t *testing.T) {
 			opts:                nil,
 			wantIndex:           "vector_index",
 			wantPageContentName: "page_content",
-			wantPath:            "plot_embedding",
+			wantPath:            "embeddings",
 		},
 		{
 			name:                "no options",
 			opts:                []Option{},
 			wantIndex:           "vector_index",
 			wantPageContentName: "page_content",
-			wantPath:            "plot_embedding",
+			wantPath:            "embeddings",
 		},
 		{
 			name:                "mixed custom options",
 			opts:                []Option{WithIndex("custom_vector_index")},
 			wantIndex:           "custom_vector_index",
 			wantPageContentName: "page_content",
-			wantPath:            "plot_embedding",
+			wantPath:            "embeddings",
 		},
 		{
 			name: "all custom options",
 			opts: []Option{
 				WithIndex("custom_vector_index"),
-				WithPath("custom_plot_embedding"),
+				WithPath("custom_embeddings"),
 			},
 			wantIndex: "custom_vector_index",
-			wantPath:  "custom_plot_embedding",
+			wantPath:  "custom_embeddings",
 		},
 	}
 
@@ -606,7 +606,7 @@ func resetForE2E(ctx context.Context, client *mongo.Client, idx string, dim int,
 
 	fields = append(fields, vectorField{
 		Type:          "vector",
-		Path:          "plot_embedding",
+		Path:          "embeddings",
 		NumDimensions: dim,
 		Similarity:    "dotProduct",
 	})


### PR DESCRIPTION
defaultPath is currently "plot_embedding" which is a reference to a specific example in mongodb documentation concerning movie plots. This value should be more generic and inline with the langchain API: https://langchain-mongodb.readthedocs.io/en/latest/_modules/langchain_mongodb/vectorstores.html#MongoDBAtlasVectorSearch.add_documents

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [ x Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
