### PR TITLE
openai: add support for max_tokens

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -34,7 +34,7 @@ type ChatRequest struct {
 	Temperature float64        `json:"temperature"`
 	TopP        float64        `json:"top_p,omitempty"`
 	// Deprecated: Use MaxCompletionTokens
-	MaxTokens           int      `json:"-"`
+	MaxTokens           int      `json:"max_tokens,omitempty"`
 	MaxCompletionTokens int      `json:"max_completion_tokens,omitempty"`
 	N                   int      `json:"n,omitempty"`
 	StopWords           []string `json:"stop,omitempty"`

--- a/llms/openai/internal/openaiclient/chat_test.go
+++ b/llms/openai/internal/openaiclient/chat_test.go
@@ -122,3 +122,94 @@ func TestChatMessage_MarshalUnmarshal_WithReasoning(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, msg, msg2)
 }
+
+func TestChatRequest_MaxTokens_MarshalJSON(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		request  ChatRequest
+		expected string
+	}{
+		{
+			name: "with MaxTokens set",
+			request: ChatRequest{
+				Model:     "gpt-3.5-turbo",
+				MaxTokens: 100,
+			},
+			expected: `{"model":"gpt-3.5-turbo","messages":null,"temperature":0,"max_tokens":100}`,
+		},
+		{
+			name: "with zero MaxTokens",
+			request: ChatRequest{
+				Model:     "gpt-3.5-turbo",
+				MaxTokens: 0,
+			},
+			expected: `{"model":"gpt-3.5-turbo","messages":null,"temperature":0}`,
+		},
+		{
+			name: "with both MaxTokens and MaxCompletionTokens",
+			request: ChatRequest{
+				Model:               "gpt-3.5-turbo",
+				MaxTokens:           100,
+				MaxCompletionTokens: 150,
+			},
+			expected: `{"model":"gpt-3.5-turbo","messages":null,"temperature":0,"max_tokens":100,"max_completion_tokens":150}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			data, err := json.Marshal(tt.request)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+		})
+	}
+}
+
+func TestChatRequest_MaxTokens_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    string
+		expected ChatRequest
+	}{
+		{
+			name:  "with max_tokens in JSON",
+			input: `{"model":"gpt-3.5-turbo","max_tokens":100}`,
+			expected: ChatRequest{
+				Model:     "gpt-3.5-turbo",
+				MaxTokens: 100,
+			},
+		},
+		{
+			name:  "with max_completion_tokens in JSON",
+			input: `{"model":"gpt-3.5-turbo","max_completion_tokens":150}`,
+			expected: ChatRequest{
+				Model:               "gpt-3.5-turbo",
+				MaxCompletionTokens: 150,
+			},
+		},
+		{
+			name:  "with both tokens fields in JSON",
+			input: `{"model":"gpt-3.5-turbo","max_tokens":100,"max_completion_tokens":150}`,
+			expected: ChatRequest{
+				Model:               "gpt-3.5-turbo",
+				MaxTokens:           100,
+				MaxCompletionTokens: 150,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var request ChatRequest
+			err := json.Unmarshal([]byte(tt.input), &request)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected.Model, request.Model)
+			assert.Equal(t, tt.expected.MaxTokens, request.MaxTokens)
+			assert.Equal(t, tt.expected.MaxCompletionTokens, request.MaxCompletionTokens)
+		})
+	}
+}

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -113,6 +113,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		FrequencyPenalty:       opts.FrequencyPenalty,
 		PresencePenalty:        opts.PresencePenalty,
 
+		MaxTokens:           opts.MaxTokens,
 		MaxCompletionTokens: opts.MaxTokens,
 
 		ToolChoice:           opts.ToolChoice,


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

I was trying to use Digital Ocean's serverless inference base URL, see: https://github.com/tmc/langchaingo/issues/1028#issuecomment-3192326871 and noticed it only supports `max_tokens` instead of `max_completion_tokens`. I'm inclined that it'll be quite a while for every openai "compatible" api to reflect the change that openai themselves made. In the meantime, this solves the issue. I manually verified that the actual open ai api has no problem sending both parameters.