### PR TITLE
agents: Add more robust response handling to executor.go

### DIFF
--- a/agents/executor.go
+++ b/agents/executor.go
@@ -134,7 +134,7 @@ func (e *Executor) doAction(
 		}), nil
 	}
 
-	observation, err := tool.Call(ctx, action.ToolInput)
+	observation, err := tool.Call(ctx, strings.TrimSuffix(action.ToolInput, "\nObservation:"))
 	if err != nil {
 		return nil, err
 	}

--- a/agents/executor_test.go
+++ b/agents/executor_test.go
@@ -23,6 +23,7 @@ type testAgent struct {
 	err        error
 	inputKeys  []string
 	outputKeys []string
+	tools      []tools.Tool
 
 	recordedIntermediateSteps []schema.AgentStep
 	recordedInputs            map[string]string
@@ -50,7 +51,7 @@ func (a testAgent) GetOutputKeys() []string {
 }
 
 func (a *testAgent) GetTools() []tools.Tool {
-	return nil
+	return a.tools
 }
 
 func TestExecutorWithErrorHandler(t *testing.T) {
@@ -170,4 +171,60 @@ func TestExecutorWithOpenAIFunctionAgent(t *testing.T) {
 
 	require.True(t, strings.Contains(result, "2012") || strings.Contains(result, "March"),
 		"correct answer 2012 or March not in response")
+}
+
+// mockTool implements the tools.Tool interface for testing
+type mockTool struct {
+	name             string
+	description      string
+	receivedInputPtr *string
+}
+
+func (m *mockTool) Name() string {
+	return m.name
+}
+
+func (m *mockTool) Description() string {
+	return m.description
+}
+
+func (m *mockTool) Call(_ context.Context, input string) (string, error) {
+	*m.receivedInputPtr = input
+	return "mock result", nil
+}
+
+func TestExecutorTrimsObservationSuffix(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Create a mock tool that records what input it receives
+	var receivedInput string
+	mockToolInst := &mockTool{
+		name:             "mock_tool",
+		description:      "A mock tool for testing",
+		receivedInputPtr: &receivedInput,
+	}
+
+	// Create a test agent that returns an action with trailing "\nObservation:"
+	testAgent := &testAgent{
+		actions: []schema.AgentAction{
+			{
+				Tool:      "mock_tool",
+				ToolInput: "test input\nObservation:",
+				Log:       "Action: mock_tool\nAction Input: test input\nObservation:",
+			},
+		},
+		inputKeys:  []string{"input"},
+		outputKeys: []string{"output"},
+		tools:      []tools.Tool{mockToolInst},
+	}
+
+	executor := agents.NewExecutor(testAgent, agents.WithMaxIterations(1))
+
+	_, err := chains.Call(ctx, executor, map[string]any{"input": "test question"})
+	// We expect ErrNotFinished since our test agent doesn't provide a finish action
+	require.ErrorIs(t, err, agents.ErrNotFinished)
+
+	// Verify that the tool received the input with "\nObservation:" trimmed off
+	require.Equal(t, "test input", receivedInput, "Tool should receive input with \\nObservation: suffix trimmed")
 }

--- a/agents/markl_test.go
+++ b/agents/markl_test.go
@@ -36,6 +36,16 @@ func TestMRKLOutputParser(t *testing.T) {
 			expectedFinish: nil,
 			expectedErr:    nil,
 		},
+		{
+			input: "Action: calculator\nAction Input: 5 + 3\nObservation:",
+			expectedActions: []schema.AgentAction{{
+				Tool:      "calculator",
+				ToolInput: "5 + 3\nObservation:",
+				Log:       "Action: calculator\nAction Input: 5 + 3\nObservation:",
+			}},
+			expectedFinish: nil,
+			expectedErr:    nil,
+		},
 	}
 
 	a := OneShotZeroAgent{}


### PR DESCRIPTION
fix a bug that cause params error


### PR Checklist

- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
