### PR TITLE
duckduckgo: descriptive error message

### DIFF
--- a/tools/duckduckgo/internal/client.go
+++ b/tools/duckduckgo/internal/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -11,10 +12,7 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
-var (
-	ErrNoGoodResult = errors.New("no good search results found")
-	ErrAPIResponse  = errors.New("duckduckgo api responded with error")
-)
+var ErrNoGoodResult = errors.New("no good search results found")
 
 // Client defines an HTTP client for communicating with duckduckgo.
 type Client struct {
@@ -72,7 +70,8 @@ func (client *Client) Search(ctx context.Context, query string) (string, error) 
 
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
-		return "", ErrAPIResponse
+		b, _ := io.ReadAll(response.Body) // body just used to populate an error message. No point capturing any errors reading from body
+		return "", fmt.Errorf("duckduckgo api responded with %d: %s", response.StatusCode, string(b))
 	}
 
 	doc, err := goquery.NewDocumentFromReader(response.Body)


### PR DESCRIPTION
Presently if the DDG API returns a non-200 status you get a really generic error message that is basically of no help what-so-ever.

This PR basically just shares the HTTP response in the error message

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
