### PR TITLE
documentation: Text Splitters conceptual link going to 404

### DIFF
--- a/docs/docs/modules/data_connection/text_splitters/index.mdx
+++ b/docs/docs/modules/data_connection/text_splitters/index.mdx
@@ -10,7 +10,7 @@ import CodeBlock from "@theme/CodeBlock";
 # Getting Started: Text Splitters
 
 :::info
-[Conceptual Guide](https://python.langchain.com/docs/modules/data_connection/document_transformers)
+[Conceptual Guide](https://python.langchain.com/docs/how_to/#text-splitters)
 :::
 
 Language Models are often limited by the amount of text that you can pass to them. Therefore, it is neccessary to split them up into smaller chunks. LangChain provides several utilities for doing so.


### PR DESCRIPTION
[Data Connections => Text Splitters](https://tmc.github.io/langchaingo/docs/modules/data_connection/text_splitters/) conceptual link is going to 404.  This PR updates the link to the current LangChain document for text splitters.  
