### PR TITLE
ci: migrate linting golangci-lint to v2.0.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,9 +17,9 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.61
+          version: v2.0.2
           args: --timeout=5m
   build-examples:
     name: Build Examples

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,68 +1,133 @@
+version: "2"
 linters:
-  presets:
-    - bugs
-    - comment
-    - complexity
-    - error
-    - format
-    - import
-    - metalinter
-    - module
-    - performance
-    - sql
-    - style
-    - test
-    - unused
   enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - containedctx
+    - contextcheck
+    - copyloopvar
+    - cyclop
+    - decorder
+    - dogsled
+    - dupl
+    - dupword
+    - durationcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - exhaustive
+    - exptostd
+    - fatcontext
     - forbidigo
+    - funlen
+    - ginkgolinter
+    - gocheckcompilerdirectives
+    - gochecknoglobals
+    - gochecknoinits
+    - gochecksumtype
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - goheader
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - grouper
+    - iface
+    - importas
+    - inamedparam
+    - interfacebloat
+    - loggercheck
+    - maintidx
+    - makezero
+    - mirror
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnesserr
+    - nilnil
+    - noctx
+    - nonamedreturns
+    - nosprintfhostport
+    - paralleltest
+    - prealloc
+    - predeclared
+    - promlinter
+    - protogetter
+    - reassign
+    - revive
+    - rowserrcheck
+    - sloglint
+    - spancheck
+    - sqlclosecheck
+    - staticcheck
+    - testableexamples
+    - thelper
+    - tparallel
+    - unconvert
+    - unparam
+    - usestdlibvars
+    - usetesting
+    - wastedassign
+    - whitespace
+    - zerologlint
   disable:
-    - gci # We don't use gci.
-    - godox # We allow TODO lines.
-    - tagliatelle # As we're dealing with third parties we must accept snake case.
-    - wsl # We don't agree with wsl's style rules
-    - exhaustruct
-    - lll
-    - varnamelen
-    - nlreturn
-    - gomnd
-    - err113
-    - wrapcheck # TODO: we should probably enable this one (at least for new code).
-    - testpackage
-    - nolintlint # see https://github.com/golangci/golangci-lint/issues/3228.
-    - depguard # disabling temporarily
-    - ireturn # disabling temporarily
-    - perfsprint
-    - musttag
-    - tagalign # Impractical for schema-defined output parser, which relies heavily on struct tagging.
-    - mnd
     - canonicalheader
+    - depguard
+    - err113
+    - exhaustruct
+    - godox
     - intrange
+    - ireturn
+    - lll
+    - mnd
+    - musttag
+    - nlreturn
+    - nolintlint
+    - perfsprint
+    - tagalign
+    - tagliatelle
     - testifylint
-
-linters-settings:
-  cyclop:
-    max-complexity: 12
-  funlen:
-    lines: 90
-  depguard:
-    list-type: denylist
-    packages:
-      - github.com/samber/lo # Use exp packages or internal utilities instead.
-    additional-guards:
-      - list-type: denylist
-        include-go-root: false
-        packages:
-          - github.com/stretchr/testify
-        # Specify rules by which the linter ignores certain files for consideration.
-        ignore-file-rules:
-          - "**/*_test.go"
-          - "**/mock/**/*.go"
-  forbidigo:
-    forbid:
-      - 'import "[^"]+/(util|common|helpers)"'
-  gosec:
-    excludes:
-    - G115 # https://github.com/securego/gosec/issues/1212
-run:
-  exclude-dirs:
-    - 'exp'
+    - testpackage
+    - varnamelen
+    - wrapcheck
+    - wsl
+  settings:
+    cyclop:
+      max-complexity: 12
+    forbidigo:
+      forbid:
+        - pattern: import "[^"]+/(util|common|helpers)"
+    funlen:
+      lines: 90
+    gosec:
+      excludes:
+        - G115
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/chains/map_reduce.go
+++ b/chains/map_reduce.go
@@ -3,10 +3,10 @@ package chains
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/tmc/langchaingo/memory"
 	"github.com/tmc/langchaingo/schema"
-	"golang.org/x/exp/maps"
 )
 
 // MapReduceDocuments is a chain that combines documents by mapping a chain over them, then
@@ -158,7 +158,11 @@ func (c MapReduceDocuments) GetInputKeys() []string {
 		inputKeys[key] = true
 	}
 
-	return maps.Keys(inputKeys)
+	result := make([]string, 0, len(inputKeys))
+	for k := range inputKeys {
+		result = append(result, k)
+	}
+	return result
 }
 
 func (c MapReduceDocuments) GetOutputKeys() []string {

--- a/chains/map_rerank_documents.go
+++ b/chains/map_rerank_documents.go
@@ -3,13 +3,13 @@ package chains
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sort"
 	"strconv"
 
 	"github.com/tmc/langchaingo/memory"
 	"github.com/tmc/langchaingo/outputparser"
 	"github.com/tmc/langchaingo/schema"
-	"golang.org/x/exp/maps"
 )
 
 const (

--- a/documentloaders/csv.go
+++ b/documentloaders/csv.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/tmc/langchaingo/schema"
 	"github.com/tmc/langchaingo/textsplitter"
-	"golang.org/x/exp/slices"
 )
 
 // CSV represents a CSV document loader.

--- a/documentloaders/notion_test.go
+++ b/documentloaders/notion_test.go
@@ -14,9 +14,7 @@ func TestNotionDirectoryLoader_Load(t *testing.T) {
 	t.Parallel()
 
 	// Create a temporary test directory
-	tempDir, err := os.MkdirTemp("", "notion_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	// Create sample Markdown files in the temporary directory
 	testFiles := []struct {

--- a/examples/deepseek-completion-example/deepseek-completion-example.go
+++ b/examples/deepseek-completion-example/deepseek-completion-example.go
@@ -32,7 +32,7 @@ func main() {
 		content,
 		llms.WithMaxTokens(2000),
 		llms.WithTemperature(0.7),
-		llms.WithStreamingReasoningFunc(func(ctx context.Context, reasoningChunk []byte, chunk []byte) error {
+		llms.WithStreamingReasoningFunc(func(_ context.Context, reasoningChunk []byte, chunk []byte) error {
 			if len(reasoningChunk) > 0 {
 				fmt.Printf("Streaming Reasoning: %s\n", string(reasoningChunk))
 			}

--- a/examples/maritaca-example/maritaca-chat-example.go
+++ b/examples/maritaca-example/maritaca-chat-example.go
@@ -16,7 +16,6 @@ func main() {
 		maritaca.WithModel("sabia-2-medium"),
 	}
 	llm, err := maritaca.New(opts...)
-
 	if err != nil {
 		panic(err)
 	}
@@ -28,5 +27,4 @@ func main() {
 		panic(err)
 	}
 	fmt.Println(resp)
-
 }

--- a/examples/zep-memory-chain-example/main.go
+++ b/examples/zep-memory-chain-example/main.go
@@ -3,13 +3,14 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/getzep/zep-go"
 	zepClient "github.com/getzep/zep-go/client"
 	zepOption "github.com/getzep/zep-go/option"
 	"github.com/tmc/langchaingo/chains"
 	"github.com/tmc/langchaingo/llms/openai"
 	zepLangchainMemory "github.com/tmc/langchaingo/memory/zep"
-	"os"
 )
 
 func main() {

--- a/llms/bedrock/internal/bedrockclient/provider_anthropic.go
+++ b/llms/bedrock/internal/bedrockclient/provider_anthropic.go
@@ -350,12 +350,13 @@ func getAnthropicRole(role llms.ChatMessageType) (string, error) {
 
 func getAnthropicInputContent(message Message) anthropicTextGenerationInputContent {
 	var c anthropicTextGenerationInputContent
-	if message.Type == AnthropicMessageTypeText {
+	switch message.Type {
+	case AnthropicMessageTypeText:
 		c = anthropicTextGenerationInputContent{
 			Type: message.Type,
 			Text: message.Content,
 		}
-	} else if message.Type == AnthropicMessageTypeImage {
+	case AnthropicMessageTypeImage:
 		c = anthropicTextGenerationInputContent{
 			Type: message.Type,
 			Source: &anthropicBinGenerationInputSource{

--- a/llms/huggingface/internal/huggingfaceclient/huggingfaceclient_test.go
+++ b/llms/huggingface/internal/huggingfaceclient/huggingfaceclient_test.go
@@ -62,10 +62,10 @@ func mockServer(t *testing.T) *httptest.Server {
 
 		if infReq.Parameters.TopK == -1 {
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"error":["%s"]}`, errMsg)))
+			_, _ = fmt.Fprintf(w, `{"error":["%s"]}`, errMsg)
 		} else {
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(fmt.Sprintf(`[{"generated_text":"%s"}]`, goodResponse)))
+			_, _ = fmt.Fprintf(w, `[{"generated_text":"%s"}]`, goodResponse)
 		}
 	}))
 }

--- a/llms/maritaca/maritacallm.go
+++ b/llms/maritaca/maritacallm.go
@@ -190,9 +190,9 @@ func createChoice(resp maritacaclient.ChatResponse) []*llms.ContentChoice {
 		{
 			Content: resp.Answer,
 			GenerationInfo: map[string]any{
-				"CompletionTokens": resp.Metrics.Usage.CompletionTokens,
-				"PromptTokens":     resp.Metrics.Usage.PromptTokens,
-				"TotalTokens":      resp.Metrics.Usage.TotalTokens,
+				"CompletionTokens": resp.Usage.CompletionTokens,
+				"PromptTokens":     resp.Usage.PromptTokens,
+				"TotalTokens":      resp.Usage.TotalTokens,
 			},
 		},
 	}

--- a/memory/token_buffer.go
+++ b/memory/token_buffer.go
@@ -98,8 +98,8 @@ func (tb *ConversationTokenBuffer) getNumTokensFromMessages(ctx context.Context)
 
 	bufferString, err := llms.GetBufferString(
 		messages,
-		tb.ConversationBuffer.HumanPrefix,
-		tb.ConversationBuffer.AIPrefix,
+		tb.HumanPrefix,
+		tb.AIPrefix,
 	)
 	if err != nil {
 		return 0, err

--- a/memory/window_buffer.go
+++ b/memory/window_buffer.go
@@ -76,12 +76,12 @@ func (wb *ConversationWindowBuffer) SaveContext(
 	if err != nil {
 		return err
 	}
-	messages, err := wb.ConversationBuffer.ChatHistory.Messages(ctx)
+	messages, err := wb.ChatHistory.Messages(ctx)
 	if err != nil {
 		return err
 	}
 	if messages, ok := wb.cutMessages(messages); ok {
-		err := wb.ConversationBuffer.ChatHistory.SetMessages(ctx, messages)
+		err := wb.ChatHistory.SetMessages(ctx, messages)
 		if err != nil {
 			return err
 		}

--- a/outputparser/boolean_parser.go
+++ b/outputparser/boolean_parser.go
@@ -2,11 +2,11 @@ package outputparser
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/schema"
-	"golang.org/x/exp/slices"
 )
 
 // BooleanParser is an output parser used to parse the output of an LLM as a boolean.

--- a/prompts/templates.go
+++ b/prompts/templates.go
@@ -3,6 +3,7 @@ package prompts
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/nikolalohinski/gonja"
 	"github.com/tmc/langchaingo/prompts/internal/fstring"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 // ErrInvalidTemplateFormat is the error when the template format is invalid and

--- a/vectorstores/chroma/chroma.go
+++ b/vectorstores/chroma/chroma.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	chromago "github.com/amikos-tech/chroma-go"
 	"github.com/amikos-tech/chroma-go/openai"
@@ -12,7 +13,6 @@ import (
 	"github.com/tmc/langchaingo/embeddings"
 	"github.com/tmc/langchaingo/schema"
 	"github.com/tmc/langchaingo/vectorstores"
-	"golang.org/x/exp/maps"
 )
 
 var (

--- a/vectorstores/mongovector/mongovector_test.go
+++ b/vectorstores/mongovector/mongovector_test.go
@@ -104,7 +104,7 @@ func setupTest(t *testing.T, dim int, index string) Store {
 		require.NoError(t, err)
 
 		uri = container.URI
-		os.Setenv(testURI, uri)
+		t.Setenv(testURI, uri)
 	}
 
 	require.NotEmpty(t, uri, "URI required")

--- a/vectorstores/weaviate/options.go
+++ b/vectorstores/weaviate/options.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 
 	"github.com/tmc/langchaingo/embeddings"
 	"github.com/weaviate/weaviate-go-client/v4/weaviate/auth"
-	"golang.org/x/exp/slices"
 )
 
 const (


### PR DESCRIPTION
- **chore: use slices and maps packages**
- **chore: skip embedded type**
- **chore: use fmt.Fprint instead**
- **chore: use switch**
- **chore: reorder imports**
- **chore: add white lines**
- **chore: use t.Setenv**
- **chore: excplicitly omit non used param**
- **chore: use t.TempDir**
- **chore: use maps package**
- **chore: migrate golangci-lint config file**
- **chore: bump golangci-lint action to v7**

It migrates golangci-lint to the recently released v2, which changed the config file format.

```shell
golangci-lint migrate -c .golangci.yaml --skip-validation
```

I just removed a few of the linters/formatters it applied because they were not applied before the migration and they complaint with more errors that I was not able to easily resolve:
- `forcetypeassert`
- `recvcheck`
- `gosmopolitan`

For that reason I'd prefer re-adding them in follow-up, smaller PRs if possible.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
