### PR TITLE
openai: add option to filter streaming chunks

### DIFF
--- a/llms/openai/internal/openaiclient/chat_test.go
+++ b/llms/openai/internal/openaiclient/chat_test.go
@@ -26,7 +26,8 @@ func TestParseStreamingChatResponse_FinishReason(t *testing.T) {
 		},
 	}
 
-	resp, err := parseStreamingChatResponse(context.Background(), r, req)
+	testClient := &Client{}
+	resp, err := testClient.parseStreamingChatResponse(context.Background(), r, req)
 
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
@@ -47,7 +48,8 @@ func TestParseStreamingChatResponse_ReasoningContent(t *testing.T) {
 		},
 	}
 
-	resp, err := parseStreamingChatResponse(context.Background(), r, req)
+	testClient := &Client{}
+	resp, err := testClient.parseStreamingChatResponse(context.Background(), r, req)
 
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
@@ -74,7 +76,8 @@ data: {"id":"fa7e4fc5-a05d-4e7b-9a66-a2dd89e91a4e","object":"chat.completion.chu
 		},
 	}
 
-	resp, err := parseStreamingChatResponse(context.Background(), r, req)
+	testClient := &Client{}
+	resp, err := testClient.parseStreamingChatResponse(context.Background(), r, req)
 
 	require.NoError(t, err)
 	assert.NotNil(t, resp)

--- a/llms/openai/internal/openaiclient/openaiclient.go
+++ b/llms/openai/internal/openaiclient/openaiclient.go
@@ -24,6 +24,9 @@ const (
 	APITypeAzureAD APIType = "AZURE_AD"
 )
 
+// StreamingChunkFilter is a function which decides if a chunk of a streaming response should be distributed via StreamingFunc.
+type StreamingChunkFilter func(payload StreamedChatResponsePayload) bool
+
 // Client is a client for the OpenAI API.
 type Client struct {
 	token        string
@@ -38,6 +41,8 @@ type Client struct {
 	apiVersion string
 
 	ResponseFormat *ResponseFormat
+
+	streamingChunkFilter StreamingChunkFilter
 }
 
 // Option is an option for the OpenAI client.
@@ -51,19 +56,20 @@ type Doer interface {
 // New returns a new OpenAI client.
 func New(token string, model string, baseURL string, organization string,
 	apiType APIType, apiVersion string, httpClient Doer, embeddingModel string,
-	responseFormat *ResponseFormat,
+	responseFormat *ResponseFormat, scFilter StreamingChunkFilter,
 	opts ...Option,
 ) (*Client, error) {
 	c := &Client{
-		token:          token,
-		Model:          model,
-		EmbeddingModel: embeddingModel,
-		baseURL:        strings.TrimSuffix(baseURL, "/"),
-		organization:   organization,
-		apiType:        apiType,
-		apiVersion:     apiVersion,
-		httpClient:     httpClient,
-		ResponseFormat: responseFormat,
+		token:                token,
+		Model:                model,
+		EmbeddingModel:       embeddingModel,
+		baseURL:              strings.TrimSuffix(baseURL, "/"),
+		organization:         organization,
+		apiType:              apiType,
+		apiVersion:           apiVersion,
+		httpClient:           httpClient,
+		ResponseFormat:       responseFormat,
+		streamingChunkFilter: scFilter,
 	}
 	if c.baseURL == "" {
 		c.baseURL = defaultBaseURL

--- a/llms/openai/llm.go
+++ b/llms/openai/llm.go
@@ -49,7 +49,7 @@ func newClient(opts ...Option) (*options, *openaiclient.Client, error) {
 
 	cli, err := openaiclient.New(options.token, options.model, options.baseURL, options.organization,
 		openaiclient.APIType(options.apiType), options.apiVersion, options.httpClient, options.embeddingModel,
-		options.responseFormat,
+		options.responseFormat, options.streamingChunkFilter,
 	)
 	return options, cli, err
 }

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -16,6 +16,17 @@ type LLM struct {
 	client           *openaiclient.Client
 }
 
+// StreamingChunkFilter is a function which decides if a chunk of a streaming response should be distributed via StreamingFunc.
+type StreamingChunkFilter func(chunkMeta StreamingChunkMetaData) bool
+
+type StreamingChunkMetaData struct {
+	// IsFunctionCall is true if the chunk is part of a function call.
+	IsFunctionCall bool
+
+	// IsToolCall is true if the chunk is part of any tool call.
+	IsToolCall bool
+}
+
 const (
 	RoleSystem    = "system"
 	RoleAssistant = "assistant"


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

---
Currently it is impossible to check the "type" of a streaming-chunk. So that the `StreamingFunc` will be called when the OpenAI-LLM responses with Text-Content **and** with Function/Tool-Call-Content. The StreamingFunc has only one argument for the chunk-content itself. But no meta-information about the chunk/context.

I looked into the code and decided to add a new LLM-Specific Option, where you can define a function which will check if the chunks of the current stream-response will be forwarded. Because of backwards compatibility, I decided against adding additional arguments in the `StreamingFunc`. Also i decided against another "advanced" streaming function in the "main interface" to avoid extending all other LLM implementations than OpenAI.

Furthermore I used an struct as argument, instead of the "plain" boolean values. I think this mechanism is more robust against possible future extensions (such as adding more information than the two boolean values).

In this PullRequest will also tackle the following issues:
* [#1031 - OpenAI Streaming response parser will stream function call args to output](https://github.com/tmc/langchaingo/issues/1031)
* [#855 - Can I customize the streamingfunc function?](https://github.com/tmc/langchaingo/issues/855) (at least for OpenAI)