### PR TITLE
llms/openai: replace deprecated gpt-4-vision-preview with gpt-4o in TestMultiContentImage

### DIFF
--- a/llms/openai/multicontent_test.go
+++ b/llms/openai/multicontent_test.go
@@ -77,7 +77,7 @@ func TestMultiContentTextChatSequence(t *testing.T) {
 func TestMultiContentImage(t *testing.T) {
 	t.Parallel()
 
-	llm := newTestClient(t, WithModel("gpt-4-vision-preview"))
+	llm := newTestClient(t, WithModel("gpt-4o"))
 
 	parts := []llms.ContentPart{
 		llms.ImageURLPart("https://github.com/tmc/langchaingo/blob/main/docs/static/img/parrot-icon.png?raw=true"),


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

---
When running `multicontent_test.go` under `llms/openai` got error:

`API returned unexpected status code: 404: The model gpt-4-vision-preview has been deprecated, learn more here: https://platform.openai.com/docs/deprecations`

Follow the deprecations guide link above :

<img width="735" alt="image" src="https://github.com/user-attachments/assets/399685cb-b9c2-40c6-98e3-6f3c245b548a" />


Thus, I changed: `gpt-4-vision-preview` -> `gpt-4o` in the `multicontent_test.go`

