### PR TITLE
openai: add user and parallel tool calls fields to chat completions request

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -78,6 +78,12 @@ type ChatRequest struct {
 
 	// Metadata allows you to specify additional information that will be passed to the model.
 	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+	User string `json:"user,omitempty"`
+
+	// Whether to enable parallel function calling during tool use.
+	ParallelToolCalls bool `json:"parallel_tool_calls,omitempty"`
 }
 
 // ToolType is the type of a tool.

--- a/llms/openai/internal/openaiclient/openaiclient.go
+++ b/llms/openai/internal/openaiclient/openaiclient.go
@@ -38,6 +38,9 @@ type Client struct {
 	apiVersion string
 
 	ResponseFormat *ResponseFormat
+
+	User              string
+	ParallelToolCalls bool
 }
 
 // Option is an option for the OpenAI client.
@@ -51,19 +54,21 @@ type Doer interface {
 // New returns a new OpenAI client.
 func New(token string, model string, baseURL string, organization string,
 	apiType APIType, apiVersion string, httpClient Doer, embeddingModel string,
-	responseFormat *ResponseFormat,
+	responseFormat *ResponseFormat, user string, parallelToolCalls bool,
 	opts ...Option,
 ) (*Client, error) {
 	c := &Client{
-		token:          token,
-		Model:          model,
-		EmbeddingModel: embeddingModel,
-		baseURL:        strings.TrimSuffix(baseURL, "/"),
-		organization:   organization,
-		apiType:        apiType,
-		apiVersion:     apiVersion,
-		httpClient:     httpClient,
-		ResponseFormat: responseFormat,
+		token:             token,
+		Model:             model,
+		EmbeddingModel:    embeddingModel,
+		baseURL:           strings.TrimSuffix(baseURL, "/"),
+		organization:      organization,
+		apiType:           apiType,
+		apiVersion:        apiVersion,
+		httpClient:        httpClient,
+		ResponseFormat:    responseFormat,
+		User:              user,
+		ParallelToolCalls: parallelToolCalls,
 	}
 	if c.baseURL == "" {
 		c.baseURL = defaultBaseURL

--- a/llms/openai/llm.go
+++ b/llms/openai/llm.go
@@ -49,7 +49,7 @@ func newClient(opts ...Option) (*options, *openaiclient.Client, error) {
 
 	cli, err := openaiclient.New(options.token, options.model, options.baseURL, options.organization,
 		openaiclient.APIType(options.apiType), options.apiVersion, options.httpClient, options.embeddingModel,
-		options.responseFormat,
+		options.responseFormat, options.user, options.parallelToolCalls,
 	)
 	return options, cli, err
 }

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -112,6 +112,8 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		FunctionCallBehavior: openaiclient.FunctionCallBehavior(opts.FunctionCallBehavior),
 		Seed:                 opts.Seed,
 		Metadata:             opts.Metadata,
+		User:                 o.client.User,
+		ParallelToolCalls:    o.client.ParallelToolCalls,
 	}
 	if opts.JSONMode {
 		req.ResponseFormat = ResponseFormatJSON

--- a/llms/openai/openaillm_option.go
+++ b/llms/openai/openaillm_option.go
@@ -40,6 +40,9 @@ type options struct {
 	embeddingModel string
 
 	callbackHandler callbacks.Handler
+
+	user              string
+	parallelToolCalls bool
 }
 
 // Option is a functional option for the OpenAI client.
@@ -133,5 +136,19 @@ func WithCallback(callbackHandler callbacks.Handler) Option {
 func WithResponseFormat(responseFormat *ResponseFormat) Option {
 	return func(opts *options) {
 		opts.responseFormat = responseFormat
+	}
+}
+
+// WithUser allows setting a unique user identifier for the request.
+func WithUser(user string) Option {
+	return func(opts *options) {
+		opts.user = user
+	}
+}
+
+// WithParallelToolCalls allows enabling function calling during tool use.
+func WithParallelToolCalls(parallelToolCalls bool) Option {
+	return func(opts *options) {
+		opts.parallelToolCalls = parallelToolCalls
 	}
 }


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
---

The OpenAI LLM currently doesn't support two options:
- user
- parallel_tool_calls

The user field allows the consumer to send a unique identifier so OpenAI can track abuse.
The parallel_tool_calls allows the consumer to enable the execution of function calls in parallel when using a tool.

User seems to be very specific to OpenAI, so it makes sense to be in the LLM implementation and not a general setting.
Parallel tool calls are supported by more models, but after looking at the javascript langchain implementation, they also added a specific setting to the OpenAI LLM only.