### PR TITLE
googleai: add the ability to use context caching

### DIFF
--- a/llms/googleai/hooks.go
+++ b/llms/googleai/hooks.go
@@ -1,0 +1,26 @@
+package googleai
+
+import (
+	"context"
+	"github.com/google/generative-ai-go/genai"
+	"github.com/tmc/langchaingo/llms"
+)
+
+type PreSendingHook func(
+	ctx context.Context,
+	model *genai.GenerativeModel,
+	meta PreSendingHookMetadata,
+)
+
+// PreSendingHookMetadata contains more metadata for the pre-sending hook.
+type PreSendingHookMetadata struct {
+	// Options contains the options used for the call.
+	Options llms.CallOptions
+
+	// History contains the history of the conversation.
+	// It is empty if this is the first call of the conversation.
+	History []*genai.Content
+
+	// Parts contains the parts of the content that are being sent.
+	Parts []genai.Part
+}

--- a/llms/googleai/new.go
+++ b/llms/googleai/new.go
@@ -39,3 +39,8 @@ func New(ctx context.Context, opts ...Option) (*GoogleAI, error) {
 	gi.client = client
 	return gi, nil
 }
+
+// GetGenaiClient returns the underlying [genai.Client] which is used for communication with the Google AI API.
+func (g *GoogleAI) GetGenaiClient() *genai.Client {
+	return g.client
+}

--- a/llms/googleai/option.go
+++ b/llms/googleai/option.go
@@ -21,6 +21,7 @@ type Options struct {
 	DefaultTopK           int
 	DefaultTopP           float64
 	HarmThreshold         HarmBlockThreshold
+	PreSendingHook        PreSendingHook
 
 	ClientOptions []option.ClientOption
 }
@@ -171,6 +172,14 @@ func WithDefaultTopP(defaultTopP float64) Option {
 func WithHarmThreshold(ht HarmBlockThreshold) Option {
 	return func(opts *Options) {
 		opts.HarmThreshold = ht
+	}
+}
+
+// WithPreSendingHook sets a function which called right before sending the request to the model.
+// You can manipulate the model's value. Which can be necessary for caching or other purposes.
+func WithPreSendingHook(hook PreSendingHook) Option {
+	return func(opts *Options) {
+		opts.PreSendingHook = hook
 	}
 }
 


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

This PR contains two "major" updates:
* Expose the cached-token usage
* Add a pre-sending hook to make it possible to "activate" custom caching strategies

How to use caching is described at the official [gemini-api docs](https://ai.google.dev/gemini-api/docs/caching?lang=go)

Unfortunately there is no way to create a cache before sending the request without changing the message-request. For example: if you want to cache the tools-definitions you have to:
* create a cache with the content of that tool-definitions
* set the returned cache name in the model
* **remove** the tools-definition out of the model (otherwise you will produce a bad request)

So that's the reason why I introduced the "PreSendingHook". Let me know if you know a more elegant way to do that :sweat_smile: 

So here is a little show-case how to use that hook, for setting up tool caching:
```go
package main

import (
	"context"
	"fmt"
	"github.com/google/generative-ai-go/genai"
	"github.com/tmc/langchaingo/llms"
	"github.com/tmc/langchaingo/llms/googleai"
	"time"
)

var client *googleai.GoogleAI
var cacheName = ""

func main() {
	var err error
	client, err = googleai.New(
		context.Background(),
		googleai.WithAPIKey("YOUR_API_KEY"),
		googleai.WithDefaultModel("gemini-2.0-flash-lite"),
		googleai.WithPreSendingHook(hook),
	)
	if err != nil {
		panic(err)
	}

	messages := []llms.MessageContent{{
		Role:  llms.ChatMessageTypeHuman,
		Parts: []llms.ContentPart{llms.TextPart("Call one test function for me, please.")},
	}}

	var tools []llms.Tool
	for i := 0; i < 250; i++ {
		tools = append(tools, llms.Tool{
			Type: "function",
			Function: &llms.FunctionDefinition{
				Name:        fmt.Sprintf("TestFn%d", i),
				Description: fmt.Sprintf("This is the test function #%d", i),
				Parameters: map[string]any{
					"type": "object",
				},
			},
		})
	}

	resp, err := client.GenerateContent(context.Background(), messages, llms.WithTools(tools))
	if err != nil {
		panic(fmt.Errorf("error generating content: %w", err))
	}
	
	for i, c := range resp.Choices {
		fmt.Printf("Choice #%d usage: %v", i, c.GenerationInfo)
	}
}

func hook(ctx context.Context, model *genai.GenerativeModel, meta googleai.PreSendingHookMetadata) {
	if cacheName == "" {
		content, err := client.GetGenaiClient().CreateCachedContent(ctx, &genai.CachedContent{
			Expiration: genai.ExpireTimeOrTTL{
				TTL: 5 * time.Minute,
			},
			Model: meta.Options.Model,
			Tools: model.Tools,
		})
		if err != nil {
			panic(fmt.Errorf("error creating cache: %w", err))
		}
		cacheName = content.Name
	}

	model.Tools = nil // Clear tools to avoid sending them with the request
	model.CachedContentName = cacheName
}
```