### PR TITLE
feat(chat): add StreamingSkipLines option to skip specific lines in streaming responses

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -78,6 +78,9 @@ type ChatRequest struct {
 
 	// Metadata allows you to specify additional information that will be passed to the model.
 	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// StreamingSkipLines is a list of lines to skip in the streaming response.
+	StreamingSkipLines []string `json:"streaming_skip_lines,omitempty"`
 }
 
 // ToolType is the type of a tool.
@@ -451,6 +454,21 @@ func parseStreamingChatResponse(ctx context.Context, r *http.Response, payload *
 			if data == "[DONE]" {
 				return
 			}
+
+			skiped := false
+			for _, skip := range payload.StreamingSkipLines {
+				if strings.EqualFold(skip, data) {
+					// Skip this line
+					skiped = true
+					break
+				}
+			}
+
+			if skiped {
+				println("skipped line:", data)
+				continue
+			}
+
 			var streamPayload StreamedChatResponsePayload
 			err := json.NewDecoder(bytes.NewReader([]byte(data))).Decode(&streamPayload)
 			if err != nil {

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -101,6 +101,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		Messages:               chatMsgs,
 		StreamingFunc:          opts.StreamingFunc,
 		StreamingReasoningFunc: opts.StreamingReasoningFunc,
+		StreamingSkipLines:     opts.StreamingSkipLines,
 		Temperature:            opts.Temperature,
 		N:                      opts.N,
 		FrequencyPenalty:       opts.FrequencyPenalty,

--- a/llms/options.go
+++ b/llms/options.go
@@ -21,6 +21,9 @@ type CallOptions struct {
 	// StreamingFunc is a function to be called for each chunk of a streaming response.
 	// Return an error to stop streaming early.
 	StreamingFunc func(ctx context.Context, chunk []byte) error `json:"-"`
+	// StreamingSkipLines is a list of lines to skip in a streaming response.
+	// This is useful for skipping lines that are not part of the generated text.
+	StreamingSkipLines []string `json:"streaming_skip_lines,omitempty"`
 	// StreamingReasoningFunc is a function to be called for each chunk of a streaming response.
 	// Return an error to stop streaming early.
 	StreamingReasoningFunc func(ctx context.Context, reasoningChunk, chunk []byte) error `json:"-"`
@@ -288,5 +291,11 @@ func WithMetadata(metadata map[string]interface{}) CallOption {
 func WithResponseMIMEType(responseMIMEType string) CallOption {
 	return func(o *CallOptions) {
 		o.ResponseMIMEType = responseMIMEType
+	}
+}
+
+func WithStreamingSkipLines(streamingSkipLines []string) CallOption {
+	return func(o *CallOptions) {
+		o.StreamingSkipLines = streamingSkipLines
 	}
 }


### PR DESCRIPTION
When parsing streaming responses, may not a result data, such as OpenRouter's `: OPENROUTER PROCESSING`, which needs to be ignored during JSON parsing.

Related issues:

- https://github.com/tmc/langchaingo/issues/1172
- https://github.com/tmc/langchaingo/issues/942

```go
package main

import (
	"context"
	"log"

	"github.com/tmc/langchaingo/llms"
	"github.com/tmc/langchaingo/llms/openai"
)

func main() {
	ctx := context.Background()
	options := []openai.Option{
		openai.WithModel("deepseek/deepseek-v3-base:free"),
		openai.WithBaseURL("https://openrouter.ai/api/v1"),
	}
	llm, err := openai.New(options...)
	if err != nil {
		log.Fatal(err)
	}
	prompt := "帮我给小朋友写一个关于春天故事，100字左右即可。"
	_, err = llms.GenerateFromSinglePrompt(ctx, llm, prompt, llms.WithStreamingFunc(func(ctx context.Context, chunk []byte) error {
		print(string(chunk))
		return nil
	}), llms.WithStreamingSkipLines([]string{
		": OPENROUTER PROCESSING",
	}))
	if err != nil {
		log.Fatal(err)
	}
}

```


### PR Checklist

- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
