### PR TITLE
fix: ensure googleai schema conversion works with nested objects and arrays

### DIFF
--- a/llms/googleai/googleai.go
+++ b/llms/googleai/googleai.go
@@ -370,6 +370,93 @@ DoStream:
 	return convertCandidates([]*genai.Candidate{candidate}, mresp.UsageMetadata)
 }
 
+// convertSchemaRecursive recursively converts a schema map to a genai.Schema
+func convertSchemaRecursive(schemaMap map[string]any, toolIndex int, propertyPath string) (*genai.Schema, error) {
+	schema := &genai.Schema{}
+
+	if ty, ok := schemaMap["type"]; ok {
+		tyString, ok := ty.(string)
+		if !ok {
+			return nil, fmt.Errorf("tool [%d], property [%s]: expected string for type", toolIndex, propertyPath)
+		}
+		schema.Type = convertToolSchemaType(tyString)
+	}
+
+	if desc, ok := schemaMap["description"]; ok {
+		descString, ok := desc.(string)
+		if !ok {
+			return nil, fmt.Errorf("tool [%d], property [%s]: expected string for description", toolIndex, propertyPath)
+		}
+		schema.Description = descString
+	}
+
+	// Handle object properties recursively
+	if properties, ok := schemaMap["properties"]; ok {
+		propMap, ok := properties.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("tool [%d], property [%s]: expected map for properties", toolIndex, propertyPath)
+		}
+
+		schema.Properties = make(map[string]*genai.Schema)
+		for propName, propValue := range propMap {
+			valueMap, ok := propValue.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("tool [%d], property [%s.%s]: expect to find a value map", toolIndex, propertyPath, propName)
+			}
+
+			nestedPath := propName
+			if propertyPath != "" {
+				nestedPath = propertyPath + "." + propName
+			}
+
+			nestedSchema, err := convertSchemaRecursive(valueMap, toolIndex, nestedPath)
+			if err != nil {
+				return nil, err
+			}
+			schema.Properties[propName] = nestedSchema
+		}
+	} else if schema.Type == genai.TypeObject && propertyPath == "" {
+		// For top-level object schemas without properties, this is an error
+		return nil, fmt.Errorf("tool [%d]: expected to find a map of properties", toolIndex)
+	}
+
+	// Handle array items recursively
+	if items, ok := schemaMap["items"]; ok && schema.Type == genai.TypeArray {
+		itemMap, ok := items.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("tool [%d], property [%s]: expect to find a map for array items", toolIndex, propertyPath)
+		}
+
+		itemsPath := propertyPath + "[]"
+		itemsSchema, err := convertSchemaRecursive(itemMap, toolIndex, itemsPath)
+		if err != nil {
+			return nil, err
+		}
+		schema.Items = itemsSchema
+	}
+
+	// Handle required fields
+	if required, ok := schemaMap["required"]; ok {
+		if rs, ok := required.([]string); ok {
+			schema.Required = rs
+		} else if ri, ok := required.([]interface{}); ok {
+			rs := make([]string, 0, len(ri))
+			for _, r := range ri {
+				rString, ok := r.(string)
+				if !ok {
+					return nil, fmt.Errorf("tool [%d], property [%s]: expected string for required", toolIndex, propertyPath)
+				}
+				rs = append(rs, rString)
+			}
+			schema.Required = rs
+		} else {
+			return nil, fmt.Errorf("tool [%d], property [%s]: expected array for required", toolIndex, propertyPath)
+		}
+	}
+
+	return schema, nil
+}
+
 // convertTools converts from a list of langchaingo tools to a list of genai
 // tools.
 func convertTools(tools []llms.Tool) ([]*genai.Tool, error) {
@@ -403,60 +490,9 @@ func convertTools(tools []llms.Tool) ([]*genai.Tool, error) {
 			return nil, fmt.Errorf("tool [%d]: unsupported type %T of Parameters", i, tool.Function.Parameters)
 		}
 
-		schema := &genai.Schema{}
-		if ty, ok := params["type"]; ok {
-			tyString, ok := ty.(string)
-			if !ok {
-				return nil, fmt.Errorf("tool [%d]: expected string for type", i)
-			}
-			schema.Type = convertToolSchemaType(tyString)
-		}
-
-		paramProperties, ok := params["properties"].(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("tool [%d]: expected to find a map of properties", i)
-		}
-
-		schema.Properties = make(map[string]*genai.Schema)
-		for propName, propValue := range paramProperties {
-			valueMap, ok := propValue.(map[string]any)
-			if !ok {
-				return nil, fmt.Errorf("tool [%d], property [%v]: expect to find a value map", i, propName)
-			}
-			schema.Properties[propName] = &genai.Schema{}
-
-			if ty, ok := valueMap["type"]; ok {
-				tyString, ok := ty.(string)
-				if !ok {
-					return nil, fmt.Errorf("tool [%d]: expected string for type", i)
-				}
-				schema.Properties[propName].Type = convertToolSchemaType(tyString)
-			}
-			if desc, ok := valueMap["description"]; ok {
-				descString, ok := desc.(string)
-				if !ok {
-					return nil, fmt.Errorf("tool [%d]: expected string for description", i)
-				}
-				schema.Properties[propName].Description = descString
-			}
-		}
-
-		if required, ok := params["required"]; ok {
-			if rs, ok := required.([]string); ok {
-				schema.Required = rs
-			} else if ri, ok := required.([]interface{}); ok {
-				rs := make([]string, 0, len(ri))
-				for _, r := range ri {
-					rString, ok := r.(string)
-					if !ok {
-						return nil, fmt.Errorf("tool [%d]: expected string for required", i)
-					}
-					rs = append(rs, rString)
-				}
-				schema.Required = rs
-			} else {
-				return nil, fmt.Errorf("tool [%d]: expected string for required", i)
-			}
+		schema, err := convertSchemaRecursive(params, i, "")
+		if err != nil {
+			return nil, err
 		}
 		genaiFuncDecl.Parameters = schema
 


### PR DESCRIPTION

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

Similar to https://github.com/langchain-ai/langchain-google/pull/882, this adds support for nested objects both in arrays as well as other objects inside of the parameters of a tool definition. Prior to this fix, I was receiving 400s back from Google for arrays that were missing an `items` property (though they were defined in the `llm.Tool`), as well as missing `properties` on nested arrays.
