### PR TITLE
fix: bedrock LLM add modelProvider to resolve "unsupported provider"

### DIFF
--- a/llms/bedrock/bedrockllm.go
+++ b/llms/bedrock/bedrockllm.go
@@ -15,6 +15,7 @@ const defaultModel = ModelAmazonTitanTextLiteV1
 
 // LLM is a Bedrock LLM implementation.
 type LLM struct {
+	modelProvider    string
 	modelID          string
 	client           *bedrockclient.Client
 	CallbacksHandler callbacks.Handler
@@ -33,6 +34,7 @@ func NewWithContext(ctx context.Context, opts ...Option) (*LLM, error) {
 	}
 	return &LLM{
 		client:           c,
+		modelProvider:    o.modelProvider,
 		modelID:          o.modelID,
 		CallbacksHandler: o.callbackHandler,
 	}, nil
@@ -81,7 +83,7 @@ func (l *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		return nil, err
 	}
 
-	res, err := l.client.CreateCompletion(ctx, opts.Model, m, opts)
+	res, err := l.client.CreateCompletion(ctx, l.modelProvider, opts.Model, m, opts)
 	if err != nil {
 		if l.CallbacksHandler != nil {
 			l.CallbacksHandler.HandleLLMError(ctx, err)

--- a/llms/bedrock/bedrockllm_option.go
+++ b/llms/bedrock/bedrockllm_option.go
@@ -9,6 +9,7 @@ import (
 type Option func(*options)
 
 type options struct {
+	modelProvider   string
 	modelID         string
 	client          *bedrockruntime.Client
 	callbackHandler callbacks.Handler
@@ -21,6 +22,16 @@ type options struct {
 func WithModel(modelID string) Option {
 	return func(o *options) {
 		o.modelID = modelID
+	}
+}
+
+// WithModelProvider allows setting a custom model provider.
+//
+// If not set, the default model provider is used
+// i.e. "anthropic".
+func WithModelProvider(modelProvider string) Option {
+	return func(o *options) {
+		o.modelProvider = modelProvider
 	}
 }
 

--- a/llms/bedrock/bedrockllm_unit_test.go
+++ b/llms/bedrock/bedrockllm_unit_test.go
@@ -27,6 +27,13 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
+			name: "with custom model provider",
+			opts: []Option{
+				WithClient(&bedrockruntime.Client{}),
+				WithModelProvider("anthropic"),
+			},
+		},
+		{
 			name: "with callback handler",
 			opts: []Option{
 				WithClient(&bedrockruntime.Client{}),

--- a/llms/bedrock/internal/bedrockclient/bedrockclient.go
+++ b/llms/bedrock/internal/bedrockclient/bedrockclient.go
@@ -33,9 +33,7 @@ func getProvider(modelID string) string {
 	if strings.Contains(modelID, ".nova-") || strings.Contains(modelID, "amazon.nova-") {
 		return "nova"
 	}
-	
 	parts := strings.Split(modelID, ".")
-	
 	// For backward compatibility with the original provider detection
 	switch {
 	case strings.Contains(modelID, "ai21"):
@@ -54,7 +52,7 @@ func getProvider(modelID string) string {
 	if len(parts) > 0 {
 		return parts[0]
 	}
-	
+
 	return ""
 }
 
@@ -68,11 +66,14 @@ func NewClient(client *bedrockruntime.Client) *Client {
 // CreateCompletion creates a new completion response from the provider
 // after sending the messages to the provider.
 func (c *Client) CreateCompletion(ctx context.Context,
+	provider string,
 	modelID string,
 	messages []Message,
 	options llms.CallOptions,
 ) (*llms.ContentResponse, error) {
-	provider := getProvider(modelID)
+	if provider == "" {
+		provider = getProvider(modelID)
+	}
 	switch provider {
 	case "ai21":
 		return createAi21Completion(ctx, c.client, modelID, messages, options)

--- a/llms/bedrock/internal/bedrockclient/bedrockclient_test.go
+++ b/llms/bedrock/internal/bedrockclient/bedrockclient_test.go
@@ -158,7 +158,7 @@ func TestCreateCompletion_UnsupportedProvider(t *testing.T) {
 	}
 	options := llms.CallOptions{}
 
-	_, err = client.CreateCompletion(context.Background(), "unsupported.model", messages, options)
+	_, err = client.CreateCompletion(context.Background(), "unsupported", "unsupported.model", messages, options)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported provider")
 }


### PR DESCRIPTION
Fixes: #1345 

This PR introduces a modelProvider field to the Bedrock LLM structure. Users can now specify the provider using bedrock.WithModelProvider("anthropic") to resolve issues where model IDs (e.g., us.anthropic.claude-3-7-sonnet-20250219-v1:0) could not be mapped to the correct provider.

