### PR TITLE
feat: Support Reasoning in anthropic and openai requests.

### DIFF
--- a/llms/anthropic/internal/anthropicclient/anthropicclient.go
+++ b/llms/anthropic/internal/anthropicclient/anthropicclient.go
@@ -127,29 +127,33 @@ type MessageRequest struct {
 	Model       string        `json:"model"`
 	Messages    []ChatMessage `json:"messages"`
 	System      string        `json:"system,omitempty"`
-	Temperature float64       `json:"temperature"`
+	Temperature *float64      `json:"temperature,omitempty"`
 	MaxTokens   int           `json:"max_tokens,omitempty"`
-	TopP        float64       `json:"top_p,omitempty"`
+	TopP        *float64      `json:"top_p,omitempty"`
 	Tools       []Tool        `json:"tools,omitempty"`
 	StopWords   []string      `json:"stop_sequences,omitempty"`
 	Stream      bool          `json:"stream,omitempty"`
+	Thinking    *Thinking     `json:"thinking,omitempty"`
 
-	StreamingFunc func(ctx context.Context, chunk []byte) error `json:"-"`
+	StreamingFunc          func(ctx context.Context, chunk []byte) error                 `json:"-"`
+	StreamingReasoningFunc func(ctx context.Context, reasoningChunk, chunk []byte) error `json:"-"`
 }
 
 // CreateMessage creates message for the messages api.
 func (c *Client) CreateMessage(ctx context.Context, r *MessageRequest) (*MessageResponsePayload, error) {
 	resp, err := c.createMessage(ctx, &messagePayload{
-		Model:         r.Model,
-		Messages:      r.Messages,
-		System:        r.System,
-		Temperature:   r.Temperature,
-		MaxTokens:     r.MaxTokens,
-		StopWords:     r.StopWords,
-		TopP:          r.TopP,
-		Tools:         r.Tools,
-		Stream:        r.Stream,
-		StreamingFunc: r.StreamingFunc,
+		Model:                  r.Model,
+		Messages:               r.Messages,
+		System:                 r.System,
+		Temperature:            r.Temperature,
+		MaxTokens:              r.MaxTokens,
+		StopWords:              r.StopWords,
+		TopP:                   r.TopP,
+		Tools:                  r.Tools,
+		Stream:                 r.Stream,
+		StreamingFunc:          r.StreamingFunc,
+		StreamingReasoningFunc: r.StreamingReasoningFunc,
+		Thinking:               r.Thinking,
 	})
 	if err != nil {
 		return nil, err

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -31,8 +31,8 @@ type StreamOptions struct {
 type ChatRequest struct {
 	Model       string         `json:"model"`
 	Messages    []*ChatMessage `json:"messages"`
-	Temperature float64        `json:"temperature"`
-	TopP        float64        `json:"top_p,omitempty"`
+	Temperature *float64       `json:"temperature,omitempty"`
+	TopP        *float64       `json:"top_p,omitempty"`
 	// Deprecated: Use MaxCompletionTokens
 	MaxTokens           int      `json:"-,omitempty"`
 	MaxCompletionTokens int      `json:"max_completion_tokens,omitempty"`
@@ -78,6 +78,9 @@ type ChatRequest struct {
 
 	// Metadata allows you to specify additional information that will be passed to the model.
 	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// ReasoningEffort constrains effort on reasoning for reasoning models
+	ReasoningEffort llms.ReasoningLevel `json:"reasoning_effort,omitempty"`
 }
 
 // ToolType is the type of a tool.

--- a/llms/openai/internal/openaiclient/completions.go
+++ b/llms/openai/internal/openaiclient/completions.go
@@ -2,22 +2,26 @@ package openaiclient
 
 import (
 	"context"
+
+	"github.com/tmc/langchaingo/llms"
 )
 
 // CompletionRequest is a request to complete a completion.
 type CompletionRequest struct {
-	Model       string  `json:"model"`
-	Prompt      string  `json:"prompt"`
-	Temperature float64 `json:"temperature"`
+	Model       string   `json:"model"`
+	Prompt      string   `json:"prompt"`
+	Temperature *float64 `json:"temperature,omitempty"`
 	// Deprecated: Use MaxCompletionTokens
 	MaxTokens           int      `json:"-,omitempty"`
 	MaxCompletionTokens int      `json:"max_completion_tokens,omitempty"`
 	N                   int      `json:"n,omitempty"`
 	FrequencyPenalty    float64  `json:"frequency_penalty,omitempty"`
 	PresencePenalty     float64  `json:"presence_penalty,omitempty"`
-	TopP                float64  `json:"top_p,omitempty"`
+	TopP                *float64 `json:"top_p,omitempty"`
 	StopWords           []string `json:"stop,omitempty"`
 	Seed                int      `json:"seed,omitempty"`
+
+	ReasoningEffort llms.ReasoningLevel `json:"reasoning_effort,omitempty"`
 
 	// StreamingFunc is a function to be called for each chunk of a streaming response.
 	// Return an error to stop streaming early.
@@ -89,5 +93,6 @@ func (c *Client) createCompletion(ctx context.Context, payload *CompletionReques
 		PresencePenalty:     payload.PresencePenalty,
 		StreamingFunc:       payload.StreamingFunc,
 		Seed:                payload.Seed,
+		ReasoningEffort:     payload.ReasoningEffort,
 	})
 }

--- a/llms/options.go
+++ b/llms/options.go
@@ -69,7 +69,37 @@ type CallOptions struct {
 	// Supported MIME types are: text/plain: (default) Text output.
 	// application/json: JSON response in the response candidates.
 	ResponseMIMEType string `json:"response_mime_type,omitempty"`
+
+	// Reasoning constrains effort on reasoning for reasoning models
+	Reasoning *Reasoning `json:"reasoning,omitempty"`
 }
+
+type Reasoning struct {
+	IsEnabled bool           `json:"is_enabled"`
+	Mode      ReasoningMode  `json:"mode,omitempty"`
+	Level     ReasoningLevel `json:"level,omitempty"`
+	Tokens    int            `json:"tokens,omitempty"`
+}
+
+// ReasoningMode is the reasoning mode supported by the model.
+// OpenAI APIs support levels based reasoning, i.e "low", "medium", "high".
+// Anthropic supports allocating budget tokens (>1024) for reasoning.
+type ReasoningMode string
+
+const (
+	ReasoningModeLevel  ReasoningMode = "level"
+	ReasoningModeTokens ReasoningMode = "tokens"
+)
+
+// ReasoningLevel is the reasoning level to use for the model.
+// Defaults to "medium".
+type ReasoningLevel string
+
+const (
+	ReasoningLevelLow    ReasoningLevel = "low"
+	ReasoningLevelMedium ReasoningLevel = "medium"
+	ReasoningLevelHigh   ReasoningLevel = "high"
+)
 
 // Tool is a tool that can be used by the model.
 type Tool struct {
@@ -288,5 +318,12 @@ func WithMetadata(metadata map[string]interface{}) CallOption {
 func WithResponseMIMEType(responseMIMEType string) CallOption {
 	return func(o *CallOptions) {
 		o.ResponseMIMEType = responseMIMEType
+	}
+}
+
+// WithReasoning sets the reasoning object for the model, if it supports it.
+func WithReasoning(reasoning Reasoning) CallOption {
+	return func(o *CallOptions) {
+		o.Reasoning = &reasoning
 	}
 }


### PR DESCRIPTION
    - Add Reasoning type that can be used by all LLMs to support reasoning. Add relevant flavors of reasoning types.
    - Support Hybrid budget token based reasoning in anthropic.
    - Support thinking content with and without streaming in anthropic.
    - Support level based reasoning request in openai
    - Need to make Temperature and TopP optional in internal structs in anthropic and openai.