### PR TITLE
chains: expose GetLLMCallOptions

### DIFF
--- a/chains/llm.go
+++ b/chains/llm.go
@@ -56,7 +56,7 @@ func (c LLMChain) Call(ctx context.Context, values map[string]any, options ...Ch
 		return nil, err
 	}
 
-	result, err := llms.GenerateFromSinglePrompt(ctx, c.LLM, promptValue.String(), getLLMCallOptions(options...)...)
+	result, err := llms.GenerateFromSinglePrompt(ctx, c.LLM, promptValue.String(), GetLLMCallOptions(options...)...)
 	if err != nil {
 		return nil, err
 	}

--- a/chains/options.go
+++ b/chains/options.go
@@ -161,7 +161,7 @@ func WithCallback(callbackHandler callbacks.Handler) ChainCallOption {
 	}
 }
 
-func getLLMCallOptions(options ...ChainCallOption) []llms.CallOption { //nolint:cyclop
+func GetLLMCallOptions(options ...ChainCallOption) []llms.CallOption { //nolint:cyclop
 	opts := &chainCallOption{}
 	for _, option := range options {
 		option(opts)


### PR DESCRIPTION
### Motivation
This method is very useful for a user who wants to use an LLM `GenerateContent`method when working with parameters defined in a chain, I see no advantage in keeping it private.

### PR Checklist

- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
