### PR TITLE
fix(googleai): Change GoogleAI default model from 'gemini-pro' to 'gemini-2.0-flash'

### DIFF
--- a/llms/googleai/option.go
+++ b/llms/googleai/option.go
@@ -29,7 +29,7 @@ func DefaultOptions() Options {
 	return Options{
 		CloudProject:          "",
 		CloudLocation:         "",
-		DefaultModel:          "gemini-pro",
+		DefaultModel:          "gemini-2.0-flash",
 		DefaultEmbeddingModel: "embedding-001",
 		DefaultCandidateCount: 1,
 		DefaultMaxTokens:      2048,


### PR DESCRIPTION

### PR Checklist

- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

---

This PR change Google AI's default model from `gemini-pro` to `gemini-2.0-flash`.
The main reason to change the model is to fix the error below,

```
rpc error: 
code = FailedPrecondition 
desc = Project `000000000000` is not allowed to use Publisher Model 
`projects/000000000000/locations/asia-northeast1/publishers/google/models/gemini-pro`
```

This error occurs some hours ago suddenly.
I guess the model `gemini-pro`  may be deprecated. (model itself, or this style to point the model)
ref: https://www.googlecloudcommunity.com/gc/AI-ML/Error-Project-is-not-allowed-to-use-Vertex-AI-model-text-bison/m-p/825751

Gemini App use 2.0 flash as default model, so I choose it too.
https://gemini.google.com/app

For testers, Gemini cannot run with some location  (e.g. 🚫  asia-northeast1).
https://cloud.google.com/gemini/docs/locations
I tested using ✅  `us-central1.
