### PR TITLE
mongovector: fix expected error string in non-tokenized filter test

### DIFF
--- a/vectorstores/mongovector/mongovector_test.go
+++ b/vectorstores/mongovector/mongovector_test.go
@@ -723,7 +723,7 @@ func TestStore_SimilaritySearch_NonExactQuery(t *testing.T) {
 				vectorstores.WithFilters(bson.D{{Key: "pageContent", Value: "v0001"}}),
 				vectorstores.WithEmbedder(newMockEmbedder(testIndexSize1536)),
 			},
-			wantErr: "'pageContent' needs to be indexed as token",
+			wantErr: "'pageContent' needs to be indexed as filter",
 		},
 		{name: "with deduplicator",
 			numDocuments: 1,


### PR DESCRIPTION
The expected MongoDB error string for a specifying a non-tokenized filter changed with the latest `mongodb/mongodb-atlas-local` testcontainer image. Update the expected error string in the `TestStore_SimilaritySearch_NonExactQuery/with_non-tokenized_filter` test to match the new server error.

### PR Checklist

- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
