### PR TITLE
googleai: fix tool conversion in case of complex schema

### DIFF
--- a/llms/googleai/googleai.go
+++ b/llms/googleai/googleai.go
@@ -396,74 +396,170 @@ func convertTools(tools []llms.Tool) ([]*genai.Tool, error) {
 			Description: tool.Function.Description,
 		}
 
-		// Expect the Parameters field to be a map[string]any, from which we will
-		// extract properties to populate the schema.
-		params, ok := tool.Function.Parameters.(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("tool [%d]: unsupported type %T of Parameters", i, tool.Function.Parameters)
+		var err error
+
+		if schema, ok := tool.Function.Parameters.(*genai.Schema); ok {
+			// If the Parameters field is already a genai.Schema, we can use it directly.
+			genaiFuncDecl.Parameters = schema
+		} else if params, ok := tool.Function.Parameters.(map[string]any); ok {
+			// If the Parameters field is a map[string]any, we will extract properties to populate the schema.
+			genaiFuncDecl.Parameters, err = convertParameter(params)
+		} else {
+			err = fmt.Errorf("unsupported type %T of Parameters", tool.Function.Parameters)
 		}
 
-		schema := &genai.Schema{}
-		if ty, ok := params["type"]; ok {
-			tyString, ok := ty.(string)
-			if !ok {
-				return nil, fmt.Errorf("tool [%d]: expected string for type", i)
-			}
-			schema.Type = convertToolSchemaType(tyString)
+		if err != nil {
+			return nil, fmt.Errorf("tool [%d]: %s", i, err.Error())
 		}
-
-		paramProperties, ok := params["properties"].(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("tool [%d]: expected to find a map of properties", i)
-		}
-
-		schema.Properties = make(map[string]*genai.Schema)
-		for propName, propValue := range paramProperties {
-			valueMap, ok := propValue.(map[string]any)
-			if !ok {
-				return nil, fmt.Errorf("tool [%d], property [%v]: expect to find a value map", i, propName)
-			}
-			schema.Properties[propName] = &genai.Schema{}
-
-			if ty, ok := valueMap["type"]; ok {
-				tyString, ok := ty.(string)
-				if !ok {
-					return nil, fmt.Errorf("tool [%d]: expected string for type", i)
-				}
-				schema.Properties[propName].Type = convertToolSchemaType(tyString)
-			}
-			if desc, ok := valueMap["description"]; ok {
-				descString, ok := desc.(string)
-				if !ok {
-					return nil, fmt.Errorf("tool [%d]: expected string for description", i)
-				}
-				schema.Properties[propName].Description = descString
-			}
-		}
-
-		if required, ok := params["required"]; ok {
-			if rs, ok := required.([]string); ok {
-				schema.Required = rs
-			} else if ri, ok := required.([]interface{}); ok {
-				rs := make([]string, 0, len(ri))
-				for _, r := range ri {
-					rString, ok := r.(string)
-					if !ok {
-						return nil, fmt.Errorf("tool [%d]: expected string for required", i)
-					}
-					rs = append(rs, rString)
-				}
-				schema.Required = rs
-			} else {
-				return nil, fmt.Errorf("tool [%d]: expected string for required", i)
-			}
-		}
-		genaiFuncDecl.Parameters = schema
 
 		genaiTool.FunctionDeclarations = append(genaiTool.FunctionDeclarations, genaiFuncDecl)
 	}
 
 	return []*genai.Tool{&genaiTool}, nil
+}
+
+// convertParameters converts a map of parameters to a genai.Schema.
+func convertParameters(params map[string]any) (map[string]*genai.Schema, error) {
+	result := map[string]*genai.Schema{}
+
+	for propertyName, def := range params {
+		defAsMap, ok := def.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("property %s is not a map", propertyName)
+		}
+
+		var err error
+		result[propertyName], err = convertParameter(defAsMap)
+		if err != nil {
+			return nil, fmt.Errorf("error converting property %s: %w", propertyName, err)
+		}
+	}
+
+	return result, nil
+}
+
+// convertParameter converts a single parameter to a genai.Schema.
+func convertParameter(param map[string]any) (*genai.Schema, error) {
+	schema := &genai.Schema{}
+
+	if err := convertType(param, schema); err != nil {
+		return nil, err
+	}
+	if err := convertDescription(param, schema); err != nil {
+		return nil, err
+	}
+	if err := convertEnum(param, schema); err != nil {
+		return nil, err
+	}
+	if err := convertRequired(param, schema); err != nil {
+		return nil, err
+	}
+	if err := convertItems(param, schema); err != nil {
+		return nil, err
+	}
+	if err := convertProperties(param, schema); err != nil {
+		return nil, err
+	}
+
+	return schema, nil
+}
+
+// convertType is responsible for converting the "type" field of a parameter
+func convertType(param map[string]any, schema *genai.Schema) error {
+	if ty, ok := param["type"]; ok {
+		if sType, ok := ty.(string); ok {
+			schema.Type = convertToolSchemaType(sType)
+		} else {
+			return fmt.Errorf("type is not a string")
+		}
+	} else {
+		return fmt.Errorf("type is missing")
+	}
+	return nil
+}
+
+// convertDescription is responsible for converting the "description" field of a parameter
+func convertDescription(param map[string]any, schema *genai.Schema) error {
+	if desc, ok := param["description"]; ok {
+		if sDesc, ok := desc.(string); ok {
+			schema.Description = sDesc
+		} else {
+			return fmt.Errorf("description is not a string")
+		}
+	}
+	return nil
+}
+
+// convertEnum is responsible for converting the "enum" field of a parameter
+func convertEnum(param map[string]any, schema *genai.Schema) error {
+	if enum, ok := param["enum"]; ok {
+		if sEnum, ok := enum.([]string); ok {
+			schema.Enum = sEnum
+		} else if aEnum, ok := enum.([]any); ok {
+			// convert []any to []string
+			schema.Enum = make([]string, len(aEnum))
+			for i := range aEnum {
+				schema.Enum[i] = fmt.Sprintf("%v", aEnum[i])
+			}
+		} else {
+			return fmt.Errorf("enum is not a slice")
+		}
+	}
+	return nil
+}
+
+// convertRequired is responsible for converting the "required" field of a parameter
+func convertRequired(param map[string]any, schema *genai.Schema) error {
+	if req, ok := param["required"]; ok {
+		if aReq, ok := req.([]string); ok {
+			schema.Required = aReq
+		} else if ri, ok := req.([]any); ok {
+			rs := make([]string, 0, len(ri))
+			for _, r := range ri {
+				rString, ok := r.(string)
+				if !ok {
+					return fmt.Errorf("expected string for required")
+				}
+				rs = append(rs, rString)
+			}
+			schema.Required = rs
+		} else {
+			return fmt.Errorf("required field is not a slice")
+		}
+	}
+	return nil
+}
+
+// convertItems is responsible for converting the "items" field of a parameter
+func convertItems(param map[string]any, schema *genai.Schema) error {
+	if items, ok := param["items"]; ok {
+		if itemsMap, ok := items.(map[string]any); ok {
+			var err error
+			schema.Items, err = convertParameter(itemsMap)
+			if err != nil {
+				return fmt.Errorf("error converting items: %w", err)
+			}
+		} else {
+			return fmt.Errorf("items is not a map")
+		}
+	}
+	return nil
+}
+
+// convertProperties is responsible for converting the "properties" field of a parameter
+func convertProperties(param map[string]any, schema *genai.Schema) error {
+	if props, ok := param["properties"]; ok {
+		if propsMap, ok := props.(map[string]any); ok {
+			var err error
+			schema.Properties, err = convertParameters(propsMap)
+			if err != nil {
+				return fmt.Errorf("error converting properties: %w", err)
+			}
+		} else {
+			return fmt.Errorf("properties is not a map")
+		}
+	}
+	return nil
 }
 
 // convertToolSchemaType converts a tool's schema type from its langchaingo

--- a/llms/googleai/googleai_test.go
+++ b/llms/googleai/googleai_test.go
@@ -1,0 +1,559 @@
+package googleai
+
+import (
+	"github.com/google/generative-ai-go/genai"
+	"github.com/stretchr/testify/assert"
+	"github.com/tmc/langchaingo/llms"
+	"testing"
+)
+
+func Test_convertTools(t *testing.T) {
+	tests := []struct {
+		name        string
+		tools       []llms.Tool
+		expected    []*genai.FunctionDeclaration
+		expectedErr string
+	}{
+		{
+			name:  "no tools",
+			tools: nil,
+		},
+		{
+			name: "unsupported tool type",
+			tools: []llms.Tool{
+				{Type: "unsupported"},
+			},
+			expectedErr: `unsupported type "unsupported", want 'function'`,
+		},
+		{
+			name: "unsupported tool parameter type",
+			tools: []llms.Tool{
+				{Type: "function", Function: &llms.FunctionDefinition{Parameters: "unsupported"}},
+			},
+			expectedErr: `unsupported type string of Parameters`,
+		},
+		{
+			name: "missing type",
+			tools: []llms.Tool{{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Parameters: map[string]any{},
+				}},
+			},
+			expectedErr: "type is missing",
+		},
+		{
+			name: "type is not string",
+			tools: []llms.Tool{{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Parameters: map[string]any{
+						"type": 123,
+					},
+				}},
+			},
+			expectedErr: "type is not a string",
+		},
+		{
+			name: "description is not string",
+			tools: []llms.Tool{{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Parameters: map[string]any{
+						"type":        "object",
+						"description": 123,
+					},
+				}},
+			},
+			expectedErr: "description is not a string",
+		},
+		{
+			name: "enum is not a slice",
+			tools: []llms.Tool{{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Parameters: map[string]any{
+						"type": "object",
+						"enum": 123,
+					},
+				}},
+			},
+			expectedErr: "enum is not a slice",
+		},
+		{
+			name: "required is not a slice",
+			tools: []llms.Tool{{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Parameters: map[string]any{
+						"type":     "object",
+						"required": 123,
+					},
+				}},
+			},
+			expectedErr: "required field is not a slice",
+		},
+		{
+			name: "required items are not strings",
+			tools: []llms.Tool{{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Parameters: map[string]any{
+						"type":     "object",
+						"required": []any{"string", 123},
+					},
+				}},
+			},
+			expectedErr: "expected string for required",
+		},
+		{
+			name: "items is not a map",
+			tools: []llms.Tool{{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Parameters: map[string]any{
+						"type":  "object",
+						"items": 123,
+					},
+				}},
+			},
+			expectedErr: "items is not a map",
+		},
+		{
+			name: "properties is not a map",
+			tools: []llms.Tool{{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Parameters: map[string]any{
+						"type":       "object",
+						"properties": 123,
+					},
+				}},
+			},
+			expectedErr: "properties is not a map",
+		},
+		{
+			name: "use given schema",
+			tools: []llms.Tool{{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Name:        "TestFunction",
+					Description: "A test function",
+					Parameters:  &genai.Schema{},
+				}},
+			},
+			expected: []*genai.FunctionDeclaration{{
+				Name:        "TestFunction",
+				Description: "A test function",
+				Parameters:  &genai.Schema{},
+			}},
+		},
+		{
+			name: "simple parameter",
+			tools: []llms.Tool{{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Name:        "TestFunction",
+					Description: "A test function",
+					Parameters: map[string]any{
+						"type":        "string",
+						"description": "A simple string parameter",
+					},
+				}},
+			},
+			expected: []*genai.FunctionDeclaration{{
+				Name:        "TestFunction",
+				Description: "A test function",
+				Parameters: &genai.Schema{
+					Type:        genai.TypeString,
+					Description: "A simple string parameter",
+				},
+			}},
+		},
+		{
+			name: "object parameter",
+			tools: []llms.Tool{{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Name:        "TestFunction",
+					Description: "A test function",
+					Parameters: map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"string": map[string]any{
+								"type":        "string",
+								"description": "A string parameter",
+							},
+							"number": map[string]any{
+								"type":        "number",
+								"description": "A number parameter",
+							},
+							"integer": map[string]any{
+								"type":        "integer",
+								"description": "An integer parameter",
+							},
+							"boolean": map[string]any{
+								"type":        "boolean",
+								"description": "A boolean parameter",
+							},
+						},
+					},
+				}},
+			},
+			expected: []*genai.FunctionDeclaration{{
+				Name:        "TestFunction",
+				Description: "A test function",
+				Parameters: &genai.Schema{
+					Type: genai.TypeObject,
+					Properties: map[string]*genai.Schema{
+						"string": {
+							Type:        genai.TypeString,
+							Description: "A string parameter",
+						},
+						"number": {
+							Type:        genai.TypeNumber,
+							Description: "A number parameter",
+						},
+						"integer": {
+							Type:        genai.TypeInteger,
+							Description: "An integer parameter",
+						},
+						"boolean": {
+							Type:        genai.TypeBoolean,
+							Description: "A boolean parameter",
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "required parameter",
+			tools: []llms.Tool{{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Name:        "TestFunction",
+					Description: "A test function",
+					Parameters: map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"string": map[string]any{
+								"type":        "string",
+								"description": "A string parameter",
+							},
+							"number": map[string]any{
+								"type":        "number",
+								"description": "A number parameter",
+							},
+						},
+						"required": []string{"string"},
+					},
+				}},
+			},
+			expected: []*genai.FunctionDeclaration{{
+				Name:        "TestFunction",
+				Description: "A test function",
+				Parameters: &genai.Schema{
+					Type: genai.TypeObject,
+					Properties: map[string]*genai.Schema{
+						"string": {
+							Type:        genai.TypeString,
+							Description: "A string parameter",
+						},
+						"number": {
+							Type:        genai.TypeNumber,
+							Description: "A number parameter",
+						},
+					},
+					Required: []string{"string"},
+				},
+			}},
+		},
+		{
+			name: "enum parameter",
+			tools: []llms.Tool{{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Name:        "TestFunction",
+					Description: "A test function",
+					Parameters: map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"enum": map[string]any{
+								"type":        "string",
+								"description": "A enum parameter",
+								"enum":        []string{"option1", "option2", "option3"},
+							},
+							"anyEnum": map[string]any{
+								"type":        "string",
+								"description": "A any enum parameter",
+								"enum":        []any{1, 1.2, "option3"},
+							},
+						},
+					},
+				}},
+			},
+			expected: []*genai.FunctionDeclaration{{
+				Name:        "TestFunction",
+				Description: "A test function",
+				Parameters: &genai.Schema{
+					Type: genai.TypeObject,
+					Properties: map[string]*genai.Schema{
+						"enum": {
+							Type:        genai.TypeString,
+							Description: "A enum parameter",
+							Enum:        []string{"option1", "option2", "option3"},
+						},
+						"anyEnum": {
+							Type:        genai.TypeString,
+							Description: "A any enum parameter",
+							Enum:        []string{"1", "1.2", "option3"},
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "simple array parameter",
+			tools: []llms.Tool{{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Name:        "TestFunction",
+					Description: "A test function",
+					Parameters: map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"string": map[string]any{
+								"type":        "array",
+								"description": "A string array parameter",
+								"items": map[string]any{
+									"type": "string",
+								},
+							},
+							"number": map[string]any{
+								"type":        "array",
+								"description": "A number array parameter",
+								"items": map[string]any{
+									"type": "number",
+								},
+							},
+							"integer": map[string]any{
+								"type":        "array",
+								"description": "An integer array parameter",
+								"items": map[string]any{
+									"type": "integer",
+								},
+							},
+							"boolean": map[string]any{
+								"type":        "array",
+								"description": "A boolean array parameter",
+								"items": map[string]any{
+									"type": "boolean",
+								},
+							},
+						},
+					},
+				}},
+			},
+			expected: []*genai.FunctionDeclaration{{
+				Name:        "TestFunction",
+				Description: "A test function",
+				Parameters: &genai.Schema{
+					Type: genai.TypeObject,
+					Properties: map[string]*genai.Schema{
+						"string": {
+							Type:        genai.TypeArray,
+							Description: "A string array parameter",
+							Items: &genai.Schema{
+								Type: genai.TypeString,
+							},
+						},
+						"number": {
+							Type:        genai.TypeArray,
+							Description: "A number array parameter",
+							Items: &genai.Schema{
+								Type: genai.TypeNumber,
+							},
+						},
+						"integer": {
+							Type:        genai.TypeArray,
+							Description: "An integer array parameter",
+							Items: &genai.Schema{
+								Type: genai.TypeInteger,
+							},
+						},
+						"boolean": {
+							Type:        genai.TypeArray,
+							Description: "A boolean array parameter",
+							Items: &genai.Schema{
+								Type: genai.TypeBoolean,
+							},
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "complex array parameter",
+			tools: []llms.Tool{{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Name:        "TestFunction",
+					Description: "A test function",
+					Parameters: map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"array": map[string]any{
+								"type":        "array",
+								"description": "A array parameter",
+								"items": map[string]any{
+									"type": "object",
+									"properties": map[string]any{
+										"string": map[string]any{
+											"type":        "string",
+											"description": "A string parameter",
+										},
+										"number": map[string]any{
+											"type":        "number",
+											"description": "A number parameter",
+										},
+									},
+									"required": []string{"string"},
+								},
+							},
+						},
+					},
+				}},
+			},
+			expected: []*genai.FunctionDeclaration{{
+				Name:        "TestFunction",
+				Description: "A test function",
+				Parameters: &genai.Schema{
+					Type: genai.TypeObject,
+					Properties: map[string]*genai.Schema{
+						"array": {
+							Type:        genai.TypeArray,
+							Description: "A array parameter",
+							Items: &genai.Schema{
+								Type: genai.TypeObject,
+								Properties: map[string]*genai.Schema{
+									"string": {
+										Type:        genai.TypeString,
+										Description: "A string parameter",
+									},
+									"number": {
+										Type:        genai.TypeNumber,
+										Description: "A number parameter",
+									},
+								},
+								Required: []string{"string"},
+							},
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "complex object parameter",
+			tools: []llms.Tool{{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Name:        "TestFunction",
+					Description: "A test function",
+					Parameters: map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"param1": map[string]any{
+								"type":        "object",
+								"description": "A object parameter",
+								"properties": map[string]any{
+									"array": map[string]any{
+										"type":        "array",
+										"description": "A array parameter",
+										"items": map[string]any{
+											"type": "object",
+											"properties": map[string]any{
+												"string": map[string]any{
+													"type":        "string",
+													"description": "A string parameter",
+												},
+												"number": map[string]any{
+													"type":        "number",
+													"description": "A number parameter",
+												},
+											},
+											"required": []string{"string"},
+										},
+									},
+								},
+							},
+							"param2": map[string]any{
+								"type":        "string",
+								"description": "A string parameter",
+								"enum":        []string{"option1", "option2", "option3"},
+							},
+						},
+					},
+				}},
+			},
+			expected: []*genai.FunctionDeclaration{{
+				Name:        "TestFunction",
+				Description: "A test function",
+				Parameters: &genai.Schema{
+					Type: genai.TypeObject,
+					Properties: map[string]*genai.Schema{
+						"param1": {
+							Type:        genai.TypeObject,
+							Description: "A object parameter",
+							Properties: map[string]*genai.Schema{
+								"array": {
+									Type:        genai.TypeArray,
+									Description: "A array parameter",
+									Items: &genai.Schema{
+										Type: genai.TypeObject,
+										Properties: map[string]*genai.Schema{
+											"string": {
+												Type:        genai.TypeString,
+												Description: "A string parameter",
+											},
+											"number": {
+												Type:        genai.TypeNumber,
+												Description: "A number parameter",
+											},
+										},
+										Required: []string{"string"},
+									},
+								},
+							},
+						},
+						"param2": {
+							Type:        genai.TypeString,
+							Description: "A string parameter",
+							Enum:        []string{"option1", "option2", "option3"},
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := convertTools(tt.tools)
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			}
+
+			if tt.expected == nil {
+				assert.Empty(t, result)
+			} else {
+				assert.Len(t, result, 1)
+				assert.Equal(t, tt.expected, result[0].FunctionDeclarations)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

I figured out that tool conversation did not work in case of complex tool definitions. Especially for arrays and inner-objects. So in this PR I refactored the tool-conversation logic and wrote some tests (only for the conversation logic). Furthermore, I implements the possibility to "outsource" the schema-definition to the user of this library. This is the case if the user will set the schema directly as Tool's Parameter.