### PR TITLE
feat: new chains.ChatChain that uses Model.GenerateContent(...)

### DIFF
--- a/chains/chat.go
+++ b/chains/chat.go
@@ -1,0 +1,96 @@
+package chains
+
+import (
+	"context"
+	"errors"
+
+	"github.com/tmc/langchaingo/callbacks"
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/memory"
+	"github.com/tmc/langchaingo/outputparser"
+	"github.com/tmc/langchaingo/prompts"
+	"github.com/tmc/langchaingo/schema"
+)
+
+const _chatChainDefaultOutputKey = "text"
+
+type ChatChain struct {
+	Prompt           prompts.MessageFormatter
+	LLM              llms.Model
+	Memory           schema.Memory
+	CallbacksHandler callbacks.Handler
+	OutputParser     schema.OutputParser[any]
+
+	OutputKey string
+}
+
+var (
+	_ Chain                  = &ChatChain{}
+	_ callbacks.HandlerHaver = &ChatChain{}
+)
+
+// NewChatChain creates a new ChatChain with an LLM and a prompt.
+func NewChatChain(llm llms.Model, prompt prompts.MessageFormatter, opts ...ChainCallOption) *ChatChain {
+	opt := &chainCallOption{}
+	for _, o := range opts {
+		o(opt)
+	}
+	chain := &ChatChain{
+		Prompt:           prompt,
+		LLM:              llm,
+		OutputParser:     outputparser.NewSimple(),
+		Memory:           memory.NewSimple(),
+		OutputKey:        _chatChainDefaultOutputKey,
+		CallbacksHandler: opt.CallbackHandler,
+	}
+
+	return chain
+}
+
+// Call formats the messages with the input values, generates using the llm, and parses
+// the output from the llm with the output parser. This function should not be called
+// directly, use rather the Call or Run function if the prompt only requires one input
+// value.
+func (c ChatChain) Call(ctx context.Context, values map[string]any, options ...ChainCallOption) (map[string]any, error) {
+	msgs, err := c.Prompt.FormatMessages(values)
+	if err != nil {
+		return nil, err
+	}
+
+	messageContent := make([]llms.MessageContent, len(msgs))
+	for i, msg := range msgs {
+		messageContent[i] = llms.TextParts(msg.GetType(), msg.GetContent())
+	}
+
+	resp, err := c.LLM.GenerateContent(ctx, messageContent, getLLMCallOptions(options...)...)
+	if err != nil {
+		return nil, err
+	}
+
+	choices := resp.Choices
+	if len(choices) < 1 {
+		return nil, errors.New("empty response from model")
+	}
+	c1 := choices[0]
+
+	return map[string]any{c.OutputKey: c1.Content}, nil
+}
+
+// GetMemory returns the memory of the chain.
+func (c ChatChain) GetMemory() schema.Memory {
+	return c.Memory
+}
+
+func (c ChatChain) GetCallbackHandler() callbacks.Handler { //nolint:ireturn
+	return c.CallbacksHandler
+}
+
+// GetInputKeys returns the expected input keys.
+func (c ChatChain) GetInputKeys() []string {
+	return append([]string{}, c.Prompt.GetInputVariables()...)
+}
+
+// GetOutputKeys returns the output keys the chain will return.
+func (c ChatChain) GetOutputKeys() []string {
+	return []string{c.OutputKey}
+}


### PR DESCRIPTION
Introduces a new chain type that allows chaining a `prompts.MessageFormatter` with an `llms.Model`. In contrast to the `LLMChain`, it uses `Model.GenerateContent(...)`, using separate messages instead of a single message.

## Remarks

Draft PR, because I'm not sure if this is the direction we should go. Tests and examples are missing and will be added once the direction is clear.

### General objective of this change

My main goal is to be able to have a way to combine a prompt template `prompts.MessageFormatter` with an `llms.Model`, so that I can easily re-use it. I think the combination of `prompt x model x model config` is quite common, but there is currently no way to achieve this.

There is already another similar chain (`chains.LLMChain`), but it uses `llms.GenerateFromSinglePrompt` and `prompts.FormatPrompter.FormatPrompt(values map[string]any).String()` which does not create separate messages with the correct message type, but renders all messages into a single message. That's not really compatible with most chat API's.

### Current workaround

`prompts.FormatMessages(values map[string]any)` returns `[]llms.ChatMessage` (interface) which is not directly compatible with `llms.Model.GenerateContent(ctx context.Context, messages []MessageContent, options ...CallOption) (*ContentResponse, error)`. A simple for-loop is required, e.g.:

```go
msgs, err := tmpl.FormatMessages(data)
if err != nil {
	return nil, fmt.Errorf("failed to format messages: %w", err)
}
contents := make([]llms.MessageContent, len(msgs))
for i, msg := range msgs {
	contents[i] = llms.TextParts(msg.GetType(), msg.GetContent())
}
// use contents in llms.GenerateContent
```

### State of the `chains` package

The `chains` package seems to be a bit behind the llms package. `chains.Call` accepts `chains.ChainCallOption` as options and has a private mapping function `getLLMCallOptions` that converts the options into `llms.CallOption`. It seems like this function currently doesn't support all options, e.g. `llms.CallOptions.JSONMode`. To me, this feels like a design flaw, because changes in the `llms` package require changes in the `chains` package to keep it usable.

### Alternative A

It might also be helpful to add another function to the concrete types in the `prompts` package that returns `[]llms.MessageContent` which can be passed to `llms.GenerateContent(...)`. This would help avoiding the conversion step.

### Alternative B

A more disruptive change would be to have `llms.GenerateContent(...)` accept an interface type instead of a struct type, similar to how `http.NewRequest` accepts an `io.Reader` as body instead of `[]byte` ([docs](https://pkg.go.dev/net/http#NewRequest)). This would probably be the most versatile approach, but it would probably break a lot of code. We could introduce a helper function that converts `[]llms.MessageContent` into the new interface type to make it easy to fix the breaking change.
