### PR TITLE
llms: add GitHub Models API integration

### DIFF
--- a/docs/docs/modules/model_io/models/llms/Integrations/githubmodels.mdx
+++ b/docs/docs/modules/model_io/models/llms/Integrations/githubmodels.mdx
@@ -1,0 +1,70 @@
+---
+sidebar_label: GitHub Models
+---
+
+import CodeBlock from "@theme/CodeBlock";
+import ExampleGitHubModels from "@examples/githubmodels-example/githubmodels_example.go";
+
+# GitHub Models
+
+GitHub Models offers access to various powerful language models like GPT-4.1, Claude 3, and Mistral through GitHub's Models API.
+
+This example shows how to use LangChain to interact with GitHub Models.
+
+## Authentication
+
+There are two ways to set the GitHub token for authentication:
+
+1. Set the environment variable `GITHUB_TOKEN` with your GitHub token:
+
+```bash
+# For Linux/macOS
+export GITHUB_TOKEN=your_github_token_here
+
+# For Windows PowerShell
+$env:GITHUB_TOKEN = "your_github_token_here"
+```
+
+2. Or provide it when initializing the client:
+
+```go
+llm, err := githubmodels.New(githubmodels.WithToken("your_github_token"))
+```
+
+## Available Models
+
+GitHub Models provides access to several models including:
+
+- `openai/gpt-4.1` (default)
+- `anthropic/claude-3-sonnet`
+- `anthropic/claude-3-haiku`
+- `mistral/mistral-large`
+- `mistral/mistral-small`
+
+You can specify the model to use:
+
+```go
+llm, err := githubmodels.New(githubmodels.WithModel("anthropic/claude-3-sonnet"))
+```
+
+## Callbacks
+
+GitHub Models integration supports callbacks, which can be useful for logging, monitoring, or other integrations:
+
+```go
+// Create a simple logger callback
+logger := callbacks.NewLogHandler()
+
+// Initialize the model with the callback
+llm, err := githubmodels.New(
+    githubmodels.WithCallbacksHandler(logger),
+)
+```
+
+## Example
+
+<CodeBlock language="go">{ExampleGitHubModels}</CodeBlock>
+
+## API Reference
+
+For more details on the GitHub Models API, see the [GitHub Models documentation](https://docs.github.com/en/github-models).

--- a/docs/docs/modules/model_io/models/llms/index.mdx
+++ b/docs/docs/modules/model_io/models/llms/index.mdx
@@ -22,7 +22,7 @@ type LLM interface {
 	Generate(ctx context.Context, prompts []string, options ...CallOption) ([]*Generation, error)
 }
 ```
-As you can see LLMs expose two main methods. The Call metod takes a prompt and returns a completion and an evetuall error.
+As you can see LLMs expose two main methods. The Call method takes a prompt and returns a completion and an eventual error.
 With the generate method you can take multiple prompts and get a generation for each of the prompts.
 
 ```go

--- a/examples/githubmodels-example/README.md
+++ b/examples/githubmodels-example/README.md
@@ -1,0 +1,92 @@
+# GitHub Models Example
+
+This example demonstrates how to use the GitHub Models API with LangChain Go library. The example shows both simple prompt completion and chat-based interactions with the GitHub Models API.
+
+## What This Example Does
+
+1. **Sets up a GitHub Models LLM**: 
+   - Initializes the GitHub Models LLM client with your GitHub token.
+   - Configures the model to use (default is "openai/gpt-4.1").
+
+2. **Performs a Simple Query**:
+   - Sends a basic prompt asking about the capital of France.
+   - Prints the response from the model.
+
+3. **Performs a Chat Completion**:
+   - Creates a conversation with system and user messages.
+   - Sends the conversation to the GitHub Models API.
+   - Prints the assistant's response.
+
+## Prerequisites
+
+- A GitHub token with appropriate permissions to access the GitHub Models API.
+- Go installed on your system.
+
+## Running the Example
+
+1. Set your GitHub token as an environment variable:
+
+```bash
+# For Linux/macOS
+export GITHUB_TOKEN=your_github_token_here
+
+# For Windows PowerShell
+$env:GITHUB_TOKEN = "your_github_token_here"
+```
+
+2. Run the example:
+
+```bash
+go run githubmodels_example.go
+```
+
+## Available Models
+
+GitHub Models supports various models, including:
+
+- openai/gpt-4.1
+- anthropic/claude-3-sonnet
+- anthropic/claude-3-haiku
+- mistral/mistral-large
+- mistral/mistral-small
+
+You can specify the model to use with the `WithModel` option when creating the LLM client.
+
+## API Reference
+
+For more details on the GitHub Models API, see the [GitHub Models documentation](https://docs.github.com/en/models).
+
+## Code Implementation
+
+To see the full implementation, check the `githubmodels_example.go` file in this directory.
+
+The example demonstrates:
+- How to initialize the GitHub Models client
+- How to send a simple text prompt
+- How to create and send a multi-message chat conversation
+- How to handle the responses
+
+## Further Reading
+
+For more information on how to use the GitHub Models integration with LangChain Go, see the [GitHub Models documentation](https://tmc.github.io/langchaingo/docs/modules/model_io/models/llms/Integrations/githubmodels) in the LangChain Go documentation site.
+
+The GitHub Models API documentation can be found at [GitHub Models documentation](https://docs.github.com/en/github-models).
+
+## Using GitHub Models in Your Own Projects
+
+To use GitHub Models in your own projects, you need to:
+
+1. Import the GitHub Models package:
+```go
+import "github.com/tmc/langchaingo/llms/githubmodels"
+```
+
+2. Create a new GitHub Models LLM client:
+```go
+llm, err := githubmodels.New(
+    githubmodels.WithToken("your_github_token"),
+    githubmodels.WithModel("openai/gpt-4.1"),
+)
+```
+
+3. Use the LLM for text generation or chat completion as shown in the example.

--- a/examples/githubmodels-example/githubmodels_example.go
+++ b/examples/githubmodels-example/githubmodels_example.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/githubmodels"
+)
+
+func main() {
+	// Check if GitHub token is set
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		log.Fatal("GITHUB_TOKEN environment variable is not set")
+	}
+
+	// Create a new GitHub Models LLM
+	llm, err := githubmodels.New(
+		githubmodels.WithToken(token),
+		githubmodels.WithModel("openai/gpt-4.1"), // Can be changed to any model available in GitHub Models
+	)
+	if err != nil {
+		log.Fatalf("Failed to create GitHub Models LLM: %v", err)
+	}
+
+	// Create context
+	ctx := context.Background()
+
+	// Simple query
+	prompt := "What is the capital of France?"
+	response, err := llms.GenerateFromSinglePrompt(ctx, llm, prompt)
+	if err != nil {
+		log.Fatalf("Failed to generate completion: %v", err)
+	}
+
+	fmt.Printf("Prompt: %s\n\nResponse: %s\n", prompt, response)
+
+	// Chat completion example
+	messages := []llms.MessageContent{
+		{
+			Role: llms.ChatMessageTypeSystem,
+			Parts: []llms.ContentPart{
+				llms.TextContent{Text: "You are a helpful assistant."},
+			},
+		},
+		{
+			Role: llms.ChatMessageTypeHuman,
+			Parts: []llms.ContentPart{
+				llms.TextContent{Text: "Tell me about the solar system."},
+			},
+		},
+	}
+
+	chatResponse, err := llm.GenerateContent(ctx, messages)
+	if err != nil {
+		log.Fatalf("Failed to generate chat completion: %v", err)
+	}
+
+	if len(chatResponse.Choices) > 0 {
+		fmt.Printf("\nChat Response: %s\n", chatResponse.Choices[0].Content)
+	}
+}

--- a/llms/githubmodels/README.md
+++ b/llms/githubmodels/README.md
@@ -1,0 +1,100 @@
+# GitHub Models LLM Integration for LangChain Go
+
+This package provides integration with GitHub Models API for LangChain Go, allowing you to use various LLMs available through GitHub's Models API.
+
+## Installation
+
+```bash
+go get github.com/tmc/langchaingo
+```
+
+## Usage
+
+### Basic Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/githubmodels"
+)
+
+func main() {
+	// The GITHUB_TOKEN environment variable will be used automatically if not provided
+	llm, err := githubmodels.New()
+	if err != nil {
+		log.Fatalf("Failed to create GitHub Models client: %v", err)
+	}
+
+	ctx := context.Background()
+	result, err := llms.GenerateFromSinglePrompt(ctx, llm, "What is the capital of France?")
+	if err != nil {
+		log.Fatalf("Error generating text: %v", err)
+	}
+
+	fmt.Println(result)
+}
+```
+
+### Configuration Options
+
+You can configure the GitHub Models client with various options:
+
+```go
+llm, err := githubmodels.New(
+    githubmodels.WithToken("your-github-token"), // Explicitly set token instead of using env var
+    githubmodels.WithModel("anthropic/claude-3-sonnet"), // Choose a different model
+    githubmodels.WithHTTPClient(customClient), // Use a custom HTTP client
+    githubmodels.WithCallbacksHandler(myCallbacksHandler), // Add callbacks
+)
+```
+
+### Available Models
+
+GitHub Models provides access to various models including:
+
+- `openai/gpt-4.1` (default)
+- `anthropic/claude-3-sonnet`
+- `anthropic/claude-3-haiku`
+- `mistral/mistral-large`
+- `mistral/mistral-small`
+
+For the latest list of available models, refer to the GitHub documentation.
+
+### Chat Completion
+
+For a more complex conversation with multiple messages:
+
+```go
+messages := []llms.MessageContent{
+    {
+        Role: llms.ChatMessageTypeSystem,
+        Parts: []llms.ContentPart{
+            llms.TextContent{Text: "You are a helpful assistant."},
+        },
+    },
+    {
+        Role: llms.ChatMessageTypeHuman,
+        Parts: []llms.ContentPart{
+            llms.TextContent{Text: "What is the capital of France?"},
+        },
+    },
+}
+
+response, err := llm.GenerateContent(ctx, messages)
+if err != nil {
+    log.Fatalf("Error generating chat completion: %v", err)
+}
+
+fmt.Println(response.Choices[0].Content)
+```
+
+## Authentication
+
+You'll need a GitHub token with the appropriate permissions to access the GitHub Models API. You can set this token as the `GITHUB_TOKEN` environment variable or provide it directly using the `WithToken` option.

--- a/llms/githubmodels/githubmodelsllm.go
+++ b/llms/githubmodels/githubmodelsllm.go
@@ -11,6 +11,14 @@ import (
 	"github.com/tmc/langchaingo/llms/githubmodels/internal/githubmodelsclient"
 )
 
+const (
+	roleSystem    = "system"
+	roleAssistant = "assistant"
+	roleUser      = "user"
+	roleFunction  = "function"
+	roleTool      = "tool"
+)
+
 var (
 	ErrEmptyResponse = errors.New("no response")
 	ErrMissingToken  = errors.New("missing token")
@@ -33,7 +41,7 @@ func New(opts ...Option) (*LLM, error) {
 		model:      defaultModel,
 		httpClient: http.DefaultClient,
 	}
-	
+
 	// Apply all options
 	for _, opt := range opts {
 		opt(&o)
@@ -126,26 +134,26 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 // CreateEmbedding creates embeddings for the given input texts.
 // Note: As of this implementation, GitHub Models may not support embeddings.
 // This is a placeholder implementation to satisfy the interface.
-func (o *LLM) CreateEmbedding(ctx context.Context, inputTexts []string) ([][]float32, error) {
+func (o *LLM) CreateEmbedding(_ context.Context, _ []string) ([][]float32, error) {
 	return nil, errors.New("embedding is not supported by GitHub Models at this time")
 }
 
-// typeToRole converts llms.ChatMessageType to GitHub Models role string
+// typeToRole converts llms.ChatMessageType to GitHub Models role string.
 func typeToRole(typ llms.ChatMessageType) string {
 	switch typ {
 	case llms.ChatMessageTypeSystem:
-		return "system"
+		return roleSystem
 	case llms.ChatMessageTypeAI:
-		return "assistant"
+		return roleAssistant
 	case llms.ChatMessageTypeHuman:
-		return "user"
+		return roleUser
 	case llms.ChatMessageTypeGeneric:
-		return "user"
+		return roleUser
 	case llms.ChatMessageTypeFunction:
-		return "function"
+		return roleFunction
 	case llms.ChatMessageTypeTool:
-		return "tool"
+		return roleTool
 	default:
-		return "user"
+		return roleUser
 	}
 }

--- a/llms/githubmodels/githubmodelsllm.go
+++ b/llms/githubmodels/githubmodelsllm.go
@@ -73,15 +73,15 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 	if opts.Model != "" {
 		model = opts.Model
 	}
-
 	// Convert messages to GitHub Models format
 	chatMsgs := make([]githubmodelsclient.Message, 0, len(messages))
-	for _, mc := range messages {		var contentText string
+	for _, mc := range messages {
+		var contentText string
 		for _, part := range mc.Parts {
 			if textContent, ok := part.(llms.TextContent); ok {
-				contentText = textContent.Text
-				break
+				contentText += textContent.Text // Concatenate all text parts
 			}
+			// Silently ignore non-text parts as GitHub Models API only supports text
 		}
 
 		chatMsgs = append(chatMsgs, githubmodelsclient.Message{

--- a/llms/githubmodels/githubmodelsllm.go
+++ b/llms/githubmodels/githubmodelsllm.go
@@ -1,0 +1,151 @@
+package githubmodels
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+
+	"github.com/tmc/langchaingo/callbacks"
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/githubmodels/internal/githubmodelsclient"
+)
+
+var (
+	ErrEmptyResponse = errors.New("no response")
+	ErrMissingToken  = errors.New("missing token")
+)
+
+// LLM is a GitHub Models LLM implementation.
+type LLM struct {
+	CallbacksHandler callbacks.Handler
+	client           *githubmodelsclient.Client
+	options          options
+}
+
+var _ llms.Model = (*LLM)(nil)
+
+// New creates a new GitHub Models LLM implementation.
+func New(opts ...Option) (*LLM, error) {
+	// Initialize options with defaults and environment variables
+	o := options{
+		token:      os.Getenv(tokenEnvVarName),
+		model:      defaultModel,
+		httpClient: http.DefaultClient,
+	}
+	
+	// Apply all options
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	// Validate token
+	if o.token == "" {
+		return nil, ErrMissingToken
+	}
+
+	client, err := githubmodelsclient.NewClient(o.token, o.model, o.httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LLM{client: client, options: o, CallbacksHandler: o.callbacksHandler}, nil
+}
+
+// Call implements the call interface for LLM.
+func (o *LLM) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
+	return llms.GenerateFromSinglePrompt(ctx, o, prompt, options...)
+}
+
+// GenerateContent implements the Model interface.
+func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
+	if o.CallbacksHandler != nil {
+		o.CallbacksHandler.HandleLLMGenerateContentStart(ctx, messages)
+	}
+
+	opts := llms.CallOptions{}
+	for _, opt := range options {
+		opt(&opts)
+	}
+
+	// Override LLM model if set as llms.CallOption
+	model := o.options.model
+	if opts.Model != "" {
+		model = opts.Model
+	}
+
+	// Convert messages to GitHub Models format
+	chatMsgs := make([]githubmodelsclient.Message, 0, len(messages))
+	for _, mc := range messages {		var contentText string
+		for _, part := range mc.Parts {
+			if textContent, ok := part.(llms.TextContent); ok {
+				contentText = textContent.Text
+				break
+			}
+		}
+
+		chatMsgs = append(chatMsgs, githubmodelsclient.Message{
+			Role:    typeToRole(mc.Role),
+			Content: contentText,
+		})
+	}
+	// Create chat request with options
+	req := &githubmodelsclient.ChatRequest{
+		Model:       model,
+		Messages:    chatMsgs,
+		Temperature: opts.Temperature,
+		MaxTokens:   opts.MaxTokens,
+		TopP:        opts.TopP,
+	}
+
+	// Call the client
+	resp, err := o.client.CreateChat(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Process response
+	if len(resp.Choices) == 0 {
+		return nil, ErrEmptyResponse
+	}
+
+	choices := make([]*llms.ContentChoice, len(resp.Choices))
+	for i, c := range resp.Choices {
+		choices[i] = &llms.ContentChoice{
+			Content:    c.Message.Content,
+			StopReason: c.FinishReason,
+		}
+	}
+	response := &llms.ContentResponse{Choices: choices}
+	if o.CallbacksHandler != nil {
+		o.CallbacksHandler.HandleLLMGenerateContentEnd(ctx, response)
+	}
+	return response, nil
+}
+
+// CreateEmbedding creates embeddings for the given input texts.
+// Note: As of this implementation, GitHub Models may not support embeddings.
+// This is a placeholder implementation to satisfy the interface.
+func (o *LLM) CreateEmbedding(ctx context.Context, inputTexts []string) ([][]float32, error) {
+	return nil, errors.New("embedding is not supported by GitHub Models at this time")
+}
+
+// typeToRole converts llms.ChatMessageType to GitHub Models role string
+func typeToRole(typ llms.ChatMessageType) string {
+	switch typ {
+	case llms.ChatMessageTypeSystem:
+		return "system"
+	case llms.ChatMessageTypeAI:
+		return "assistant"
+	case llms.ChatMessageTypeHuman:
+		return "user"
+	case llms.ChatMessageTypeGeneric:
+		return "user"
+	case llms.ChatMessageTypeFunction:
+		return "function"
+	case llms.ChatMessageTypeTool:
+		return "tool"
+	default:
+		return "user"
+	}
+}

--- a/llms/githubmodels/githubmodelsllm_option.go
+++ b/llms/githubmodels/githubmodelsllm_option.go
@@ -1,0 +1,65 @@
+package githubmodels
+
+import (
+	"net/http"
+
+	"github.com/tmc/langchaingo/callbacks"
+)
+
+const (
+	// tokenEnvVarName is the environment variable name for the GitHub token.
+	tokenEnvVarName = "GITHUB_TOKEN"
+	// defaultModel is the default GitHub model to use.
+	defaultModel = "openai/gpt-4.1"
+)
+
+// Available GitHub Models (as of May 2025):
+// - openai/gpt-4.1 - OpenAI's GPT-4.1 model
+// - anthropic/claude-3-sonnet - Anthropic's Claude 3 Sonnet model
+// - anthropic/claude-3-haiku - Anthropic's Claude 3 Haiku model
+// - mistral/mistral-large - Mistral's Large model
+// - mistral/mistral-small - Mistral's Small model
+// 
+// Note: Available models may change over time. Check GitHub documentation for the latest information.
+
+// options contains options for the GitHub Models client.
+type options struct {
+	token           string
+	model           string
+	httpClient      *http.Client
+	callbacksHandler callbacks.Handler
+}
+
+// Option is a function that configures the GitHub Models client.
+type Option func(*options)
+
+// WithToken sets the GitHub token for the client.
+// If not set, then will be used the GITHUB_TOKEN environment variable.
+func WithToken(token string) Option {
+	return func(o *options) {
+		o.token = token
+	}
+}
+
+// WithModel sets the model to use.
+// Default is "openai/gpt-4.1".
+func WithModel(model string) Option {
+	return func(o *options) {
+		o.model = model
+	}
+}
+
+// WithHTTPClient sets the HTTP client to use.
+// Default is http.DefaultClient.
+func WithHTTPClient(client *http.Client) Option {
+	return func(o *options) {
+		o.httpClient = client
+	}
+}
+
+// WithCallbacksHandler sets the callbacks handler.
+func WithCallbacksHandler(handler callbacks.Handler) Option {
+	return func(o *options) {
+		o.callbacksHandler = handler
+	}
+}

--- a/llms/githubmodels/githubmodelsllm_option.go
+++ b/llms/githubmodels/githubmodelsllm_option.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// tokenEnvVarName is the environment variable name for the GitHub token.
-	tokenEnvVarName = "GITHUB_TOKEN"
+	tokenEnvVarName = "GITHUB_TOKEN" // #nosec G101
 	// defaultModel is the default GitHub model to use.
 	defaultModel = "openai/gpt-4.1"
 )
@@ -19,14 +19,14 @@ const (
 // - anthropic/claude-3-haiku - Anthropic's Claude 3 Haiku model
 // - mistral/mistral-large - Mistral's Large model
 // - mistral/mistral-small - Mistral's Small model
-// 
+//
 // Note: Available models may change over time. Check GitHub documentation for the latest information.
 
 // options contains options for the GitHub Models client.
 type options struct {
-	token           string
-	model           string
-	httpClient      *http.Client
+	token            string
+	model            string
+	httpClient       *http.Client
 	callbacksHandler callbacks.Handler
 }
 

--- a/llms/githubmodels/githubmodelsllm_test.go
+++ b/llms/githubmodels/githubmodelsllm_test.go
@@ -19,11 +19,15 @@ func skipIfNoGitHubToken(t *testing.T) string {
 	return token
 }
 
+// TestNew tests the New function.
+// nolint:tparallel
 func TestNew(t *testing.T) {
+	// Cannot use t.Parallel() here because TestNew/with_token_from_env uses t.Setenv()
+
 	t.Run("with token from env", func(t *testing.T) {
+		// Cannot use t.Parallel() with t.Setenv()
 		token := skipIfNoGitHubToken(t)
-		os.Setenv(tokenEnvVarName, token)
-		defer os.Unsetenv(tokenEnvVarName)
+		t.Setenv(tokenEnvVarName, token)
 
 		llm, err := New()
 		require.NoError(t, err)
@@ -31,13 +35,15 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("with explicit token", func(t *testing.T) {
+		t.Parallel()
 		token := skipIfNoGitHubToken(t)
 		llm, err := New(WithToken(token))
 		require.NoError(t, err)
 		require.NotNil(t, llm)
 	})
 
-	t.Run("no token", func(t *testing.T) {
+	t.Run("no token", func(t *testing.T) { //nolint:paralleltest
+		// Cannot use t.Parallel() with os.Unsetenv() which affects environment
 		os.Unsetenv(tokenEnvVarName)
 		llm, err := New()
 		require.Error(t, err)
@@ -47,6 +53,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestCall(t *testing.T) {
+	t.Parallel()
 	token := skipIfNoGitHubToken(t)
 	llm, err := New(WithToken(token))
 	require.NoError(t, err)
@@ -57,6 +64,7 @@ func TestCall(t *testing.T) {
 }
 
 func TestGenerateContent(t *testing.T) {
+	t.Parallel()
 	token := skipIfNoGitHubToken(t)
 	llm, err := New(WithToken(token))
 	require.NoError(t, err)
@@ -79,6 +87,7 @@ func TestGenerateContent(t *testing.T) {
 }
 
 func TestMessageTypeToRole(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		msgType  llms.ChatMessageType
@@ -95,6 +104,7 @@ func TestMessageTypeToRole(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			result := typeToRole(tc.msgType)
 			assert.Equal(t, tc.expected, result)
 		})
@@ -102,6 +112,7 @@ func TestMessageTypeToRole(t *testing.T) {
 }
 
 func TestContentPartConcatenation(t *testing.T) {
+	t.Parallel()
 	// Test case with multiple text parts
 	messages := []llms.MessageContent{
 		{

--- a/llms/githubmodels/githubmodelsllm_test.go
+++ b/llms/githubmodels/githubmodelsllm_test.go
@@ -77,3 +77,50 @@ func TestGenerateContent(t *testing.T) {
 	assert.NotEmpty(t, response.Choices)
 	assert.Contains(t, response.Choices[0].Content, "Paris")
 }
+
+func TestMessageTypeToRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		msgType  llms.ChatMessageType
+		expected string
+	}{
+		{"system message", llms.ChatMessageTypeSystem, "system"},
+		{"human message", llms.ChatMessageTypeHuman, "user"},
+		{"ai message", llms.ChatMessageTypeAI, "assistant"},
+		{"generic message", llms.ChatMessageTypeGeneric, "user"},
+		{"function message", llms.ChatMessageTypeFunction, "function"},
+		{"tool message", llms.ChatMessageTypeTool, "tool"},
+		{"unknown message", llms.ChatMessageType("unknown"), "user"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := typeToRole(tc.msgType)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestContentPartConcatenation(t *testing.T) {
+	// Test case with multiple text parts
+	messages := []llms.MessageContent{
+		{
+			Role: llms.ChatMessageTypeHuman,
+			Parts: []llms.ContentPart{
+				llms.TextContent{Text: "Hello"},
+				llms.TextContent{Text: " World"},
+				llms.TextContent{Text: "!"},
+			},
+		},
+	}
+
+	// Test the message content concatenation behavior
+	var contentText string
+	for _, part := range messages[0].Parts {
+		if textContent, ok := part.(llms.TextContent); ok {
+			contentText += textContent.Text
+		}
+	}
+	// Verify the concatenation worked
+	assert.Equal(t, "Hello World!", contentText)
+}

--- a/llms/githubmodels/githubmodelsllm_test.go
+++ b/llms/githubmodels/githubmodelsllm_test.go
@@ -1,0 +1,79 @@
+package githubmodels
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/llms"
+)
+
+func skipIfNoGitHubToken(t *testing.T) string {
+	t.Helper()
+	token := os.Getenv(tokenEnvVarName)
+	if token == "" {
+		t.Skip("Skipping test because GITHUB_TOKEN environment variable is not set")
+	}
+	return token
+}
+
+func TestNew(t *testing.T) {
+	t.Run("with token from env", func(t *testing.T) {
+		token := skipIfNoGitHubToken(t)
+		os.Setenv(tokenEnvVarName, token)
+		defer os.Unsetenv(tokenEnvVarName)
+
+		llm, err := New()
+		require.NoError(t, err)
+		require.NotNil(t, llm)
+	})
+
+	t.Run("with explicit token", func(t *testing.T) {
+		token := skipIfNoGitHubToken(t)
+		llm, err := New(WithToken(token))
+		require.NoError(t, err)
+		require.NotNil(t, llm)
+	})
+
+	t.Run("no token", func(t *testing.T) {
+		os.Unsetenv(tokenEnvVarName)
+		llm, err := New()
+		require.Error(t, err)
+		assert.Equal(t, ErrMissingToken, err)
+		assert.Nil(t, llm)
+	})
+}
+
+func TestCall(t *testing.T) {
+	token := skipIfNoGitHubToken(t)
+	llm, err := New(WithToken(token))
+	require.NoError(t, err)
+
+	response, err := llm.Call(context.Background(), "What is the capital of France?")
+	require.NoError(t, err)
+	assert.Contains(t, response, "Paris")
+}
+
+func TestGenerateContent(t *testing.T) {
+	token := skipIfNoGitHubToken(t)
+	llm, err := New(WithToken(token))
+	require.NoError(t, err)
+
+	messages := []llms.MessageContent{
+		{
+			Role:  llms.ChatMessageTypeSystem,
+			Parts: []llms.ContentPart{llms.TextContent{Text: "You are a helpful assistant."}},
+		},
+		{
+			Role:  llms.ChatMessageTypeHuman,
+			Parts: []llms.ContentPart{llms.TextContent{Text: "What is the capital of France?"}},
+		},
+	}
+
+	response, err := llm.GenerateContent(context.Background(), messages)
+	require.NoError(t, err)
+	assert.NotEmpty(t, response.Choices)
+	assert.Contains(t, response.Choices[0].Content, "Paris")
+}

--- a/llms/githubmodels/internal/githubmodelsclient/githubmodelsclient.go
+++ b/llms/githubmodels/internal/githubmodelsclient/githubmodelsclient.go
@@ -1,0 +1,146 @@
+package githubmodelsclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+)
+
+const (
+	defaultBaseURL = "https://models.github.ai/inference"
+	apiVersion     = "2022-11-28"
+)
+
+// Client is the GitHub Models API client.
+type Client struct {
+	token      string
+	model      string
+	baseURL    string
+	httpClient *http.Client
+}
+
+// Message represents a message in a chat conversation.
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// ChatRequest is a request to create a chat completion.
+type ChatRequest struct {
+	Model       string    `json:"model"`
+	Messages    []Message `json:"messages"`
+	Temperature float64   `json:"temperature,omitempty"`
+	MaxTokens   int       `json:"max_tokens,omitempty"`
+	TopP        float64   `json:"top_p,omitempty"`
+}
+
+// Choice represents a completion choice returned by the API.
+type Choice struct {
+	Message      Message `json:"message"`
+	FinishReason string  `json:"finish_reason"`
+}
+
+// ChatResponse is the response from a chat completion request.
+type ChatResponse struct {
+	Choices []Choice `json:"choices"`
+}
+
+// StatusError is an error returned by the GitHub Models API.
+type StatusError struct {
+	StatusCode   int    `json:"status_code"`
+	ErrorMessage string `json:"error"`
+}
+
+func (e StatusError) Error() string {
+	return fmt.Sprintf("GitHub Models API error: %s (status code: %d)", e.ErrorMessage, e.StatusCode)
+}
+
+// NewClient creates a new GitHub Models API client.
+func NewClient(token, model string, httpClient *http.Client) (*Client, error) {
+	if token == "" {
+		return nil, fmt.Errorf("missing GitHub token")
+	}
+
+	if model == "" {
+		model = "openai/gpt-4.1"
+	}
+
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	return &Client{
+		token:      token,
+		model:      model,
+		baseURL:    defaultBaseURL,
+		httpClient: httpClient,
+	}, nil
+}
+
+// CreateChat creates a chat completion.
+func (c *Client) CreateChat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	if req.Model == "" {
+		req.Model = c.model
+	}
+
+	url := fmt.Sprintf("%s/chat/completions", c.baseURL)
+	return c.sendRequest(ctx, "POST", url, req)
+}
+
+// sendRequest sends a request to the GitHub Models API.
+func (c *Client) sendRequest(ctx context.Context, method, url string, reqData interface{}) (*ChatResponse, error) {
+	var reqBody io.Reader
+	if reqData != nil {
+		jsonData, err := json.Marshal(reqData)
+		if err != nil {
+			return nil, err
+		}
+		reqBody = bytes.NewBuffer(jsonData)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("X-GitHub-Api-Version", apiVersion)
+	req.Header.Set("User-Agent", 
+		fmt.Sprintf("langchaingo/ (%s %s) Go/%s", runtime.GOARCH, runtime.GOOS, runtime.Version()))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 400 {
+		apiErr := StatusError{
+			StatusCode: resp.StatusCode,
+		}
+		
+		// Try to unmarshal error response
+		if err := json.Unmarshal(respBody, &apiErr); err != nil {
+			apiErr.ErrorMessage = string(respBody)
+		}
+		
+		return nil, apiErr
+	}
+
+	var chatResp ChatResponse
+	if err := json.Unmarshal(respBody, &chatResp); err != nil {
+		return nil, err
+	}
+
+	return &chatResp, nil
+}

--- a/llms/githubmodels/internal/githubmodelsclient/githubmodelsclient.go
+++ b/llms/githubmodels/internal/githubmodelsclient/githubmodelsclient.go
@@ -110,7 +110,7 @@ func (c *Client) sendRequest(ctx context.Context, method, url string, reqData in
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("Authorization", "Bearer "+c.token)
 	req.Header.Set("X-GitHub-Api-Version", apiVersion)
-	req.Header.Set("User-Agent", 
+	req.Header.Set("User-Agent",
 		fmt.Sprintf("langchaingo/ (%s %s) Go/%s", runtime.GOARCH, runtime.GOOS, runtime.Version()))
 
 	resp, err := c.httpClient.Do(req)
@@ -128,12 +128,12 @@ func (c *Client) sendRequest(ctx context.Context, method, url string, reqData in
 		apiErr := StatusError{
 			StatusCode: resp.StatusCode,
 		}
-		
+
 		// Try to unmarshal error response
 		if err := json.Unmarshal(respBody, &apiErr); err != nil {
 			apiErr.ErrorMessage = string(respBody)
 		}
-		
+
 		return nil, apiErr
 	}
 


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves.
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

## Description

This PR adds support for the GitHub Models API, a new LLM provider that offers access to various powerful language models like GPT-4.1, Claude 3, and Mistral through GitHub's API. The implementation follows similar patterns to other LLM implementations in the langchaingo library. This has been raised to a request I made on issue #1257 

## Implementation Details

The PR includes:

1. A new `githubmodels` package in the `llms` directory
2. Implementation of the `llms.Model` interface with support for:
   - Simple text completion via `Call()`
   - Chat-based interactions via `GenerateContent()`
   - Configuration options for models, token, HTTP client, and callbacks
3. Comprehensive documentation:
   - README.md with usage examples
   - Documentation in the docs site
   - Example code in the examples directory
4. Test coverage for all main functionality