### PR TITLE
llms/anthropic: allow streaming responses with tool use

### DIFF
--- a/llms/anthropic/anthropicllm.go
+++ b/llms/anthropic/anthropicllm.go
@@ -196,7 +196,7 @@ func generateMessagesContent(ctx context.Context, o *LLM, messages []llms.Messag
 					},
 				}
 			} else {
-				return nil, fmt.Errorf("anthropic: %w for tool use message", ErrInvalidContentType)
+				return nil, fmt.Errorf("anthropic: %w for tool use message %T", ErrInvalidContentType, content)
 			}
 		default:
 			return nil, fmt.Errorf("anthropic: %w: %v", ErrUnsupportedContentType, content.GetType())

--- a/llms/anthropic/internal/anthropicclient/messages.go
+++ b/llms/anthropic/internal/anthropicclient/messages.go
@@ -14,16 +14,18 @@ import (
 )
 
 var (
-	ErrInvalidEventType        = fmt.Errorf("invalid event type field type")
-	ErrInvalidMessageField     = fmt.Errorf("invalid message field type")
-	ErrInvalidUsageField       = fmt.Errorf("invalid usage field type")
-	ErrInvalidIndexField       = fmt.Errorf("invalid index field type")
-	ErrInvalidDeltaField       = fmt.Errorf("invalid delta field type")
-	ErrInvalidDeltaTypeField   = fmt.Errorf("invalid delta type field type")
-	ErrInvalidDeltaTextField   = fmt.Errorf("invalid delta text field type")
-	ErrContentIndexOutOfRange  = fmt.Errorf("content index out of range")
-	ErrFailedCastToTextContent = fmt.Errorf("failed to cast content to TextContent")
-	ErrInvalidFieldType        = fmt.Errorf("invalid field type")
+	ErrInvalidEventType             = fmt.Errorf("invalid event type field type")
+	ErrInvalidMessageField          = fmt.Errorf("invalid message field type")
+	ErrInvalidUsageField            = fmt.Errorf("invalid usage field type")
+	ErrInvalidIndexField            = fmt.Errorf("invalid index field type")
+	ErrInvalidDeltaField            = fmt.Errorf("invalid delta field type")
+	ErrInvalidDeltaTypeField        = fmt.Errorf("invalid delta type field type")
+	ErrInvalidDeltaTextField        = fmt.Errorf("invalid delta text field type")
+	ErrInvalidDeltaPartialJSONField = fmt.Errorf("invalid delta partial_json field type")
+	ErrContentIndexOutOfRange       = fmt.Errorf("content index out of range")
+	ErrFailedCastToTextContent      = fmt.Errorf("failed to cast content to TextContent")
+	ErrFailedCastToToolUseContent   = fmt.Errorf("failed to cast content to ToolUseContent")
+	ErrInvalidFieldType             = fmt.Errorf("invalid field type")
 )
 
 type ChatMessage struct {
@@ -86,6 +88,8 @@ type ToolUseContent struct {
 	ID    string                 `json:"id"`
 	Name  string                 `json:"name"`
 	Input map[string]interface{} `json:"input"`
+
+	inputData string `json:"-"` // Used to gather input data when streaming
 }
 
 func (tuc ToolUseContent) GetType() string {
@@ -276,7 +280,7 @@ func processStreamEvent(ctx context.Context, event map[string]interface{}, paylo
 	case "content_block_delta":
 		return handleContentBlockDeltaEvent(ctx, event, response, payload)
 	case "content_block_stop":
-		// Nothing to do here
+		return handleContentBlockStop(event, response)
 	case "message_delta":
 		return handleMessageDeltaEvent(event, response)
 	case "message_stop":
@@ -324,19 +328,43 @@ func handleContentBlockStartEvent(event map[string]interface{}, response Message
 	index := int(indexValue)
 
 	var eventType string
+	var contentBlock map[string]any
 	if cb, ok := event["content_block"].(map[string]any); ok {
+		contentBlock = cb
 		typ, _ := cb["type"].(string)
 		eventType = typ
 	}
+	if eventType == "" {
+		return response, fmt.Errorf("%w: content block type is empty", ErrInvalidDeltaField)
+	}
 
 	if len(response.Content) <= index {
-		response.Content = append(response.Content, &TextContent{
-			Type: eventType,
-		})
+		switch eventType {
+		case "text":
+			response.Content = append(response.Content, &TextContent{
+				Type: eventType,
+			})
+		case "tool_use":
+			input, ok := event["input"].(map[string]interface{})
+			if !ok {
+				// If the input is not provided, it may be coming in a future event.
+				input = make(map[string]interface{})
+			}
+
+			response.Content = append(response.Content, &ToolUseContent{
+				Type:  eventType,
+				ID:    getString(contentBlock, "id"),
+				Name:  getString(contentBlock, "name"),
+				Input: input,
+			})
+		default:
+			return response, fmt.Errorf("%w: unknown content block type: %s", ErrInvalidDeltaField, eventType)
+		}
 	}
 	return response, nil
 }
 
+// handleContentBlockDeltaEvent processes delta events for content blocks, handling both text and JSON deltas.
 func handleContentBlockDeltaEvent(ctx context.Context, event map[string]interface{}, response MessageResponsePayload, payload *messagePayload) (MessageResponsePayload, error) {
 	indexValue, ok := event["index"].(float64)
 	if !ok {
@@ -353,31 +381,79 @@ func handleContentBlockDeltaEvent(ctx context.Context, event map[string]interfac
 		return response, ErrInvalidDeltaTypeField
 	}
 
-	if deltaType == "text_delta" {
-		text, ok := delta["text"].(string)
-		if !ok {
-			return response, ErrInvalidDeltaTextField
-		}
-		if len(response.Content) <= index {
-			return response, ErrContentIndexOutOfRange
-		}
-		textContent, ok := response.Content[index].(*TextContent)
-		if !ok {
-			return response, ErrFailedCastToTextContent
-		}
-		textContent.Text += text
+	if len(response.Content) <= index {
+		return response, ErrContentIndexOutOfRange
 	}
 
+	switch deltaType {
+	case "text_delta":
+		return handleTextDelta(ctx, delta, response, payload, index)
+	case "input_json_delta":
+		return handleJSONDelta(delta, response, index)
+	}
+
+	return response, nil
+}
+
+// handleTextDelta processes text delta events for content blocks.
+func handleTextDelta(ctx context.Context, delta map[string]interface{}, response MessageResponsePayload, payload *messagePayload, index int) (MessageResponsePayload, error) {
+	text, ok := delta["text"].(string)
+	if !ok {
+		return response, ErrInvalidDeltaTextField
+	}
+	textContent, ok := response.Content[index].(*TextContent)
+	if !ok {
+		return response, ErrFailedCastToTextContent
+	}
+	textContent.Text += text
+
+	// Streaming functions only work with text deltas.
 	if payload.StreamingFunc != nil {
-		text, ok := delta["text"].(string)
-		if !ok {
-			return response, ErrInvalidDeltaTextField
-		}
 		err := payload.StreamingFunc(ctx, []byte(text))
 		if err != nil {
 			return response, fmt.Errorf("streaming func returned an error: %w", err)
 		}
 	}
+
+	return response, nil
+}
+
+// handleJSONDelta processes JSON delta events for content blocks.
+func handleJSONDelta(delta map[string]interface{}, response MessageResponsePayload, index int) (MessageResponsePayload, error) {
+	partialJSON, ok := delta["partial_json"].(string)
+	if !ok {
+		return response, ErrInvalidDeltaPartialJSONField
+	}
+	toolUseContent, ok := response.Content[index].(*ToolUseContent)
+	if !ok {
+		return response, ErrFailedCastToToolUseContent
+	}
+	toolUseContent.inputData += partialJSON
+
+	return response, nil
+}
+
+func handleContentBlockStop(event map[string]interface{}, response MessageResponsePayload) (MessageResponsePayload, error) {
+	indexValue, ok := event["index"].(float64)
+	if !ok {
+		return response, ErrInvalidIndexField
+	}
+
+	index := int(indexValue)
+	if len(response.Content) <= index {
+		return response, ErrContentIndexOutOfRange
+	}
+	if toolUseContent, ok := response.Content[index].(*ToolUseContent); ok {
+		toolUseContent.inputData = strings.TrimSpace(toolUseContent.inputData)
+		if toolUseContent.inputData != "" {
+			var input map[string]interface{}
+			if err := json.Unmarshal([]byte(toolUseContent.inputData), &input); err != nil {
+				return response, fmt.Errorf("failed to unmarshal input data: %w", err)
+			}
+			toolUseContent.Input = input
+		}
+	}
+
 	return response, nil
 }
 

--- a/llms/anthropic/internal/anthropicclient/messages_test.go
+++ b/llms/anthropic/internal/anthropicclient/messages_test.go
@@ -1,0 +1,170 @@
+package anthropicclient
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_parseStreamingMessageResponse_withEmptyInput(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	response := createSSEResponse(SSEDataWithEmptyInput)
+	defer response.Body.Close()
+	payload := &messagePayload{}
+
+	result, err := parseStreamingMessageResponse(ctx, response, payload)
+
+	// Verify results
+	require.NoError(t, err, "Parsing should complete without errors")
+	require.NotNil(t, result, "Result should not be nil")
+
+	// Additional assertions could verify specific content parsed from the SSE stream
+	require.Equal(t, "msg_01KpsxABJ1CZwpfVuT6XFz7T", result.ID, "Message ID should match expected value")
+	require.Equal(t, "claude-3-7-sonnet-latest", result.Model, "Model should match expected value")
+	require.Equal(t, "assistant", result.Role, "Role should be 'assistant'")
+	require.Len(t, result.Content, 2, "Content should contain two blocks")
+
+	firstContent, ok := result.Content[0].(*TextContent)
+	require.True(t, ok, "First content block should be of type TextContent")
+	require.Equal(t, "I can help you find your current IP address. Let me retrieve that information for you.", firstContent.Text, "First content block text should match expected value")
+
+	secondContent, ok := result.Content[1].(*ToolUseContent)
+	require.True(t, ok, "Second content block should be of type ToolUseContent")
+	require.Equal(t, "get_current_ip_address", secondContent.Name, "Tool use name should match expected value")
+	require.Empty(t, secondContent.Input, "Tool use input should be empty")
+}
+
+func Test_parseStreamingMessageResponse_withInputJSONDeltas(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	response := createSSEResponse(SSEDataWithInputJSONDeltas)
+	defer response.Body.Close()
+	payload := &messagePayload{}
+
+	result, err := parseStreamingMessageResponse(ctx, response, payload)
+
+	// Verify results
+	require.NoError(t, err, "Parsing should complete without errors")
+	require.NotNil(t, result, "Result should not be nil")
+
+	// Additional assertions could verify specific content parsed from the SSE stream
+	require.Equal(t, "msg_01QdDq6hdDLd5v9fndWvs43Z", result.ID, "Message ID should match expected value")
+	require.Equal(t, "claude-3-7-sonnet-latest", result.Model, "Model should match expected value")
+	require.Equal(t, "assistant", result.Role, "Role should be 'assistant'")
+	require.Len(t, result.Content, 2, "Content should contain two blocks")
+
+	firstContent, ok := result.Content[0].(*TextContent)
+	require.True(t, ok, "First content block should be of type TextContent")
+	require.Equal(t, "I can help you get the current time. Let me check that for you.", firstContent.Text, "First content block text should match expected value")
+
+	secondContent, ok := result.Content[1].(*ToolUseContent)
+	require.True(t, ok, "Second content block should be of type ToolUseContent")
+	require.Equal(t, "get_current_time", secondContent.Name, "Tool use name should match expected value")
+	require.Equal(t, map[string]interface{}{
+		"format": "2006-01-02 15:04:05",
+	}, secondContent.Input, "Tool use input should match expected value")
+}
+
+// createAnthropicSSEResponse creates an HTTP response containing a simulated
+// Anthropic API server-sent events (SSE) stream.
+func createSSEResponse(data string) *http.Response {
+	recorder := httptest.NewRecorder()
+	recorder.Header().Set("Content-Type", "application/json")
+	recorder.WriteHeader(http.StatusOK)
+	if _, err := recorder.WriteString(data); err != nil {
+		panic(err)
+	}
+
+	return recorder.Result()
+}
+
+const SSEDataWithEmptyInput = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_01KpsxABJ1CZwpfVuT6XFz7T","type":"message","role":"assistant","model":"claude-3-7-sonnet-latest","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":417,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":2}}        }
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I can"}   }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" help you find your current IP address. Let me retrieve"}   }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" that information for you."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0        }
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01Lz8gVHwSEMLBTTDbTqGcia","name":"get_current_ip_address","input":{}}           }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}           }
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1          }
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":59}   }
+
+event: message_stop
+data: {"type":"message_stop"            }`
+
+const SSEDataWithInputJSONDeltas = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_01QdDq6hdDLd5v9fndWvs43Z","type":"message","role":"assistant","model":"claude-3-7-sonnet-latest","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":463,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":2}}    }
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}        }
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I can"}      }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" help you get the current time. Let"}        }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" me check that for you."}        }
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0   }
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01HSrVQU8QDxAsVwuAdbja45","name":"get_current_time","input":{}}             }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}    }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"for"}      }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"mat\": \"20"}          }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"06-01-0"}  }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"2 15:04:"}          }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"05\"}"}           }
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1          }
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":83}            }
+
+event: message_stop
+data: {"type":"message_stop"           }`


### PR DESCRIPTION
Fixes: #1248

## What:

This PR adds handling for content blocks with event types of `tool_use`. These are present when Anthropic returns tools call while streaming is on.


## Example data from Anthropic:

```
data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01HSrVQU8QDxAsVwuAdbja45","name":"get_current_time","input":{}}             }
event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}    }
event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"for"}      }
event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"mat\": \"20"}          }
event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"06-01-0"}  }
event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"2 15:04:"}          }
event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"05\"}"}           }
event: content_block_stop
data: {"type":"content_block_stop","index":1          }
event: message_delta
data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":83}            }
event: message_stop
data: {"type":"message_stop"           }
```

Note before we would error on type: `input_json_delta`. So before this PR any streaming request to Anthropic with tool use fail.
