### PR TITLE
feat: Add max pages limit for scraper functionality

### DIFF
--- a/tools/scraper/options.go
+++ b/tools/scraper/options.go
@@ -101,3 +101,15 @@ func WithBlacklist(blacklist []string) Options {
 		o.Blacklist = append(o.Blacklist, blacklist...)
 	}
 }
+
+// WithMaxPages sets the maximum number of pages to scrape.
+//
+// Default value: 0 (no limit)
+//
+// maxPages: the maximum number of pages to scrape. Set to 0 for no limit.
+// Returns: an Options function.
+func WithMaxPages(maxPages int) Options {
+	return func(o *Scraper) {
+		o.MaxPages = maxPages
+	}
+}

--- a/tools/scraper/scraper.go
+++ b/tools/scraper/scraper.go
@@ -18,6 +18,7 @@ const (
 	DefualtParallels = 2
 	DefualtDelay     = 3
 	DefualtAsync     = true
+	DefualtMaxPages  = 0
 )
 
 var ErrScrapingFailed = errors.New("scraper could not read URL, or scraping is not allowed for provided URL")
@@ -28,6 +29,7 @@ type Scraper struct {
 	Delay     int64
 	Blacklist []string
 	Async     bool
+	MaxPages  int
 }
 
 var _ tools.Tool = Scraper{}
@@ -46,6 +48,7 @@ func New(options ...Options) (*Scraper, error) {
 		Parallels: DefualtParallels,
 		Delay:     int64(DefualtDelay),
 		Async:     DefualtAsync,
+		MaxPages:  DefualtMaxPages,
 		Blacklist: []string{
 			"login",
 			"signup",
@@ -114,10 +117,24 @@ func (s Scraper) Call(ctx context.Context, input string) (string, error) {
 	homePageLinks := make(map[string]bool)
 	scrapedLinks := make(map[string]bool)
 	scrapedLinksMutex := sync.RWMutex{}
+	pageCount := 0
+	pageCountMutex := sync.Mutex{}
 
 	c.OnRequest(func(r *colly.Request) {
 		if ctx.Err() != nil {
 			r.Abort()
+			return
+		}
+
+		if s.MaxPages > 0 {
+			pageCountMutex.Lock()
+			if pageCount >= s.MaxPages {
+				r.Abort()
+				pageCountMutex.Unlock()
+				return
+			}
+			pageCount++
+			pageCountMutex.Unlock()
 		}
 	})
 


### PR DESCRIPTION
Added WithMaxPages option to set a maximum number of pages to scrape, defaulting to 0 (no limit).


### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
