### PR TITLE
vectorstores: add WithEndpoint option for Azure AI Search

### DIFF
--- a/vectorstores/azureaisearch/azureaisearch_httprr_test.go
+++ b/vectorstores/azureaisearch/azureaisearch_httprr_test.go
@@ -47,14 +47,11 @@ func TestStoreHTTPRR_CreateIndex(t *testing.T) {
 		apiKey = envKey
 	}
 
-	// Set endpoint via environment variable
-	os.Setenv("AZURE_AI_SEARCH_ENDPOINT", endpoint)
-	defer os.Unsetenv("AZURE_AI_SEARCH_ENDPOINT")
-
 	store, err := New(
 		WithAPIKey(apiKey),
 		WithEmbedder(&mockEmbedder{}),
 		WithHTTPClient(rr.Client()),
+		WithEndpoint(endpoint),
 	)
 	require.NoError(t, err)
 
@@ -83,14 +80,11 @@ func TestStoreHTTPRR_AddDocuments(t *testing.T) {
 		apiKey = envKey
 	}
 
-	// Set endpoint via environment variable
-	os.Setenv("AZURE_AI_SEARCH_ENDPOINT", endpoint)
-	defer os.Unsetenv("AZURE_AI_SEARCH_ENDPOINT")
-
 	store, err := New(
 		WithAPIKey(apiKey),
 		WithEmbedder(&mockEmbedder{}),
 		WithHTTPClient(rr.Client()),
+		WithEndpoint(endpoint),
 	)
 	require.NoError(t, err)
 
@@ -136,14 +130,11 @@ func TestStoreHTTPRR_SimilaritySearch(t *testing.T) {
 		apiKey = envKey
 	}
 
-	// Set endpoint via environment variable
-	os.Setenv("AZURE_AI_SEARCH_ENDPOINT", endpoint)
-	defer os.Unsetenv("AZURE_AI_SEARCH_ENDPOINT")
-
 	store, err := New(
 		WithAPIKey(apiKey),
 		WithEmbedder(&mockEmbedder{}),
 		WithHTTPClient(rr.Client()),
+		WithEndpoint(endpoint),
 	)
 	require.NoError(t, err)
 
@@ -173,14 +164,11 @@ func TestStoreHTTPRR_DeleteIndex(t *testing.T) {
 		apiKey = envKey
 	}
 
-	// Set endpoint via environment variable
-	os.Setenv("AZURE_AI_SEARCH_ENDPOINT", endpoint)
-	defer os.Unsetenv("AZURE_AI_SEARCH_ENDPOINT")
-
 	store, err := New(
 		WithAPIKey(apiKey),
 		WithEmbedder(&mockEmbedder{}),
 		WithHTTPClient(rr.Client()),
+		WithEndpoint(endpoint),
 	)
 	require.NoError(t, err)
 
@@ -208,14 +196,11 @@ func TestStoreHTTPRR_ListIndexes(t *testing.T) {
 		apiKey = envKey
 	}
 
-	// Set endpoint via environment variable
-	os.Setenv("AZURE_AI_SEARCH_ENDPOINT", endpoint)
-	defer os.Unsetenv("AZURE_AI_SEARCH_ENDPOINT")
-
 	store, err := New(
 		WithAPIKey(apiKey),
 		WithEmbedder(&mockEmbedder{}),
 		WithHTTPClient(rr.Client()),
+		WithEndpoint(endpoint),
 	)
 	require.NoError(t, err)
 

--- a/vectorstores/azureaisearch/options.go
+++ b/vectorstores/azureaisearch/options.go
@@ -68,6 +68,13 @@ func WithAPIKey(azureAISearchAPIKey string) Option {
 	}
 }
 
+// WithEndpoint is an option for setting the azure AI search endpoint.
+func WithEndpoint(endpoint string) Option {
+	return func(s *Store) {
+		s.azureAISearchEndpoint = strings.TrimSuffix(endpoint, "/")
+	}
+}
+
 func applyClientOptions(s *Store, opts ...Option) error {
 	for _, opt := range opts {
 		opt(s)


### PR DESCRIPTION
### Description

Currently, the only way to configure the target endpoint for the Azure AI Search vector store is through the environment variable `AZURE_AI_SEARCH_ENDPOINT`. 
This PR adds the ability to configure the endpoint during store construction, consistent with other configuration options.

#### Existing implementation 

https://github.com/tmc/langchaingo/blob/main/vectorstores/chroma/options.go#L35

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
