### PR TITLE
llms/googleai: fix multi-tool support for Google AI and Vertex AI

### DIFF
--- a/llms/googleai/vertex/vertex.go
+++ b/llms/googleai/vertex/vertex.go
@@ -375,7 +375,7 @@ DoStream:
 // convertTools converts from a list of langchaingo tools to a list of genai
 // tools.
 func convertTools(tools []llms.Tool) ([]*genai.Tool, error) {
-	genaiTools := make([]*genai.Tool, 0, len(tools))
+	genaiFuncDecls := make([]*genai.FunctionDeclaration, 0, len(tools))
 	for i, tool := range tools {
 		if tool.Type != "function" {
 			return nil, fmt.Errorf("tool [%d]: unsupported type %q, want 'function'", i, tool.Type)
@@ -452,10 +452,18 @@ func convertTools(tools []llms.Tool) ([]*genai.Tool, error) {
 		}
 		genaiFuncDecl.Parameters = schema
 
-		genaiTools = append(genaiTools, &genai.Tool{
-			FunctionDeclarations: []*genai.FunctionDeclaration{genaiFuncDecl},
-		})
+		// google genai only support one tool, multiple tools must be embedded into function declarations:
+		// https://github.com/GoogleCloudPlatform/generative-ai/issues/636
+		// https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling#chat-samples
+		genaiFuncDecls = append(genaiFuncDecls, genaiFuncDecl)
 	}
+
+	// Return nil if no tools are provided
+	if len(genaiFuncDecls) == 0 {
+		return nil, nil
+	}
+
+	genaiTools := []*genai.Tool{{FunctionDeclarations: genaiFuncDecls}}
 
 	return genaiTools, nil
 }


### PR DESCRIPTION
## Summary
Fix tool conversion to properly support multiple tools in Google AI and Vertex AI by consolidating them into a single Tool object with multiple FunctionDeclarations.

## The Issue
Google's genai SDK requires all function declarations to be within a single Tool object, not multiple Tool objects. When multiple tools were provided, the API would fail or only recognize the first tool.

## The Fix
Modified `convertTools()` in both `llms/googleai/googleai.go` and `llms/googleai/vertex/vertex.go` to:
- Collect all FunctionDeclarations into a single array
- Return a single Tool containing all function declarations
- Handle empty tool lists properly by returning nil

## References
- https://github.com/GoogleCloudPlatform/generative-ai/issues/636
- https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling#chat-samples

## Testing
All existing tests pass with the updated implementation.