### PR TITLE
[BugFix] SSE comment line decoding error

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -447,11 +447,11 @@ func parseStreamingChatResponse(ctx context.Context, r *http.Response, payload *
 			}
 
 			// Ignore SSE comment line
-			if !strings.HasPrefix(line, ": ") {
+			if strings.HasPrefix(line, ": ") {
 				continue
 			}
 
-			data := strings.TrimPrefix(line, "data: ") // here use `data:` instead of `data: ` for compatibility
+			data := strings.TrimPrefix(line, "data:") // here use `data:` instead of `data: ` for compatibility
 			data = strings.TrimSpace(data)
 			if data == "[DONE]" {
 				return


### PR DESCRIPTION
### PR Checklist
Fixes https://github.com/tmc/langchaingo/issues/942

https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events
>  Messages in the event stream are separated by a pair of newline characters. A colon as the first character of a line is in essence a comment, and is ignored.

The current implement returns error  `error decoding streaming response: invalid character ':' looking for beginning of value` when there're  SSE comments in the stream.
This PR ignores the SSE comments and avoid decoding error.

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
