### PR TITLE
ollama: Add httprr test recordings for think parameter

### DIFF
--- a/llms/ollama/internal/ollamaclient/testdata/TestClient_GenerateChatWithThink.httprr
+++ b/llms/ollama/internal/ollamaclient/testdata/TestClient_GenerateChatWithThink.httprr
@@ -1,0 +1,73 @@
+httprr trace v1
+354 7193
+POST http://localhost:11434/api/chat HTTP/1.1
+Host: localhost:11434
+User-Agent: langchaingo-httprr
+Content-Length: 167
+Accept: application/x-ndjson
+Content-Type: application/json
+
+{"model":"gemma3:1b","messages":[{"role":"user","content":"What is 2+2? Show your reasoning."}],"format":"","options":{"num_predict":100,"temperature":0,"think":true}}HTTP/1.1 200 OK
+Transfer-Encoding: chunked
+Content-Type: application/x-ndjson
+Date: Fri, 08 Aug 2025 16:54:44 GMT
+
+1b94
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.761374Z","message":{"role":"assistant","content":"2"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.766371Z","message":{"role":"assistant","content":" +"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.771386Z","message":{"role":"assistant","content":" "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.783044Z","message":{"role":"assistant","content":"2"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.788086Z","message":{"role":"assistant","content":" ="},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.79315Z","message":{"role":"assistant","content":" "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.79823Z","message":{"role":"assistant","content":"4"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.80322Z","message":{"role":"assistant","content":"\n\n"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.808253Z","message":{"role":"assistant","content":"**"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.813283Z","message":{"role":"assistant","content":"Reason"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.818643Z","message":{"role":"assistant","content":"ing"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.823692Z","message":{"role":"assistant","content":":**"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.828715Z","message":{"role":"assistant","content":"\n\n"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.833748Z","message":{"role":"assistant","content":"Addition"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.838767Z","message":{"role":"assistant","content":" is"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.844394Z","message":{"role":"assistant","content":" simply"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.849315Z","message":{"role":"assistant","content":" combining"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.854514Z","message":{"role":"assistant","content":" two"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.859501Z","message":{"role":"assistant","content":" things"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.864494Z","message":{"role":"assistant","content":" to"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.869468Z","message":{"role":"assistant","content":" get"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.874433Z","message":{"role":"assistant","content":" a"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.879379Z","message":{"role":"assistant","content":" total"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.884667Z","message":{"role":"assistant","content":"."},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.889738Z","message":{"role":"assistant","content":" In"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.89474Z","message":{"role":"assistant","content":" this"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.899705Z","message":{"role":"assistant","content":" case"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.904642Z","message":{"role":"assistant","content":","},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.909616Z","message":{"role":"assistant","content":" we"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.919142Z","message":{"role":"assistant","content":" are"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.924633Z","message":{"role":"assistant","content":" combining"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.929622Z","message":{"role":"assistant","content":" two"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.934703Z","message":{"role":"assistant","content":" objects"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.939757Z","message":{"role":"assistant","content":" ("},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.94473Z","message":{"role":"assistant","content":"2"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.949817Z","message":{"role":"assistant","content":")"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.955022Z","message":{"role":"assistant","content":" and"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.960124Z","message":{"role":"assistant","content":" adding"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.965151Z","message":{"role":"assistant","content":" them"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.970106Z","message":{"role":"assistant","content":" together"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.975113Z","message":{"role":"assistant","content":"."},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.980164Z","message":{"role":"assistant","content":"  "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.98551Z","message":{"role":"assistant","content":"Therefore"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.990506Z","message":{"role":"assistant","content":","},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:44.995455Z","message":{"role":"assistant","content":" "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:45.000521Z","message":{"role":"assistant","content":"2"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:45.005602Z","message":{"role":"assistant","content":" +"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:45.010606Z","message":{"role":"assistant","content":" "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:45.015623Z","message":{"role":"assistant","content":"2"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:45.02087Z","message":{"role":"assistant","content":" equals"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:45.025969Z","message":{"role":"assistant","content":" "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:45.030955Z","message":{"role":"assistant","content":"4"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:45.035964Z","message":{"role":"assistant","content":"."},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:45.041073Z","message":{"role":"assistant","content":"\n"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:54:45.04636Z","message":{"role":"assistant","content":""},"done_reason":"stop","done":true,"total_duration":362837583,"load_duration":47294625,"prompt_eval_count":20,"prompt_eval_duration":29884000,"eval_count":55,"eval_duration":285425792}
+
+0
+

--- a/llms/ollama/testdata/TestWithThink.httprr
+++ b/llms/ollama/testdata/TestWithThink.httprr
@@ -1,0 +1,120 @@
+httprr trace v1
+352 13071
+POST http://localhost:11434/api/chat HTTP/1.1
+Host: localhost:11434
+User-Agent: langchaingo-httprr
+Content-Length: 165
+Accept: application/x-ndjson
+Content-Type: application/json
+
+{"model":"gemma3:1b","messages":[{"role":"user","content":"What is 2+2? Explain your reasoning step by step."}],"format":"","options":{"temperature":0,"think":true}}HTTP/1.1 200 OK
+Transfer-Encoding: chunked
+Content-Type: application/x-ndjson
+Date: Fri, 08 Aug 2025 16:53:41 GMT
+
+328a
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.657035Z","message":{"role":"assistant","content":"Okay"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.662064Z","message":{"role":"assistant","content":","},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.667596Z","message":{"role":"assistant","content":" let"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.67287Z","message":{"role":"assistant","content":"'"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.678017Z","message":{"role":"assistant","content":"s"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.683511Z","message":{"role":"assistant","content":" break"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.688519Z","message":{"role":"assistant","content":" down"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.693573Z","message":{"role":"assistant","content":" "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.69873Z","message":{"role":"assistant","content":"2"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.703749Z","message":{"role":"assistant","content":" +"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.708886Z","message":{"role":"assistant","content":" "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.714934Z","message":{"role":"assistant","content":"2"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.71996Z","message":{"role":"assistant","content":":"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.725076Z","message":{"role":"assistant","content":"\n\n"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.730215Z","message":{"role":"assistant","content":"1"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.735483Z","message":{"role":"assistant","content":"."},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.740465Z","message":{"role":"assistant","content":" **"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.745421Z","message":{"role":"assistant","content":"Understand"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.750788Z","message":{"role":"assistant","content":" the"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.755882Z","message":{"role":"assistant","content":" Basics"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.760964Z","message":{"role":"assistant","content":":**"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.766251Z","message":{"role":"assistant","content":" Addition"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.771285Z","message":{"role":"assistant","content":" is"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.77638Z","message":{"role":"assistant","content":" combining"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.781847Z","message":{"role":"assistant","content":" two"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.789176Z","message":{"role":"assistant","content":" things"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.794637Z","message":{"role":"assistant","content":" to"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.800026Z","message":{"role":"assistant","content":" get"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.805143Z","message":{"role":"assistant","content":" a"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.81025Z","message":{"role":"assistant","content":" total"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.815492Z","message":{"role":"assistant","content":"."},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.82064Z","message":{"role":"assistant","content":"\n\n"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.825856Z","message":{"role":"assistant","content":"2"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.830935Z","message":{"role":"assistant","content":"."},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.836302Z","message":{"role":"assistant","content":" **"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.841341Z","message":{"role":"assistant","content":"Identify"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.846512Z","message":{"role":"assistant","content":" the"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.852064Z","message":{"role":"assistant","content":" Numbers"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.857434Z","message":{"role":"assistant","content":":**"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.862897Z","message":{"role":"assistant","content":" We"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.868376Z","message":{"role":"assistant","content":" have"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.873507Z","message":{"role":"assistant","content":" two"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.87864Z","message":{"role":"assistant","content":" numbers"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.88419Z","message":{"role":"assistant","content":":"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.889305Z","message":{"role":"assistant","content":" "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.894326Z","message":{"role":"assistant","content":"2"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.899691Z","message":{"role":"assistant","content":" and"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.904789Z","message":{"role":"assistant","content":" "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.909832Z","message":{"role":"assistant","content":"2"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.915048Z","message":{"role":"assistant","content":"."},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.920264Z","message":{"role":"assistant","content":"\n\n"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.925449Z","message":{"role":"assistant","content":"3"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.930817Z","message":{"role":"assistant","content":"."},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.936077Z","message":{"role":"assistant","content":" **"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.941287Z","message":{"role":"assistant","content":"Perform"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.946389Z","message":{"role":"assistant","content":" the"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.951831Z","message":{"role":"assistant","content":" Addition"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.956996Z","message":{"role":"assistant","content":":**"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.962196Z","message":{"role":"assistant","content":"  "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.96765Z","message":{"role":"assistant","content":"Simply"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.972835Z","message":{"role":"assistant","content":" add"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.978028Z","message":{"role":"assistant","content":" the"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.983651Z","message":{"role":"assistant","content":" numbers"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.988776Z","message":{"role":"assistant","content":" together"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:41.993929Z","message":{"role":"assistant","content":":"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.000133Z","message":{"role":"assistant","content":" "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.004805Z","message":{"role":"assistant","content":"2"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.009939Z","message":{"role":"assistant","content":" +"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.015069Z","message":{"role":"assistant","content":" "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.020326Z","message":{"role":"assistant","content":"2"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.025432Z","message":{"role":"assistant","content":" ="},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.030451Z","message":{"role":"assistant","content":" "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.035823Z","message":{"role":"assistant","content":"4"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.040947Z","message":{"role":"assistant","content":"\n\n"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.046081Z","message":{"role":"assistant","content":"**"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.051573Z","message":{"role":"assistant","content":"Therefore"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.056648Z","message":{"role":"assistant","content":","},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.061692Z","message":{"role":"assistant","content":" "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.067196Z","message":{"role":"assistant","content":"2"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.072517Z","message":{"role":"assistant","content":" +"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.077613Z","message":{"role":"assistant","content":" "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.083095Z","message":{"role":"assistant","content":"2"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.088231Z","message":{"role":"assistant","content":" ="},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.09334Z","message":{"role":"assistant","content":" "},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.098529Z","message":{"role":"assistant","content":"4"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.103667Z","message":{"role":"assistant","content":"**"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.108856Z","message":{"role":"assistant","content":"\n\n"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.113949Z","message":{"role":"assistant","content":"Let"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.119437Z","message":{"role":"assistant","content":" me"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.124623Z","message":{"role":"assistant","content":" know"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.129716Z","message":{"role":"assistant","content":" if"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.13581Z","message":{"role":"assistant","content":" you"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.140421Z","message":{"role":"assistant","content":"'"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.145469Z","message":{"role":"assistant","content":"d"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.150927Z","message":{"role":"assistant","content":" like"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.156079Z","message":{"role":"assistant","content":" to"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.161292Z","message":{"role":"assistant","content":" try"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.166722Z","message":{"role":"assistant","content":" another"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.171844Z","message":{"role":"assistant","content":" math"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.176972Z","message":{"role":"assistant","content":" problem"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.182266Z","message":{"role":"assistant","content":"!"},"done":false}
+{"model":"gemma3:1b","created_at":"2025-08-08T16:53:42.187532Z","message":{"role":"assistant","content":""},"done_reason":"stop","done":true,"total_duration":620283000,"load_duration":58813250,"prompt_eval_count":23,"prompt_eval_duration":30335709,"eval_count":102,"eval_duration":530886125}
+
+0
+


### PR DESCRIPTION
## Summary
- Add httprr test recordings for the think parameter tests
- Tests can now run without requiring a live Ollama server

## Context
This is a follow-up to #1349 which was already merged. That PR added:
- Think parameter support for Ollama 0.9.0+
- Test functions for the feature

This PR adds the actual test recordings that were generated with Ollama 0.11.0.

## Test Recordings
- `TestWithThink.httprr` - High-level test recording showing think:true in request
- `TestClient_GenerateChatWithThink.httprr` - Low-level client test recording

## Verification
```bash
go test -v ./llms/ollama/...
```
All tests pass ✅