### PR TITLE
openai: handle binary content correctly (use file- or audio- type)

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -145,7 +145,7 @@ type ChatMessage struct { //nolint:musttag
 	Content string
 
 	// MultiContent is a list of content parts to use in the message.
-	MultiContent []llms.ContentPart
+	MultiContent []ContentPart
 
 	// The name of the author of this message. May contain a-z, A-Z, 0-9, and underscores,
 	// with a maximum length of 64 characters.
@@ -176,11 +176,11 @@ func (m ChatMessage) MarshalJSON() ([]byte, error) {
 	}
 	if len(m.MultiContent) > 0 {
 		msg := struct {
-			Role         string             `json:"role"`
-			Content      string             `json:"-"`
-			MultiContent []llms.ContentPart `json:"content,omitempty"`
-			Name         string             `json:"name,omitempty"`
-			ToolCalls    []ToolCall         `json:"tool_calls,omitempty"`
+			Role         string        `json:"role"`
+			Content      string        `json:"-"`
+			MultiContent []ContentPart `json:"content,omitempty"`
+			Name         string        `json:"name,omitempty"`
+			ToolCalls    []ToolCall    `json:"tool_calls,omitempty"`
 
 			// Deprecated: use ToolCalls instead.
 			FunctionCall *FunctionCall `json:"function_call,omitempty"`
@@ -195,11 +195,11 @@ func (m ChatMessage) MarshalJSON() ([]byte, error) {
 		return json.Marshal(msg)
 	}
 	msg := struct {
-		Role         string             `json:"role"`
-		Content      string             `json:"content"`
-		MultiContent []llms.ContentPart `json:"-"`
-		Name         string             `json:"name,omitempty"`
-		ToolCalls    []ToolCall         `json:"tool_calls,omitempty"`
+		Role         string        `json:"role"`
+		Content      string        `json:"content"`
+		MultiContent []ContentPart `json:"-"`
+		Name         string        `json:"name,omitempty"`
+		ToolCalls    []ToolCall    `json:"tool_calls,omitempty"`
 		// Deprecated: use ToolCalls instead.
 		FunctionCall *FunctionCall `json:"function_call,omitempty"`
 
@@ -213,21 +213,21 @@ func (m ChatMessage) MarshalJSON() ([]byte, error) {
 	return json.Marshal(msg)
 }
 
-func isSingleTextContent(parts []llms.ContentPart) (string, bool) {
+func isSingleTextContent(parts []ContentPart) (string, bool) {
 	if len(parts) != 1 {
 		return "", false
 	}
-	tc, isText := parts[0].(llms.TextContent)
+	tc, isText := parts[0].ContentPart.(llms.TextContent)
 	return tc.Text, isText
 }
 
 func (m *ChatMessage) UnmarshalJSON(data []byte) error {
 	msg := struct {
-		Role         string             `json:"role"`
-		Content      string             `json:"content"`
-		MultiContent []llms.ContentPart `json:"-"` // not expected in response
-		Name         string             `json:"name,omitempty"`
-		ToolCalls    []ToolCall         `json:"tool_calls,omitempty"`
+		Role         string        `json:"role"`
+		Content      string        `json:"content"`
+		MultiContent []ContentPart `json:"-"` // not expected in response
+		Name         string        `json:"name,omitempty"`
+		ToolCalls    []ToolCall    `json:"tool_calls,omitempty"`
 		// Deprecated: use ToolCalls instead.
 		FunctionCall *FunctionCall `json:"function_call,omitempty"`
 

--- a/llms/openai/internal/openaiclient/content.go
+++ b/llms/openai/internal/openaiclient/content.go
@@ -1,0 +1,100 @@
+package openaiclient
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"github.com/tmc/langchaingo/llms"
+	"regexp"
+	"strings"
+)
+
+type ContentPart struct {
+	llms.ContentPart
+}
+
+func (cp ContentPart) MarshalJSON() ([]byte, error) {
+	switch cp.ContentPart.(type) {
+	case llms.BinaryContent:
+		// we have to handle binary content separately
+		return marshalBinaryContent(cp.ContentPart.(llms.BinaryContent))
+	default:
+		// for all other content types, we can use the default JSON marshaling
+		return json.Marshal(cp.ContentPart)
+	}
+}
+
+func marshalBinaryContent(content llms.BinaryContent) ([]byte, error) {
+	if strings.HasPrefix(content.MIMEType, "audio/") {
+		// in case of audio content, we marshal it differently than other binary content
+		return marshalAudioContent(content)
+	}
+
+	// openai expects binary content to be marshaled as a file with a filename
+	// see: https://platform.openai.com/docs/guides/pdf-files#base64-encoded-files
+	return json.Marshal(map[string]any{
+		"type": "file",
+		"file": map[string]any{
+			"filename": extractFilename(content.MIMEType),
+			"file_data": Base64Data{
+				MIMEType: content.MIMEType,
+				Data:     content.Data,
+			},
+		},
+	})
+}
+
+var filenameRegex = regexp.MustCompile(`filename="?([^";]+)"?`)
+
+func extractFilename(mimeType string) string {
+	filename := "langchaingo"
+	if matches := filenameRegex.FindStringSubmatch(mimeType); len(matches) > 1 {
+		filename = matches[1]
+	}
+	return filename
+}
+
+func marshalAudioContent(content llms.BinaryContent) ([]byte, error) {
+	format := ""
+	if strings.HasPrefix(content.MIMEType, "audio/wav") {
+		format = "wav"
+	} else if strings.HasPrefix(content.MIMEType, "audio/mpeg") {
+		format = "mp3"
+	}
+
+	// see: https://platform.openai.com/docs/guides/audio?example=audio-in#add-audio-to-your-existing-application
+	return json.Marshal(map[string]any{
+		"type": "input_audio",
+		"input_audio": map[string]any{
+			"format": format,
+			"data":   content.Data,
+		},
+	})
+}
+
+type Base64Data struct {
+	MIMEType string
+	Data     []byte
+}
+
+func (bd Base64Data) MarshalJSON() ([]byte, error) {
+	var r []byte
+
+	mimeType := strings.Split(bd.MIMEType, ";")[0]
+
+	r = append(r, []byte(`"data:`)...)
+	r = append(r, []byte(mimeType)...)
+	r = append(r, []byte(";base64,")...)
+
+	b := bytes.NewBuffer(r)
+
+	_, err := base64.NewEncoder(base64.StdEncoding, b).Write(bd.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	r = b.Bytes()
+	r = append(r, '"')
+
+	return r, nil
+}

--- a/llms/openai/internal/openaiclient/content_test.go
+++ b/llms/openai/internal/openaiclient/content_test.go
@@ -1,0 +1,57 @@
+package openaiclient
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/tmc/langchaingo/llms"
+	"testing"
+)
+
+func TestContentPart_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		part     llms.ContentPart
+		expected string
+	}{
+		{
+			name:     "text content",
+			part:     llms.TextPart("Hello, world!"),
+			expected: `{"type":"text","text":"Hello, world!"}`,
+		},
+		{
+			name:     "image URL content",
+			part:     llms.ImageURLPart("https://example.com/image.png"),
+			expected: `{"type":"image_url","image_url":{"url":"https://example.com/image.png"}}`,
+		},
+		{
+			name:     "audio content: mp3",
+			part:     llms.BinaryPart("audio/mpeg", []byte{0x01, 0x02, 0x03}),
+			expected: `{"type":"input_audio","input_audio":{"format":"mp3","data":"AQID"}}`,
+		},
+		{
+			name:     "audio content: wav",
+			part:     llms.BinaryPart("audio/wav", []byte{0x01, 0x02, 0x03}),
+			expected: `{"type":"input_audio","input_audio":{"format":"wav","data":"AQID"}}`,
+		},
+		{
+			name:     "file content: pdf",
+			part:     llms.BinaryPart("application/pdf", []byte{0x01, 0x02, 0x03}),
+			expected: `{"type":"file","file":{"filename":"langchaingo","file_data":"data:application/pdf;base64,AQID"}}`,
+		},
+		{
+			name:     "file content: pdf with filename",
+			part:     llms.BinaryPart("application/pdf; filename=test.pdf", []byte{0x01, 0x02, 0x03}),
+			expected: `{"type":"file","file":{"filename":"test.pdf","file_data":"data:application/pdf;base64,AQID"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(ContentPart{ContentPart: tt.part})
+			assert.NoError(t, err)
+			assert.JSONEq(t, tt.expected, string(data))
+		})
+	}
+}

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -56,7 +56,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 
 	chatMsgs := make([]*ChatMessage, 0, len(messages))
 	for _, mc := range messages {
-		msg := &ChatMessage{MultiContent: mc.Parts}
+		msg := &ChatMessage{}
 		switch mc.Role {
 		case llms.ChatMessageTypeSystem:
 			msg.Role = RoleSystem
@@ -96,7 +96,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		}
 
 		// Here we extract tool calls from the message and populate the ToolCalls field.
-		newParts, toolCalls := ExtractToolParts(msg)
+		newParts, toolCalls := extractParts(mc.Parts)
 		msg.MultiContent = newParts
 		msg.ToolCalls = toolCallsFromToolCalls(toolCalls)
 
@@ -218,18 +218,17 @@ func (o *LLM) CreateEmbedding(ctx context.Context, inputTexts []string) ([][]flo
 	return embeddings, nil
 }
 
-// ExtractToolParts extracts the tool parts from a message.
-func ExtractToolParts(msg *ChatMessage) ([]llms.ContentPart, []llms.ToolCall) {
-	var content []llms.ContentPart
+func extractParts(parts []llms.ContentPart) ([]openaiclient.ContentPart, []llms.ToolCall) {
+	var content []openaiclient.ContentPart
 	var toolCalls []llms.ToolCall
-	for _, part := range msg.MultiContent {
+	for _, part := range parts {
 		switch p := part.(type) {
 		case llms.TextContent:
-			content = append(content, p)
+			content = append(content, openaiclient.ContentPart{ContentPart: p})
 		case llms.ImageURLContent:
-			content = append(content, p)
+			content = append(content, openaiclient.ContentPart{ContentPart: p})
 		case llms.BinaryContent:
-			content = append(content, p)
+			content = append(content, openaiclient.ContentPart{ContentPart: p})
 		case llms.ToolCall:
 			toolCalls = append(toolCalls, p)
 		}


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

In this PR the binary content will be handled properly. This will fix the issue [#958 - Unable to send BinaryPart to OpenAI Completions API](https://github.com/tmc/langchaingo/issues/958)

I know that the endpoint (currently) supports only PDF-Files. But instead to check the mime type I decided to let pass through the content to openai and let them generate a proper error message. And maybe they will support other content in the future :shrug: 