### PR TITLE
vectorstores: add MariaDB and Dolt vector store implementations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require github.com/google/uuid v1.6.0
 // Testing
 require (
 	github.com/stretchr/testify v1.10.0
-	github.com/testcontainers/testcontainers-go v0.37.0
+	github.com/testcontainers/testcontainers-go v0.38.0
 	github.com/testcontainers/testcontainers-go/modules/chroma v0.37.0
 	github.com/testcontainers/testcontainers-go/modules/milvus v0.37.0
 	github.com/testcontainers/testcontainers-go/modules/mongodb v0.37.0
@@ -315,4 +315,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-require github.com/stretchr/objx v0.5.2 // indirect
+require (
+	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/testcontainers/testcontainers-go/modules/mariadb v0.38.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -731,8 +731,12 @@ github.com/temoto/robotstxt v1.1.2 h1:W2pOjSJ6SWvldyEuiFXNxz3xZ8aiWX5LbfDiOFd7Fx
 github.com/temoto/robotstxt v1.1.2/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
 github.com/testcontainers/testcontainers-go v0.37.0 h1:L2Qc0vkTw2EHWQ08djon0D2uw7Z/PtHS/QzZZ5Ra/hg=
 github.com/testcontainers/testcontainers-go v0.37.0/go.mod h1:QPzbxZhQ6Bclip9igjLFj6z0hs01bU8lrl2dHQmgFGM=
+github.com/testcontainers/testcontainers-go v0.38.0 h1:d7uEapLcv2P8AvH8ahLqDMMxda2W9gQN1nRbHS28HBw=
+github.com/testcontainers/testcontainers-go v0.38.0/go.mod h1:C52c9MoHpWO+C4aqmgSU+hxlR5jlEayWtgYrb8Pzz1w=
 github.com/testcontainers/testcontainers-go/modules/chroma v0.37.0 h1:vb9fb1mogtlQuF3l0vSAu6rqv3y2j9wozve4xnhVyz8=
 github.com/testcontainers/testcontainers-go/modules/chroma v0.37.0/go.mod h1:IWJavzQy7rxM40OqOgSN5iyckgAw21wDyE+NhSctatk=
+github.com/testcontainers/testcontainers-go/modules/mariadb v0.38.0 h1:RfilPieRalCavWFa+XQtatazPn1L57Do/tRxe/B45I8=
+github.com/testcontainers/testcontainers-go/modules/mariadb v0.38.0/go.mod h1:26mrWngnaRhxmgy942aVfUihLnihbIGsuIds6gGBnIE=
 github.com/testcontainers/testcontainers-go/modules/milvus v0.37.0 h1:q+gx0A10DM0VJMJjo9VOXOB1t8Dv3B6EgxXZf2TIzOw=
 github.com/testcontainers/testcontainers-go/modules/milvus v0.37.0/go.mod h1:bCdLqxjPKax120BMl4aO/A0gs9+4FeJkLBVf9WpjFoQ=
 github.com/testcontainers/testcontainers-go/modules/mongodb v0.37.0 h1:drGy4LJOVkIKpKGm1YKTfVzb1qRhN/konVpmuUphq0k=

--- a/vectorstores/dolt/doc.go
+++ b/vectorstores/dolt/doc.go
@@ -1,0 +1,3 @@
+// Package dolt contains an implementation of the VectorStore
+// interface using Dolt.
+package dolt

--- a/vectorstores/dolt/dolt.go
+++ b/vectorstores/dolt/dolt.go
@@ -1,0 +1,505 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	// required for mysql driver used by Dolt.
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/google/uuid"
+	"github.com/tmc/langchaingo/embeddings"
+	"github.com/tmc/langchaingo/schema"
+	"github.com/tmc/langchaingo/vectorstores"
+)
+
+var (
+	ErrEmbedderWrongNumberVectors = errors.New("number of vectors from embedder does not match number of documents")
+	ErrInvalidScoreThreshold      = errors.New("score threshold must be between 0 and 1")
+	ErrInvalidFilters             = errors.New("invalid filters")
+	ErrUnsupportedOptions         = errors.New("unsupported options")
+)
+
+// DB represents both a sql.DB and sql.Tx.
+type DB interface {
+	PingContext(ctx context.Context) error
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+	ExecContext(ctx context.Context, sql string, arguments ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, sql string, arguments ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, sql string, arguments ...any) *sql.Row
+}
+
+type CloseNoErr interface {
+	Close()
+}
+
+// Store is a wrapper around the dolt client.
+type Store struct {
+	embedder                              embeddings.Embedder
+	connURL                               string
+	db                                    DB
+	embeddingTableName                    string
+	collectionTableName                   string
+	databaseName                          string
+	databaseUUID                          string
+	databaseMetadata                      map[string]any
+	preDeleteDatabase                     bool
+	vectorDimensions                      int
+	createEmbeddingIndexAfterAddDocuments bool
+}
+
+var _ vectorstores.VectorStore = Store{}
+
+// New creates a new Store with options.
+func New(ctx context.Context, opts ...Option) (Store, error) {
+	store, err := applyClientOptions(opts...)
+	if err != nil {
+		return Store{}, err
+	}
+	if store.db == nil {
+		store.db, err = sql.Open("mysql", store.connURL)
+		if err != nil {
+			return Store{}, err
+		}
+	}
+	if err = store.db.PingContext(ctx); err != nil {
+		return Store{}, err
+	}
+	if err = store.init(ctx); err != nil {
+		return Store{}, err
+	}
+	return store, nil
+}
+
+// Close closes the db.
+func (s Store) Close() error {
+	if closer, ok := s.db.(io.Closer); ok {
+		return closer.Close()
+	}
+	if closer, ok := s.db.(CloseNoErr); ok {
+		closer.Close()
+	}
+	return nil
+}
+
+func (s Store) init(ctx context.Context) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := s.createCollectionTableIfNotExists(ctx, tx); err != nil {
+		return err
+	}
+	if err := s.createEmbeddingTableIfNotExists(ctx, tx); err != nil {
+		return err
+	}
+	if s.preDeleteDatabase {
+		if err := s.RemoveDatabase(ctx, tx); err != nil {
+			return err
+		}
+	}
+	if err := s.createOrGetDatabase(ctx, tx); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (s Store) createCollectionTableIfNotExists(ctx context.Context, tx *sql.Tx) error {
+	sql := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+	name varchar(720),
+	cmetadata json,
+	`+"`uuid`"+` varchar(36) NOT NULL,
+	UNIQUE (name),
+	PRIMARY KEY (uuid))`, s.collectionTableName)
+	if _, err := tx.ExecContext(ctx, sql); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s Store) createEmbeddingTableIfNotExists(ctx context.Context, tx *sql.Tx) error {
+	//nolint:gosec
+	sql := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+collection_id varchar(36),
+embedding json,
+document longtext,
+cmetadata json,
+`+"`uuid`"+` varchar(36) NOT NULL,
+CONSTRAINT %s_collection_id_fkey
+FOREIGN KEY (collection_id) REFERENCES %s (uuid) ON DELETE CASCADE,
+PRIMARY KEY (uuid))`, s.embeddingTableName, s.embeddingTableName, s.collectionTableName)
+	if _, err := tx.ExecContext(ctx, sql); err != nil {
+		return err
+	}
+
+	sql = fmt.Sprintf(`SET @index_name = '%s_collection_id';
+SET @table_name = '%s';
+
+SELECT COUNT(*)
+INTO @index_exists
+FROM information_schema.statistics
+WHERE table_schema = DATABASE()
+  AND table_name = @table_name
+  AND index_name = @index_name;
+
+SET @sql = IF(@index_exists = 0, CONCAT('CREATE INDEX ', @index_name, ' ON ', @table_name, ' (collection_id)'), 'SELECT ''Index already exists''');
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;`, s.embeddingTableName, s.embeddingTableName)
+	if _, err := tx.ExecContext(ctx, sql); err != nil {
+		return err
+	}
+
+	// Dolt currently only supports euclidean squared vector indexes
+	if !s.createEmbeddingIndexAfterAddDocuments {
+		sql = fmt.Sprintf(`SET @index_name = '%s_embedding_idx';
+SET @table_name = '%s';
+
+SELECT COUNT(*)
+INTO @index_exists
+FROM information_schema.statistics
+WHERE table_schema = DATABASE()
+	AND table_name = @table_name
+	AND index_name = @index_name;
+
+SET @sql = IF(@index_exists = 0, CONCAT('CREATE VECTOR INDEX ', @index_name, ' ON ', @table_name, ' (embedding)'), 'SELECT ''Index already exists''');
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;`, s.embeddingTableName, s.embeddingTableName)
+		if _, err := tx.ExecContext(ctx, sql); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// AddDocuments adds documents to the Dolt database associated with 'Store'.
+// and returns the ids of the added documents.
+//
+//nolint:cyclop
+func (s Store) AddDocuments(
+	ctx context.Context,
+	docs []schema.Document,
+	options ...vectorstores.Option,
+) ([]string, error) {
+	opts := s.getOptions(options...)
+	if opts.ScoreThreshold != 0 || opts.Filters != nil || opts.NameSpace != "" {
+		return nil, ErrUnsupportedOptions
+	}
+
+	docs = s.deduplicate(ctx, opts, docs)
+
+	texts := make([]string, 0, len(docs))
+	for _, doc := range docs {
+		texts = append(texts, doc.PageContent)
+	}
+
+	embedder := s.embedder
+	if opts.Embedder != nil {
+		embedder = opts.Embedder
+	}
+	vectors, err := embedder.EmbedDocuments(ctx, texts)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(vectors) != len(docs) {
+		return nil, ErrEmbedderWrongNumberVectors
+	}
+
+	ids := make([]string, len(docs))
+	valueStrings := make([]string, 0, len(docs))
+	valueArgs := make([]interface{}, 0, len(docs)*2)
+	for docIdx, doc := range docs {
+		id := uuid.New().String()
+		ids[docIdx] = id
+		valueStrings = append(valueStrings, "(?, ?, ?, ?, ?)")
+		jsonEmbedding, err := json.Marshal(vectors[docIdx])
+		if err != nil {
+			return nil, err
+		}
+		jsonMetadata, err := json.Marshal(doc.Metadata)
+		if err != nil {
+			return nil, err
+		}
+		valueArgs = append(valueArgs, id, doc.PageContent, jsonEmbedding, jsonMetadata, s.databaseUUID)
+	}
+
+	sql := fmt.Sprintf(`INSERT INTO %s (`+"`uuid`"+`, document, embedding, cmetadata, collection_id)
+	VALUES %s`, s.embeddingTableName, strings.Join(valueStrings, ","))
+
+	_, err = s.db.ExecContext(ctx, sql, valueArgs...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Dolt currently only supports euclidean squared vector indexes
+	if s.createEmbeddingIndexAfterAddDocuments {
+		sql = fmt.Sprintf(`SET @index_name = '%s_embedding_idx';
+	SET @table_name = '%s';
+
+	SELECT COUNT(*)
+	INTO @index_exists
+	FROM information_schema.statistics
+	WHERE table_schema = DATABASE()
+		AND table_name = @table_name
+		AND index_name = @index_name;
+
+	SET @sql = IF(@index_exists = 0, CONCAT('CREATE VECTOR INDEX ', @index_name, ' ON ', @table_name, ' (embedding)'), 'SELECT ''Index already exists''');
+
+	PREPARE stmt FROM @sql;
+	EXECUTE stmt;
+	DEALLOCATE PREPARE stmt;`, s.embeddingTableName, s.embeddingTableName)
+		if _, err := s.db.ExecContext(ctx, sql); err != nil {
+			return nil, err
+		}
+	}
+
+	return ids, nil
+}
+
+//nolint:cyclop,funlen
+func (s Store) SimilaritySearch(
+	ctx context.Context,
+	query string,
+	numDocuments int,
+	options ...vectorstores.Option,
+) ([]schema.Document, error) {
+	opts := s.getOptions(options...)
+	databaseName := s.getDatabaseName(opts)
+	scoreThreshold, err := s.getScoreThreshold(opts)
+	if err != nil {
+		return nil, err
+	}
+	filter, err := s.getFilters(opts)
+	if err != nil {
+		return nil, err
+	}
+	embedder := s.embedder
+	if opts.Embedder != nil {
+		embedder = opts.Embedder
+	}
+	embedderData, err := embedder.EmbedQuery(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	whereQuerys := make([]string, 0)
+	if scoreThreshold != 0 {
+		whereQuerys = append(whereQuerys, fmt.Sprintf("data.distance < %f", 1-scoreThreshold))
+	}
+	for k, v := range filter {
+		whereQuerys = append(whereQuerys, fmt.Sprintf("JSON_UNQUOTE(JSON_EXTRACT(data.cmetadata, '$.%s')) = '%s'", k, v))
+	}
+	whereQuery := strings.Join(whereQuerys, " AND ")
+	if len(whereQuery) == 0 {
+		whereQuery = "TRUE"
+	}
+
+	dims := len(embedderData)
+
+	jsonEmbedding, err := json.Marshal(embedderData)
+	if err != nil {
+		return nil, err
+	}
+
+	// Dolt currently only supports euclidean squared vector distance
+	sql := fmt.Sprintf(`SELECT
+    data.document,
+    data.cmetadata,
+    (1 - data.distance) AS score
+FROM
+(
+    SELECT
+        f.*,
+        VEC_DISTANCE(f.embedding, ?) AS distance
+    FROM
+        (SELECT * FROM %s WHERE JSON_LENGTH(embedding) = ?) AS f
+        JOIN %s AS t ON f.collection_id = t.uuid
+    WHERE
+        t.name = '%s'
+) AS data WHERE %s
+ORDER BY
+    data.distance
+    LIMIT ?`, s.embeddingTableName, s.collectionTableName, databaseName, whereQuery)
+
+	rows, err := s.db.QueryContext(ctx, sql, jsonEmbedding, dims, numDocuments)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	docs := make([]schema.Document, 0)
+	for rows.Next() {
+		var content string
+		var metadata string
+		var score float64
+
+		if err := rows.Scan(&content, &metadata, &score); err != nil {
+			return nil, err
+		}
+
+		var metadataMap map[string]any
+		if metadata != "" {
+			if err := json.Unmarshal([]byte(metadata), &metadataMap); err != nil {
+				return nil, err
+			}
+		}
+
+		docs = append(docs, schema.Document{
+			PageContent: content,
+			Metadata:    metadataMap,
+			Score:       float32(score),
+		})
+	}
+	return docs, rows.Err()
+}
+
+//nolint:cyclop
+func (s Store) Search(
+	ctx context.Context,
+	numDocuments int,
+	options ...vectorstores.Option,
+) ([]schema.Document, error) {
+	opts := s.getOptions(options...)
+	databaseName := s.getDatabaseName(opts)
+	filter, err := s.getFilters(opts)
+	if err != nil {
+		return nil, err
+	}
+	whereQuerys := make([]string, 0)
+	for k, v := range filter {
+		whereQuerys = append(whereQuerys, fmt.Sprintf("JSON_UNQUOTE(JSON_EXTRACT(%s.cmetadata, '$.%s')) = '%s'", s.embeddingTableName, k, v))
+	}
+	whereQuery := strings.Join(whereQuerys, " AND ")
+	if len(whereQuery) == 0 {
+		whereQuery = "TRUE"
+	}
+	sql := fmt.Sprintf(`SELECT
+	%s.document,
+	%s.cmetadata
+FROM %s
+JOIN %s ON %s.collection_id=%s.uuid
+WHERE %s.name='%s' AND %s
+LIMIT ?`, s.embeddingTableName, s.embeddingTableName, s.embeddingTableName,
+		s.collectionTableName, s.embeddingTableName, s.collectionTableName, s.collectionTableName, databaseName,
+		whereQuery)
+	rows, err := s.db.QueryContext(ctx, sql, numDocuments)
+	if err != nil {
+		return nil, err
+	}
+	docs := make([]schema.Document, 0)
+	defer rows.Close()
+
+	for rows.Next() {
+		doc := schema.Document{}
+		var metadata string
+		if err := rows.Scan(&doc.PageContent, &metadata); err != nil {
+			return nil, err
+		}
+
+		var metadataMap map[string]any
+		if metadata != "" {
+			if err := json.Unmarshal([]byte(metadata), &metadataMap); err != nil {
+				return nil, err
+			}
+		}
+
+		doc.Metadata = metadataMap
+		docs = append(docs, doc)
+	}
+	return docs, rows.Err()
+}
+
+func (s Store) DropTables(ctx context.Context) error {
+	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, s.embeddingTableName)); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, s.collectionTableName)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s Store) RemoveDatabase(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE name = ?`, s.collectionTableName), s.databaseName)
+	return err
+}
+
+func (s Store) createOrGetDatabase(ctx context.Context, tx *sql.Tx) error {
+	jsonMetadata, err := json.Marshal(s.databaseMetadata)
+	if err != nil {
+		return err
+	}
+	//nolint:gosec
+	sql := fmt.Sprintf("INSERT INTO %s (`uuid`, name, cmetadata) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE cmetadata = ?", s.collectionTableName)
+	if _, err := tx.ExecContext(ctx, sql, uuid.New().String(), s.databaseName, jsonMetadata, jsonMetadata); err != nil {
+		return err
+	}
+	sql = fmt.Sprintf("SELECT `uuid` FROM %s WHERE name = ? ORDER BY name limit 1", s.collectionTableName)
+	return tx.QueryRowContext(ctx, sql, s.databaseName).Scan(&s.databaseUUID)
+}
+
+// getOptions applies given options to default Options and returns it
+// This uses options pattern so clients can easily pass options without changing function signature.
+func (s Store) getOptions(options ...vectorstores.Option) vectorstores.Options {
+	opts := vectorstores.Options{}
+	for _, opt := range options {
+		opt(&opts)
+	}
+	return opts
+}
+
+func (s Store) getDatabaseName(opts vectorstores.Options) string {
+	if opts.NameSpace != "" {
+		return opts.NameSpace
+	}
+	return s.databaseName
+}
+
+func (s Store) getScoreThreshold(opts vectorstores.Options) (float32, error) {
+	if opts.ScoreThreshold < 0 || opts.ScoreThreshold > 1 {
+		return 0, ErrInvalidScoreThreshold
+	}
+	return opts.ScoreThreshold, nil
+}
+
+// getFilters return metadata filters, now only support map[key]value pattern
+// TODO: should support more types like {"key1": {"key2":"values2"}} or {"key": ["value1", "values2"]}.
+func (s Store) getFilters(opts vectorstores.Options) (map[string]any, error) {
+	if opts.Filters != nil {
+		if filters, ok := opts.Filters.(map[string]any); ok {
+			return filters, nil
+		}
+		return nil, ErrInvalidFilters
+	}
+	return map[string]any{}, nil
+}
+
+func (s Store) deduplicate(
+	ctx context.Context,
+	opts vectorstores.Options,
+	docs []schema.Document,
+) []schema.Document {
+	if opts.Deduplicater == nil {
+		return docs
+	}
+
+	filtered := make([]schema.Document, 0, len(docs))
+	for _, doc := range docs {
+		if !opts.Deduplicater(ctx, doc) {
+			filtered = append(filtered, doc)
+		}
+	}
+
+	return filtered
+}

--- a/vectorstores/dolt/dolt.go
+++ b/vectorstores/dolt/dolt.go
@@ -70,7 +70,7 @@ func New(ctx context.Context, opts ...Option) (Store, error) {
 	if err = store.db.PingContext(ctx); err != nil {
 		return Store{}, err
 	}
-	if err = store.init(ctx); err != nil {
+	if err = (&store).init(ctx); err != nil {
 		return Store{}, err
 	}
 	return store, nil
@@ -87,7 +87,7 @@ func (s Store) Close() error {
 	return nil
 }
 
-func (s Store) init(ctx context.Context) error {
+func (s *Store) init(ctx context.Context) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -435,18 +435,31 @@ func (s Store) RemoveDatabase(ctx context.Context, tx *sql.Tx) error {
 	return err
 }
 
-func (s Store) createOrGetDatabase(ctx context.Context, tx *sql.Tx) error {
+func (s *Store) createOrGetDatabase(ctx context.Context, tx *sql.Tx) error {
 	jsonMetadata, err := json.Marshal(s.databaseMetadata)
 	if err != nil {
 		return err
 	}
-	//nolint:gosec
-	sql := fmt.Sprintf("INSERT INTO %s (`uuid`, name, cmetadata) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE cmetadata = ?", s.collectionTableName)
-	if _, err := tx.ExecContext(ctx, sql, uuid.New().String(), s.databaseName, jsonMetadata, jsonMetadata); err != nil {
+
+	// First, try to get existing UUID for this database name
+	//nolint:gosec // Table name is controlled internally, not user input
+	query := fmt.Sprintf("SELECT `uuid` FROM %s WHERE name = ? ORDER BY name limit 1", s.collectionTableName)
+	err = tx.QueryRowContext(ctx, query, s.databaseName).Scan(&s.databaseUUID)
+
+	if err == sql.ErrNoRows {
+		// Database doesn't exist, create it with new UUID
+		s.databaseUUID = uuid.New().String()
+		query = fmt.Sprintf("INSERT INTO %s (`uuid`, name, cmetadata) VALUES (?, ?, ?)", s.collectionTableName)
+		_, err = tx.ExecContext(ctx, query, s.databaseUUID, s.databaseName, jsonMetadata)
+		return err
+	} else if err != nil {
 		return err
 	}
-	sql = fmt.Sprintf("SELECT `uuid` FROM %s WHERE name = ? ORDER BY name limit 1", s.collectionTableName)
-	return tx.QueryRowContext(ctx, sql, s.databaseName).Scan(&s.databaseUUID)
+
+	// Database exists, update metadata if needed
+	query = fmt.Sprintf("UPDATE %s SET cmetadata = ? WHERE `uuid` = ?", s.collectionTableName)
+	_, err = tx.ExecContext(ctx, query, jsonMetadata, s.databaseUUID)
+	return err
 }
 
 // getOptions applies given options to default Options and returns it

--- a/vectorstores/dolt/dolt_test.go
+++ b/vectorstores/dolt/dolt_test.go
@@ -1,0 +1,955 @@
+package dolt_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tmc/langchaingo/vectorstores"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/chains"
+	"github.com/tmc/langchaingo/embeddings"
+	"github.com/tmc/langchaingo/llms/googleai"
+	"github.com/tmc/langchaingo/llms/openai"
+	"github.com/tmc/langchaingo/schema"
+	"github.com/tmc/langchaingo/vectorstores/dolt"
+)
+
+var (
+	//nolint:gochecknoglobals
+	doltExec string
+	//nolint:gochecknoglobals
+	doltExecOnce sync.Once
+)
+
+type testDoltServer struct {
+	t              *testing.T
+	Cmd            *exec.Cmd
+	db             *sql.DB
+	Stdout         io.ReadCloser
+	Stderr         io.ReadCloser
+	Name           string
+	StderrString   string
+	StderrCaptured chan (bool)
+	WaitError      error
+	Waited         chan (bool)
+	CmdDir         string
+	Host           string
+	Port           string
+	Password       string
+}
+
+func newTestDoltServer(t *testing.T) *testDoltServer {
+	t.Helper()
+	return &testDoltServer{
+		t:              t,
+		Waited:         make(chan bool),
+		StderrCaptured: make(chan bool),
+		Name:           "vectorstore_dolt_test",
+	}
+}
+
+func mustGetDoltExec(t *testing.T) string {
+	t.Helper()
+
+	doltCommand := "dolt"
+	if runtime.GOOS == "windows" {
+		doltCommand = "dolt.exe"
+	}
+
+	doltExecOnce.Do(func() {
+		arg := os.Getenv("DOLT_BIN")
+		if arg != "" {
+			if filepath.IsAbs(arg) {
+				doltExec = arg
+				return
+			}
+			wd, _ := os.Getwd()
+			doltExec = filepath.Join(wd, arg)
+			return
+		}
+		de, err := exec.LookPath(doltCommand)
+		if err != nil {
+			t.Skip("Dolt binary not available")
+		}
+		doltExec = de
+	})
+	return doltExec
+}
+
+func (di *testDoltServer) ConnectionString() string {
+	return fmt.Sprintf("%s:%s@(%s:%s)/%s?parseTime=true&multiStatements=true", "root", di.Password, di.Host, di.Port, di.Name)
+}
+
+//nolint:funlen
+func (di *testDoltServer) Start() error {
+	tmpDir, err := os.MkdirTemp("", "dolt-vectorstore-tests*")
+	require.NoError(di.t, err)
+
+	di.CmdDir = tmpDir
+
+	doltInit := exec.Command(mustGetDoltExec(di.t), "init") //nolint:gosec
+	doltInit.Env = os.Environ()
+	doltInit.Dir = tmpDir
+	doltInit.Stdout = os.Stdout
+	doltInit.Stderr = os.Stderr
+	err = doltInit.Run()
+	require.NoError(di.t, err)
+
+	createDB := exec.Command(mustGetDoltExec(di.t), "sql", "-q", fmt.Sprintf("CREATE DATABASE %s;", di.Name)) //nolint:gosec
+	createDB.Env = os.Environ()
+	createDB.Dir = tmpDir
+	createDB.Stdout = os.Stdout
+	createDB.Stderr = os.Stderr
+	err = createDB.Run()
+	require.NoError(di.t, err)
+
+	port, err := getFreePort()
+	require.NoError(di.t, err)
+
+	di.Host = "0.0.0.0"
+	di.Port = port
+	di.Password = ""
+
+	di.Cmd = exec.Command( //nolint:gosec
+		mustGetDoltExec(di.t),
+		"sql-server",
+		"--host", di.Host,
+		"--port", di.Port,
+	)
+
+	di.Cmd.Env = di.Cmd.Environ()
+	di.Cmd.Dir = di.CmdDir
+
+	di.Stdout, err = di.Cmd.StdoutPipe()
+	require.NoError(di.t, err)
+	di.Stderr, err = di.Cmd.StderrPipe()
+	require.NoError(di.t, err)
+
+	err = di.Cmd.Start()
+	require.NoError(di.t, err)
+	go func() {
+		di.WaitError = di.Cmd.Wait()
+		close(di.Waited)
+	}()
+
+	go func() {
+		var buffer bytes.Buffer
+		_, err := buffer.ReadFrom(di.Stderr)
+		if err != nil {
+			panic(err)
+		}
+		di.StderrString = buffer.String()
+		close(di.StderrCaptured)
+	}()
+
+	dbChan := make(chan *sql.DB)
+	go func() {
+		for i := 0; i < 50; i++ {
+			db, err := sql.Open("mysql", di.ConnectionString())
+			if err == nil {
+				err = db.Ping()
+				if err == nil {
+					dbChan <- db
+					return
+				}
+			}
+			select {
+			case <-di.Waited:
+				close(dbChan)
+				return
+			default:
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+		err = di.Shutdown()
+		if err != nil {
+			panic(err)
+		}
+		close(dbChan)
+	}()
+	di.db = <-dbChan
+
+	return nil
+}
+
+func (di *testDoltServer) IsRunning() bool {
+	return di.Cmd.Process != nil && di.Cmd.ProcessState == nil && di.db != nil && di.db.Ping() == nil
+}
+
+func (di *testDoltServer) Shutdown() error {
+	defer os.RemoveAll(di.CmdDir)
+
+	killed := false
+	if runtime.GOOS == "windows" {
+		kill := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(di.Cmd.Process.Pid)) //nolint:gosec
+		kill.Stdout = os.Stdout
+		kill.Stderr = os.Stderr
+		err := kill.Run()
+		if err != nil {
+			return err
+		}
+		killed = true
+	} else {
+		err := di.Cmd.Process.Signal(os.Interrupt)
+		if err != nil {
+			return err
+		}
+	}
+	<-di.Waited
+	<-di.StderrCaptured
+	if killed && di.WaitError != nil {
+		return nil
+	}
+	return di.WaitError
+}
+
+func (di *testDoltServer) ErrorMessage() string {
+	return di.StderrString
+}
+
+func (di *testDoltServer) DB() (*sql.DB, error) {
+	if !di.IsRunning() {
+		return nil, errors.New("dolt server is not running")
+	}
+	return di.db, nil
+}
+
+func getFreePort() (string, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return "", err
+	}
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return "", err
+	}
+	defer l.Close()
+	addr, ok := l.Addr().(*net.TCPAddr)
+	if !ok {
+		return "", errors.New("failed to get port")
+	}
+	return fmt.Sprintf("%d", addr.Port), nil
+}
+
+func preCheckEnvSetting(t *testing.T) string {
+	t.Helper()
+
+	if openaiKey := os.Getenv("OPENAI_API_KEY"); openaiKey == "" {
+		t.Skip("OPENAI_API_KEY not set")
+	}
+
+	doltURL := os.Getenv("DOLT_CONNECTION_STRING")
+	if doltURL == "" {
+		di := newTestDoltServer(t)
+		err := di.Start()
+		if err != nil && strings.Contains(err.Error(), "Cannot connect to the Docker daemon") {
+			t.Skip("Docker not available")
+		}
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, di.Shutdown())
+		})
+		doltURL = di.ConnectionString()
+	}
+
+	return doltURL
+}
+
+func makeNewDatabaseName() string {
+	return fmt.Sprintf("test-database-%s", uuid.New().String())
+}
+
+func cleanupTestArtifacts(ctx context.Context, t *testing.T, s dolt.Store, doltURL string) {
+	t.Helper()
+
+	db, err := sql.Open("mysql", doltURL)
+	require.NoError(t, err)
+
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, s.RemoveDatabase(ctx, tx))
+
+	require.NoError(t, tx.Commit())
+}
+
+func TestDoltStoreRest(t *testing.T) {
+	t.Parallel()
+	doltURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", doltURL)
+	require.NoError(t, err)
+
+	store, err := dolt.New(
+		ctx,
+		dolt.WithDB(db),
+		dolt.WithEmbedder(e),
+		dolt.WithPreDeleteDatabase(true),
+		dolt.WithDatabaseName(makeNewDatabaseName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, doltURL)
+
+	_, err = store.AddDocuments(ctx, []schema.Document{
+		{PageContent: "tokyo", Metadata: map[string]any{
+			"country": "japan",
+		}},
+		{PageContent: "potato"},
+	})
+	require.NoError(t, err)
+
+	docs, err := store.SimilaritySearch(ctx, "japan", 1)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.Equal(t, "tokyo", docs[0].PageContent)
+	require.Equal(t, "japan", docs[0].Metadata["country"])
+}
+
+func TestDoltStoreRestWithScoreThreshold(t *testing.T) {
+	t.Parallel()
+	doltURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", doltURL)
+	require.NoError(t, err)
+
+	store, err := dolt.New(
+		ctx,
+		dolt.WithDB(db),
+		dolt.WithEmbedder(e),
+		dolt.WithPreDeleteDatabase(true),
+		dolt.WithDatabaseName(makeNewDatabaseName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, doltURL)
+
+	_, err = store.AddDocuments(context.Background(), []schema.Document{
+		{PageContent: "Tokyo"},
+		{PageContent: "Yokohama"},
+		{PageContent: "Osaka"},
+		{PageContent: "Nagoya"},
+		{PageContent: "Sapporo"},
+		{PageContent: "Fukuoka"},
+		{PageContent: "Dublin"},
+		{PageContent: "Paris"},
+		{PageContent: "London"},
+		{PageContent: "New York"},
+	})
+	require.NoError(t, err)
+
+	// test with a score threshold of 0.8, expected 6 documents
+	docs, err := store.SimilaritySearch(
+		ctx,
+		"Which of these are cities in Japan",
+		10,
+		vectorstores.WithScoreThreshold(0.6), // Dolt uses euclidean squared distance
+	)
+	require.NoError(t, err)
+	require.Len(t, docs, 6)
+
+	// test with a score threshold of 0, expected all 10 documents
+	docs, err = store.SimilaritySearch(
+		ctx,
+		"Which of these are cities in Japan",
+		10,
+		vectorstores.WithScoreThreshold(0))
+	require.NoError(t, err)
+	require.Len(t, docs, 10)
+}
+
+func TestDoltStoreSimilarityScore(t *testing.T) {
+	t.Parallel()
+	doltURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", doltURL)
+	require.NoError(t, err)
+
+	store, err := dolt.New(
+		ctx,
+		dolt.WithDB(db),
+		dolt.WithEmbedder(e),
+		dolt.WithPreDeleteDatabase(true),
+		dolt.WithDatabaseName(makeNewDatabaseName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, doltURL)
+
+	_, err = store.AddDocuments(context.Background(), []schema.Document{
+		{PageContent: "Tokyo is the capital city of Japan."},
+		{PageContent: "Paris is the city of love."},
+		{PageContent: "I like to visit London."},
+	})
+	require.NoError(t, err)
+
+	// Dolt uses euclidean squared distance
+	// test with a score threshold of 0.6, expected 6 documents
+	docs, err := store.SimilaritySearch(
+		ctx,
+		"What is the capital city of Japan?",
+		3,
+		vectorstores.WithScoreThreshold(0.6),
+	)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.True(t, docs[0].Score > 0.8)
+}
+
+func TestSimilaritySearchWithInvalidScoreThreshold(t *testing.T) {
+	t.Parallel()
+	doltURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", doltURL)
+	require.NoError(t, err)
+
+	store, err := dolt.New(
+		ctx,
+		dolt.WithDB(db),
+		dolt.WithEmbedder(e),
+		dolt.WithPreDeleteDatabase(true),
+		dolt.WithDatabaseName(makeNewDatabaseName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, doltURL)
+
+	_, err = store.AddDocuments(ctx, []schema.Document{
+		{PageContent: "Tokyo"},
+		{PageContent: "Yokohama"},
+		{PageContent: "Osaka"},
+		{PageContent: "Nagoya"},
+		{PageContent: "Sapporo"},
+		{PageContent: "Fukuoka"},
+		{PageContent: "Dublin"},
+		{PageContent: "Paris"},
+		{PageContent: "London"},
+		{PageContent: "New York"},
+	})
+	require.NoError(t, err)
+
+	_, err = store.SimilaritySearch(
+		ctx,
+		"Which of these are cities in Japan",
+		10,
+		vectorstores.WithScoreThreshold(-0.8),
+	)
+	require.Error(t, err)
+
+	_, err = store.SimilaritySearch(
+		ctx,
+		"Which of these are cities in Japan",
+		10,
+		vectorstores.WithScoreThreshold(1.8),
+	)
+	require.Error(t, err)
+}
+
+// note, we can also use same llm to show this test, but need imply
+// openai embedding [dimensions](https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-dimensions) args.
+func TestSimilaritySearchWithDifferentDimensions(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	doltURL := preCheckEnvSetting(t)
+	genaiKey := os.Getenv("GENAI_API_KEY")
+	if genaiKey == "" {
+		t.Skip("GENAI_API_KEY not set")
+	}
+	databaseName := makeNewDatabaseName()
+
+	// use Google embedding (now default model is embedding-001, with dimensions:768) to add some data to collection
+	googleLLM, err := googleai.New(ctx, googleai.WithAPIKey(genaiKey))
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(googleLLM)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", doltURL)
+	require.NoError(t, err)
+
+	store, err := dolt.New(
+		ctx,
+		dolt.WithDB(db),
+		dolt.WithEmbedder(e),
+		dolt.WithPreDeleteDatabase(true),
+		dolt.WithDatabaseName(databaseName),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, doltURL)
+
+	_, err = store.AddDocuments(ctx, []schema.Document{
+		{PageContent: "Beijing"},
+	})
+	require.NoError(t, err)
+
+	// use openai embedding (now default model is text-embedding-ada-002, with dimensions:1536) to add some data to same collection (same table)
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err = embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	store, err = dolt.New(
+		ctx,
+		dolt.WithDB(db),
+		dolt.WithEmbedder(e),
+		dolt.WithPreDeleteDatabase(false),
+		dolt.WithDatabaseName(databaseName),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, doltURL)
+
+	_, err = store.AddDocuments(ctx, []schema.Document{
+		{PageContent: "Tokyo"},
+		{PageContent: "Yokohama"},
+		{PageContent: "Osaka"},
+		{PageContent: "Nagoya"},
+		{PageContent: "Sapporo"},
+		{PageContent: "Fukuoka"},
+		{PageContent: "Dublin"},
+		{PageContent: "Paris"},
+		{PageContent: "London"},
+		{PageContent: "New York"},
+	})
+	require.NoError(t, err)
+
+	docs, err := store.SimilaritySearch(
+		ctx,
+		"Which of these are cities in Japan",
+		5,
+	)
+	require.NoError(t, err)
+	require.Len(t, docs, 5)
+}
+
+func TestDoltAsRetriever(t *testing.T) {
+	t.Parallel()
+	doltURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", doltURL)
+	require.NoError(t, err)
+
+	store, err := dolt.New(
+		ctx,
+		dolt.WithDB(db),
+		dolt.WithEmbedder(e),
+		dolt.WithPreDeleteDatabase(true),
+		dolt.WithDatabaseName(makeNewDatabaseName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, doltURL)
+
+	_, err = store.AddDocuments(
+		ctx,
+		[]schema.Document{
+			{PageContent: "The color of the house is blue."},
+			{PageContent: "The color of the car is red."},
+			{PageContent: "The color of the desk is orange."},
+		},
+	)
+	require.NoError(t, err)
+
+	result, err := chains.Run(
+		ctx,
+		chains.NewRetrievalQAFromLLM(
+			llm,
+			vectorstores.ToRetriever(store, 1),
+		),
+		"What color is the desk?",
+	)
+	require.NoError(t, err)
+	require.True(t, strings.Contains(result, "orange"), "expected orange in result")
+}
+
+func TestDoltAsRetrieverWithScoreThreshold(t *testing.T) {
+	t.Parallel()
+	doltURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", doltURL)
+	require.NoError(t, err)
+
+	store, err := dolt.New(
+		ctx,
+		dolt.WithDB(db),
+		dolt.WithEmbedder(e),
+		dolt.WithPreDeleteDatabase(true),
+		dolt.WithDatabaseName(makeNewDatabaseName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, doltURL)
+
+	_, err = store.AddDocuments(
+		context.Background(),
+		[]schema.Document{
+			{PageContent: "The color of the house is blue."},
+			{PageContent: "The color of the car is red."},
+			{PageContent: "The color of the desk is orange."},
+			{PageContent: "The color of the lamp beside the desk is black."},
+			{PageContent: "The color of the chair beside the desk is beige."},
+		},
+	)
+	require.NoError(t, err)
+
+	result, err := chains.Run(
+		ctx,
+		chains.NewRetrievalQAFromLLM(
+			llm,
+			vectorstores.ToRetriever(store, 5, vectorstores.WithScoreThreshold(0.7)),
+		),
+		"What colors is each piece of furniture next to the desk?",
+	)
+	require.NoError(t, err)
+
+	require.Contains(t, result, "orange", "expected orange in result")
+	require.Contains(t, result, "black", "expected black in result")
+	require.Contains(t, result, "beige", "expected beige in result")
+}
+
+func TestDoltAsRetrieverWithMetadataFilterNotSelected(t *testing.T) {
+	t.Parallel()
+	doltURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", doltURL)
+	require.NoError(t, err)
+
+	store, err := dolt.New(
+		ctx,
+		dolt.WithDB(db),
+		dolt.WithEmbedder(e),
+		dolt.WithPreDeleteDatabase(true),
+		dolt.WithDatabaseName(makeNewDatabaseName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, doltURL)
+
+	_, err = store.AddDocuments(
+		ctx,
+		[]schema.Document{
+			{
+				PageContent: "in kitchen, The color of the lamp beside the desk is black.",
+				Metadata: map[string]any{
+					"location": "kitchen",
+				},
+			},
+			{
+				PageContent: "in bedroom, The color of the lamp beside the desk is blue.",
+				Metadata: map[string]any{
+					"location": "bedroom",
+				},
+			},
+			{
+				PageContent: "in office, The color of the lamp beside the desk is orange.",
+				Metadata: map[string]any{
+					"location": "office",
+				},
+			},
+			{
+				PageContent: "in sitting room, The color of the lamp beside the desk is purple.",
+				Metadata: map[string]any{
+					"location": "sitting room",
+				},
+			},
+			{
+				PageContent: "in patio, The color of the lamp beside the desk is yellow.",
+				Metadata: map[string]any{
+					"location": "patio",
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	result, err := chains.Run(
+		ctx,
+		chains.NewRetrievalQAFromLLM(
+			llm,
+			vectorstores.ToRetriever(store, 5),
+		),
+		"What color is the lamp in each room?",
+	)
+	require.NoError(t, err)
+	result = strings.ToLower(result)
+
+	require.Contains(t, result, "black", "expected black in result")
+	require.Contains(t, result, "blue", "expected blue in result")
+	require.Contains(t, result, "orange", "expected orange in result")
+	require.Contains(t, result, "purple", "expected purple in result")
+	require.Contains(t, result, "yellow", "expected yellow in result")
+}
+
+func TestDoltAsRetrieverWithMetadataFilters(t *testing.T) {
+	t.Parallel()
+	doltURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", doltURL)
+	require.NoError(t, err)
+
+	store, err := dolt.New(
+		ctx,
+		dolt.WithDB(db),
+		dolt.WithEmbedder(e),
+		dolt.WithPreDeleteDatabase(true),
+		dolt.WithDatabaseName(makeNewDatabaseName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, doltURL)
+
+	_, err = store.AddDocuments(
+		context.Background(),
+		[]schema.Document{
+			{
+				PageContent: "In office, the color of the lamp beside the desk is orange.",
+				Metadata: map[string]any{
+					"location":    "office",
+					"square_feet": 100,
+				},
+			},
+			{
+				PageContent: "in sitting room, the color of the lamp beside the desk is purple.",
+				Metadata: map[string]any{
+					"location":    "sitting room",
+					"square_feet": 400,
+				},
+			},
+			{
+				PageContent: "in patio, the color of the lamp beside the desk is yellow.",
+				Metadata: map[string]any{
+					"location":    "patio",
+					"square_feet": 800,
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	filter := map[string]any{"location": "sitting room"}
+
+	result, err := chains.Run(
+		ctx,
+		chains.NewRetrievalQAFromLLM(
+			llm,
+			vectorstores.ToRetriever(store,
+				5,
+				vectorstores.WithFilters(filter))),
+		"What color is the lamp in each room?",
+	)
+	require.NoError(t, err)
+	require.Contains(t, result, "purple", "expected purple in result")
+	require.NotContains(t, result, "orange", "expected not orange in result")
+	require.NotContains(t, result, "yellow", "expected not yellow in result")
+}
+
+func TestDeduplicater(t *testing.T) {
+	t.Parallel()
+	doltURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", doltURL)
+	require.NoError(t, err)
+
+	store, err := dolt.New(
+		ctx,
+		dolt.WithDB(db),
+		dolt.WithEmbedder(e),
+		dolt.WithPreDeleteDatabase(true),
+		dolt.WithDatabaseName(makeNewDatabaseName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, doltURL)
+
+	_, err = store.AddDocuments(context.Background(), []schema.Document{
+		{PageContent: "tokyo", Metadata: map[string]any{
+			"type": "city",
+		}},
+		{PageContent: "potato", Metadata: map[string]any{
+			"type": "vegetable",
+		}},
+	}, vectorstores.WithDeduplicater(
+		func(_ context.Context, doc schema.Document) bool {
+			return doc.PageContent == "tokyo"
+		},
+	))
+	require.NoError(t, err)
+
+	docs, err := store.Search(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.Equal(t, "potato", docs[0].PageContent)
+	require.Equal(t, "vegetable", docs[0].Metadata["type"])
+}
+
+func TestWithAllOptions(t *testing.T) {
+	t.Parallel()
+	doltURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+	require.NoError(t, err)
+	db, err := sql.Open("mysql", doltURL)
+	require.NoError(t, err)
+	defer db.Close()
+
+	store, err := dolt.New(
+		ctx,
+		dolt.WithDB(db),
+		dolt.WithEmbedder(e),
+		dolt.WithPreDeleteDatabase(true),
+		dolt.WithDatabaseName(makeNewDatabaseName()),
+		dolt.WithCollectionTableName("collection_table_name"),
+		dolt.WithEmbeddingTableName("embedding_table_name"),
+		dolt.WithDatabaseMetadata(map[string]any{
+			"key": "value",
+		}),
+		dolt.WithVectorDimensions(1536),
+		dolt.WithCreateEmbeddingIndexAfterAddDocuments(true),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, doltURL)
+
+	_, err = store.AddDocuments(ctx, []schema.Document{
+		{PageContent: "tokyo", Metadata: map[string]any{
+			"country": "japan",
+		}},
+		{PageContent: "potato"},
+	})
+	require.NoError(t, err)
+
+	docs, err := store.SimilaritySearch(ctx, "japan", 1)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.Equal(t, "tokyo", docs[0].PageContent)
+	require.Equal(t, "japan", docs[0].Metadata["country"])
+
+	store, err = dolt.New(
+		ctx,
+		dolt.WithDB(db),
+		dolt.WithEmbedder(e),
+		dolt.WithPreDeleteDatabase(true),
+		dolt.WithDatabaseName(makeNewDatabaseName()),
+		dolt.WithCollectionTableName("collection_table_name1"),
+		dolt.WithEmbeddingTableName("embedding_table_name1"),
+		dolt.WithDatabaseMetadata(map[string]any{
+			"key": "value",
+		}),
+		dolt.WithVectorDimensions(1536),
+		dolt.WithCreateEmbeddingIndexAfterAddDocuments(true),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, doltURL)
+
+	_, err = store.AddDocuments(ctx, []schema.Document{
+		{PageContent: "tokyo", Metadata: map[string]any{
+			"country": "japan",
+		}},
+		{PageContent: "potato"},
+	})
+	require.NoError(t, err)
+
+	docs, err = store.SimilaritySearch(ctx, "japan", 1)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.Equal(t, "tokyo", docs[0].PageContent)
+	require.Equal(t, "japan", docs[0].Metadata["country"])
+}

--- a/vectorstores/dolt/options.go
+++ b/vectorstores/dolt/options.go
@@ -1,0 +1,115 @@
+package dolt
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/tmc/langchaingo/embeddings"
+)
+
+const (
+	DefaultDatabaseName             = "langchain"
+	DefaultPreDeleteDatabase        = false
+	DefaultEmbeddingStoreTableName  = "langchain_dolt_embedding"
+	DefaultCollectionStoreTableName = "langchain_dolt_collection"
+)
+
+// ErrInvalidOptions is returned when the options given are invalid.
+var ErrInvalidOptions = errors.New("invalid options")
+
+// Option is a function type that can be used to modify the client.
+type Option func(p *Store)
+
+// WithEmbedder is an option for setting the embedder to use. Must be set.
+func WithEmbedder(e embeddings.Embedder) Option {
+	return func(p *Store) {
+		p.embedder = e
+	}
+}
+
+// WithPreDeleteDatabase is an option for setting if the database should be deleted before creating.
+func WithPreDeleteDatabase(preDelete bool) Option {
+	return func(p *Store) {
+		p.preDeleteDatabase = preDelete
+	}
+}
+
+// WithDatabaseName is an option for specifying the database name.
+func WithDatabaseName(name string) Option {
+	return func(p *Store) {
+		p.databaseName = name
+	}
+}
+
+// WithEmbeddingTableName is an option for specifying the embedding table name.
+func WithEmbeddingTableName(name string) Option {
+	return func(p *Store) {
+		p.embeddingTableName = name
+	}
+}
+
+// WithCollectionTableName is an option for specifying the collection table name.
+func WithCollectionTableName(name string) Option {
+	return func(p *Store) {
+		p.collectionTableName = name
+	}
+}
+
+// WithConnectionURL is an option for specifying the Postgres connection URL. Either this
+// or WithConn must be used.
+func WithConnectionURL(connectionURL string) Option {
+	return func(p *Store) {
+		p.connURL = connectionURL
+	}
+}
+
+// WithDB is an option for specifying the Dolt connection.
+func WithDB(db DB) Option {
+	return func(p *Store) {
+		p.db = db
+	}
+}
+
+// WithDatabaseMetadata is an option for specifying the database metadata.
+func WithDatabaseMetadata(metadata map[string]any) Option {
+	return func(p *Store) {
+		p.databaseMetadata = metadata
+	}
+}
+
+// WithVectorDimensions is an option for specifying the vector size.
+func WithVectorDimensions(size int) Option {
+	return func(p *Store) {
+		p.vectorDimensions = size
+	}
+}
+
+// WithCreateEmbeddingIndexAfterAddDocuments is an option for specifying if the embedding index should be created after adding documents.
+func WithCreateEmbeddingIndexAfterAddDocuments(createEmbeddingIndexAfterAddDocuments bool) Option {
+	return func(p *Store) {
+		p.createEmbeddingIndexAfterAddDocuments = createEmbeddingIndexAfterAddDocuments
+	}
+}
+
+func applyClientOptions(opts ...Option) (Store, error) {
+	o := &Store{
+		databaseName:        DefaultDatabaseName,
+		preDeleteDatabase:   DefaultPreDeleteDatabase,
+		embeddingTableName:  DefaultEmbeddingStoreTableName,
+		collectionTableName: DefaultCollectionStoreTableName,
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	if o.db == nil && o.connURL == "" {
+		return Store{}, fmt.Errorf("%w: missing dolt connection", ErrInvalidOptions)
+	}
+
+	if o.embedder == nil {
+		return Store{}, fmt.Errorf("%w: missing embedder", ErrInvalidOptions)
+	}
+
+	return *o, nil
+}

--- a/vectorstores/mariadb/doc.go
+++ b/vectorstores/mariadb/doc.go
@@ -1,0 +1,3 @@
+// Package mariadb contains an implementation of the VectorStore
+// interface using MariaDB.
+package mariadb

--- a/vectorstores/mariadb/mariadb.go
+++ b/vectorstores/mariadb/mariadb.go
@@ -1,0 +1,458 @@
+package mariadb
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	// required for mysql driver used by MariaDB.
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/google/uuid"
+	"github.com/tmc/langchaingo/embeddings"
+	"github.com/tmc/langchaingo/schema"
+	"github.com/tmc/langchaingo/vectorstores"
+)
+
+var (
+	ErrEmbedderWrongNumberVectors = errors.New("number of vectors from embedder does not match number of documents")
+	ErrInvalidScoreThreshold      = errors.New("score threshold must be between 0 and 1")
+	ErrInvalidFilters             = errors.New("invalid filters")
+	ErrUnsupportedOptions         = errors.New("unsupported options")
+)
+
+// DB represents both a sql.DB and sql.Tx.
+type DB interface {
+	PingContext(ctx context.Context) error
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+	ExecContext(ctx context.Context, sql string, arguments ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, sql string, arguments ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, sql string, arguments ...any) *sql.Row
+}
+
+type CloseNoErr interface {
+	Close()
+}
+
+// Store is a wrapper around the mariadb client.
+type Store struct {
+	embedder            embeddings.Embedder
+	connURL             string
+	db                  DB
+	embeddingTableName  string
+	collectionTableName string
+	databaseName        string
+	databaseUUID        string
+	databaseMetadata    map[string]any
+	preDeleteDatabase   bool
+	vectorDimensions    int
+}
+
+var _ vectorstores.VectorStore = Store{}
+
+// New creates a new Store with options.
+func New(ctx context.Context, opts ...Option) (Store, error) {
+	store, err := applyClientOptions(opts...)
+	if err != nil {
+		return Store{}, err
+	}
+	if store.db == nil {
+		store.db, err = sql.Open("mysql", store.connURL)
+		if err != nil {
+			return Store{}, err
+		}
+	}
+	if err = store.db.PingContext(ctx); err != nil {
+		return Store{}, err
+	}
+	if err = store.init(ctx); err != nil {
+		return Store{}, err
+	}
+	return store, nil
+}
+
+// Close closes the db.
+func (s Store) Close() error {
+	if closer, ok := s.db.(io.Closer); ok {
+		return closer.Close()
+	}
+	if closer, ok := s.db.(CloseNoErr); ok {
+		closer.Close()
+	}
+	return nil
+}
+
+func (s Store) init(ctx context.Context) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := s.createCollectionTableIfNotExists(ctx, tx); err != nil {
+		return err
+	}
+	if err := s.createEmbeddingTableIfNotExists(ctx, tx); err != nil {
+		return err
+	}
+
+	if s.preDeleteDatabase {
+		if err := s.RemoveDatabase(ctx, tx); err != nil {
+			return err
+		}
+	}
+	if err := s.createOrGetDatabase(ctx, tx); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (s Store) createCollectionTableIfNotExists(ctx context.Context, tx *sql.Tx) error {
+	sql := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+	name varchar(720),
+	cmetadata json,
+	`+"`uuid`"+` varchar(36) NOT NULL,
+	UNIQUE (name),
+	PRIMARY KEY (uuid))`, s.collectionTableName)
+	if _, err := tx.ExecContext(ctx, sql); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s Store) createEmbeddingTableIfNotExists(ctx context.Context, tx *sql.Tx) error {
+	if s.vectorDimensions == 0 {
+		return fmt.Errorf("vector dimensions must be greater than zero")
+	}
+	//nolint:gosec
+	sql := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+collection_id varchar(36),
+embedding VECTOR(%d) NOT NULL,
+document longtext,
+cmetadata json,
+`+"`uuid`"+` varchar(36) NOT NULL,
+INDEX %s_collection_id (collection_id),
+VECTOR INDEX %s_embedding (embedding) M=8 DISTANCE=cosine,
+CONSTRAINT %s_collection_id_fkey
+FOREIGN KEY (collection_id) REFERENCES %s (uuid) ON DELETE CASCADE,
+PRIMARY KEY (uuid))`,
+		s.embeddingTableName,
+		s.vectorDimensions,
+		s.embeddingTableName,
+		s.embeddingTableName,
+		s.embeddingTableName,
+		s.collectionTableName)
+	if _, err := tx.ExecContext(ctx, sql); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AddDocuments adds documents to the MariaDB database associated with 'Store'.
+// and returns the ids of the added documents.
+func (s Store) AddDocuments(
+	ctx context.Context,
+	docs []schema.Document,
+	options ...vectorstores.Option,
+) ([]string, error) {
+	opts := s.getOptions(options...)
+	if opts.ScoreThreshold != 0 || opts.Filters != nil || opts.NameSpace != "" {
+		return nil, ErrUnsupportedOptions
+	}
+
+	docs = s.deduplicate(ctx, opts, docs)
+
+	texts := make([]string, 0, len(docs))
+	for _, doc := range docs {
+		texts = append(texts, doc.PageContent)
+	}
+
+	embedder := s.embedder
+	if opts.Embedder != nil {
+		embedder = opts.Embedder
+	}
+	vectors, err := embedder.EmbedDocuments(ctx, texts)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(vectors) != len(docs) {
+		return nil, ErrEmbedderWrongNumberVectors
+	}
+
+	ids := make([]string, len(docs))
+	valueStrings := make([]string, 0, len(docs))
+	valueArgs := make([]interface{}, 0, len(docs)*2)
+	for docIdx, doc := range docs {
+		id := uuid.New().String()
+		ids[docIdx] = id
+		valueStrings = append(valueStrings, "(?, ?, Vec_FromText(?), ?, ?)")
+		jsonEmbedding, err := json.Marshal(vectors[docIdx])
+		if err != nil {
+			return nil, err
+		}
+		jsonMetadata, err := json.Marshal(doc.Metadata)
+		if err != nil {
+			return nil, err
+		}
+		valueArgs = append(valueArgs, id, doc.PageContent, jsonEmbedding, jsonMetadata, s.databaseUUID)
+	}
+
+	sql := fmt.Sprintf(`INSERT INTO %s (`+"`uuid`"+`, document, embedding, cmetadata, collection_id)
+	VALUES %s`, s.embeddingTableName, strings.Join(valueStrings, ","))
+
+	_, err = s.db.ExecContext(ctx, sql, valueArgs...)
+	if err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}
+
+//nolint:cyclop,funlen
+func (s Store) SimilaritySearch(
+	ctx context.Context,
+	query string,
+	numDocuments int,
+	options ...vectorstores.Option,
+) ([]schema.Document, error) {
+	opts := s.getOptions(options...)
+	databaseName := s.getDatabaseName(opts)
+	scoreThreshold, err := s.getScoreThreshold(opts)
+	if err != nil {
+		return nil, err
+	}
+	filter, err := s.getFilters(opts)
+	if err != nil {
+		return nil, err
+	}
+	embedder := s.embedder
+	if opts.Embedder != nil {
+		embedder = opts.Embedder
+	}
+	embedderData, err := embedder.EmbedQuery(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	whereQuerys := make([]string, 0)
+	if scoreThreshold != 0 {
+		whereQuerys = append(whereQuerys, fmt.Sprintf("data.distance < %f", 1-scoreThreshold))
+	}
+	for k, v := range filter {
+		whereQuerys = append(whereQuerys, fmt.Sprintf("JSON_UNQUOTE(JSON_EXTRACT(data.cmetadata, '$.%s')) = '%s'", k, v))
+	}
+	whereQuery := strings.Join(whereQuerys, " AND ")
+	if len(whereQuery) == 0 {
+		whereQuery = "TRUE"
+	}
+
+	jsonEmbedding, err := json.Marshal(embedderData)
+	if err != nil {
+		return nil, err
+	}
+
+	sql := fmt.Sprintf(`WITH filtered_embedding_dims AS (
+    SELECT
+        *
+    FROM
+        %s
+)
+SELECT
+    data.document,
+    data.cmetadata,
+    (1 - data.distance) AS score
+FROM
+(
+    SELECT
+        f.*,
+        VEC_DISTANCE_COSINE(f.embedding, Vec_FromText(?)) AS distance
+    FROM
+        filtered_embedding_dims AS f
+        JOIN %s AS t ON f.collection_id = t.uuid
+    WHERE
+        t.name = '%s'
+) AS data
+WHERE %s
+ORDER BY
+    data.distance
+LIMIT
+    ?;`, s.embeddingTableName,
+		s.collectionTableName,
+		databaseName,
+		whereQuery)
+
+	rows, err := s.db.QueryContext(ctx, sql, jsonEmbedding, numDocuments)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	docs := make([]schema.Document, 0)
+	for rows.Next() {
+		var content string
+		var metadata string
+		var score float64
+
+		if err := rows.Scan(&content, &metadata, &score); err != nil {
+			return nil, err
+		}
+
+		var metadataMap map[string]any
+		if metadata != "" {
+			if err := json.Unmarshal([]byte(metadata), &metadataMap); err != nil {
+				return nil, err
+			}
+		}
+
+		docs = append(docs, schema.Document{
+			PageContent: content,
+			Metadata:    metadataMap,
+			Score:       float32(score),
+		})
+	}
+	return docs, rows.Err()
+}
+
+//nolint:cyclop
+func (s Store) Search(
+	ctx context.Context,
+	numDocuments int,
+	options ...vectorstores.Option,
+) ([]schema.Document, error) {
+	opts := s.getOptions(options...)
+	databaseName := s.getDatabaseName(opts)
+	filter, err := s.getFilters(opts)
+	if err != nil {
+		return nil, err
+	}
+	whereQuerys := make([]string, 0)
+	for k, v := range filter {
+		whereQuerys = append(whereQuerys, fmt.Sprintf("JSON_UNQUOTE(JSON_EXTRACT(%s.cmetadata, '$.%s')) = '%s'", s.embeddingTableName, k, v))
+	}
+	whereQuery := strings.Join(whereQuerys, " AND ")
+	if len(whereQuery) == 0 {
+		whereQuery = "TRUE"
+	}
+	sql := fmt.Sprintf(`SELECT
+	%s.document,
+	%s.cmetadata
+FROM %s
+JOIN %s ON %s.collection_id=%s.uuid
+WHERE %s.name='%s' AND %s
+LIMIT ?`, s.embeddingTableName, s.embeddingTableName, s.embeddingTableName,
+		s.collectionTableName, s.embeddingTableName, s.collectionTableName, s.collectionTableName, databaseName,
+		whereQuery)
+	rows, err := s.db.QueryContext(ctx, sql, numDocuments)
+	if err != nil {
+		return nil, err
+	}
+	docs := make([]schema.Document, 0)
+	defer rows.Close()
+
+	for rows.Next() {
+		doc := schema.Document{}
+		var metadata string
+		var metadataMap map[string]any
+		if err := rows.Scan(&doc.PageContent, &metadata); err != nil {
+			return nil, err
+		}
+		if metadata != "" {
+			if err := json.Unmarshal([]byte(metadata), &metadataMap); err != nil {
+				return nil, err
+			}
+		}
+		doc.Metadata = metadataMap
+		docs = append(docs, doc)
+	}
+	return docs, rows.Err()
+}
+
+func (s Store) DropTables(ctx context.Context) error {
+	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, s.embeddingTableName)); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, s.collectionTableName)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s Store) RemoveDatabase(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE name = ?`, s.collectionTableName), s.databaseName)
+	return err
+}
+
+func (s Store) createOrGetDatabase(ctx context.Context, tx *sql.Tx) error {
+	jsonMetadata, err := json.Marshal(s.databaseMetadata)
+	if err != nil {
+		return err
+	}
+	//nolint:gosec
+	sql := fmt.Sprintf(`INSERT INTO %s (`+"`uuid`"+`, name, cmetadata)
+		VALUES(?, ?, ?) ON DUPLICATE KEY UPDATE cmetadata = ?`, s.collectionTableName)
+	if _, err := tx.ExecContext(ctx, sql, uuid.New().String(), s.databaseName, jsonMetadata, jsonMetadata); err != nil {
+		return err
+	}
+	sql = fmt.Sprintf(`SELECT `+"`uuid`"+` FROM %s WHERE name = ? ORDER BY name limit 1`, s.collectionTableName)
+	return tx.QueryRowContext(ctx, sql, s.databaseName).Scan(&s.databaseUUID)
+}
+
+// getOptions applies given options to default Options and returns it
+// This uses options pattern so clients can easily pass options without changing function signature.
+func (s Store) getOptions(options ...vectorstores.Option) vectorstores.Options {
+	opts := vectorstores.Options{}
+	for _, opt := range options {
+		opt(&opts)
+	}
+	return opts
+}
+
+func (s Store) getDatabaseName(opts vectorstores.Options) string {
+	if opts.NameSpace != "" {
+		return opts.NameSpace
+	}
+	return s.databaseName
+}
+
+func (s Store) getScoreThreshold(opts vectorstores.Options) (float32, error) {
+	if opts.ScoreThreshold < 0 || opts.ScoreThreshold > 1 {
+		return 0, ErrInvalidScoreThreshold
+	}
+	return opts.ScoreThreshold, nil
+}
+
+// getFilters return metadata filters, now only support map[key]value pattern
+// TODO: should support more types like {"key1": {"key2":"values2"}} or {"key": ["value1", "values2"]}.
+func (s Store) getFilters(opts vectorstores.Options) (map[string]any, error) {
+	if opts.Filters != nil {
+		if filters, ok := opts.Filters.(map[string]any); ok {
+			return filters, nil
+		}
+		return nil, ErrInvalidFilters
+	}
+	return map[string]any{}, nil
+}
+
+func (s Store) deduplicate(
+	ctx context.Context,
+	opts vectorstores.Options,
+	docs []schema.Document,
+) []schema.Document {
+	if opts.Deduplicater == nil {
+		return docs
+	}
+
+	filtered := make([]schema.Document, 0, len(docs))
+	for _, doc := range docs {
+		if !opts.Deduplicater(ctx, doc) {
+			filtered = append(filtered, doc)
+		}
+	}
+
+	return filtered
+}

--- a/vectorstores/mariadb/mariadb_test.go
+++ b/vectorstores/mariadb/mariadb_test.go
@@ -1,0 +1,751 @@
+package mariadb_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcmariadb "github.com/testcontainers/testcontainers-go/modules/mariadb"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"github.com/tmc/langchaingo/chains"
+	"github.com/tmc/langchaingo/embeddings"
+	"github.com/tmc/langchaingo/llms/googleai"
+	"github.com/tmc/langchaingo/llms/openai"
+	"github.com/tmc/langchaingo/schema"
+	"github.com/tmc/langchaingo/vectorstores"
+	"github.com/tmc/langchaingo/vectorstores/mariadb"
+)
+
+func preCheckEnvSetting(t *testing.T) string {
+	t.Helper()
+
+	if openaiKey := os.Getenv("OPENAI_API_KEY"); openaiKey == "" {
+		t.Skip("OPENAI_API_KEY not set")
+	}
+
+	mariadbURL := os.Getenv("MARIADB_CONNECTION_STRING")
+	if mariadbURL == "" {
+		mariadbContainer, err := tcmariadb.Run(
+			context.Background(),
+			"mariadb:11.7-rc", // supports vector types and functions
+			tcmariadb.WithDatabase("db_test"),
+			tcmariadb.WithUsername("user"),
+			tcmariadb.WithPassword("passw0rd!"),
+			testcontainers.WithWaitStrategy(
+				wait.ForLog("ready for connections").
+					WithOccurrence(2).
+					WithStartupTimeout(30*time.Second)),
+		)
+		if err != nil && strings.Contains(err.Error(), "Cannot connect to the Docker daemon") {
+			t.Skip("Docker not available")
+		}
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, mariadbContainer.Terminate(context.Background()))
+		})
+
+		str, err := mariadbContainer.ConnectionString(context.Background())
+		require.NoError(t, err)
+
+		mariadbURL = str
+	}
+
+	return mariadbURL
+}
+
+func makeNewCollectionName() string {
+	return fmt.Sprintf("test-collection-%s", uuid.New().String())
+}
+
+func cleanupTestArtifacts(ctx context.Context, t *testing.T, s mariadb.Store, mariadbURL string) {
+	t.Helper()
+
+	db, err := sql.Open("mysql", mariadbURL)
+	require.NoError(t, err)
+
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, s.RemoveDatabase(ctx, tx))
+
+	require.NoError(t, tx.Commit())
+}
+
+func TestMariaDBStoreRest(t *testing.T) {
+	t.Parallel()
+	mariadbURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", mariadbURL)
+	require.NoError(t, err)
+
+	store, err := mariadb.New(
+		ctx,
+		mariadb.WithDB(db),
+		mariadb.WithEmbedder(e),
+		mariadb.WithVectorDimensions(1536),
+		mariadb.WithPreDeleteDatabase(true),
+		mariadb.WithDatabaseName(makeNewCollectionName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, mariadbURL)
+
+	_, err = store.AddDocuments(ctx, []schema.Document{
+		{PageContent: "tokyo", Metadata: map[string]any{
+			"country": "japan",
+		}},
+		{PageContent: "potato"},
+	})
+	require.NoError(t, err)
+
+	docs, err := store.SimilaritySearch(ctx, "japan", 1)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.Equal(t, "tokyo", docs[0].PageContent)
+	require.Equal(t, "japan", docs[0].Metadata["country"])
+}
+
+func TestMariaDBStoreRestWithScoreThreshold(t *testing.T) {
+	t.Parallel()
+	mariadbURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", mariadbURL)
+	require.NoError(t, err)
+
+	store, err := mariadb.New(
+		ctx,
+		mariadb.WithDB(db),
+		mariadb.WithEmbedder(e),
+		mariadb.WithVectorDimensions(1536),
+		mariadb.WithPreDeleteDatabase(true),
+		mariadb.WithDatabaseName(makeNewCollectionName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, mariadbURL)
+
+	_, err = store.AddDocuments(context.Background(), []schema.Document{
+		{PageContent: "Tokyo"},
+		{PageContent: "Yokohama"},
+		{PageContent: "Osaka"},
+		{PageContent: "Nagoya"},
+		{PageContent: "Sapporo"},
+		{PageContent: "Fukuoka"},
+		{PageContent: "Dublin"},
+		{PageContent: "Paris"},
+		{PageContent: "London"},
+		{PageContent: "New York"},
+	})
+	require.NoError(t, err)
+
+	// test with a score threshold of 0.8, expected 6 documents
+	docs, err := store.SimilaritySearch(
+		ctx,
+		"Which of these are cities in Japan",
+		10,
+		vectorstores.WithScoreThreshold(0.8),
+	)
+	require.NoError(t, err)
+	require.Len(t, docs, 6)
+
+	// test with a score threshold of 0, expected all 10 documents
+	docs, err = store.SimilaritySearch(
+		ctx,
+		"Which of these are cities in Japan",
+		10,
+		vectorstores.WithScoreThreshold(0))
+	require.NoError(t, err)
+	require.Len(t, docs, 10)
+}
+
+func TestMariaDBStoreSimilarityScore(t *testing.T) {
+	t.Parallel()
+	mariadbURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", mariadbURL)
+	require.NoError(t, err)
+
+	store, err := mariadb.New(
+		ctx,
+		mariadb.WithDB(db),
+		mariadb.WithEmbedder(e),
+		mariadb.WithVectorDimensions(1536),
+		mariadb.WithPreDeleteDatabase(true),
+		mariadb.WithDatabaseName(makeNewCollectionName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, mariadbURL)
+
+	_, err = store.AddDocuments(context.Background(), []schema.Document{
+		{PageContent: "Tokyo is the capital city of Japan."},
+		{PageContent: "Paris is the city of love."},
+		{PageContent: "I like to visit London."},
+	})
+	require.NoError(t, err)
+
+	// test with a score threshold of 0.8, expected 6 documents
+	docs, err := store.SimilaritySearch(
+		ctx,
+		"What is the capital city of Japan?",
+		3,
+		vectorstores.WithScoreThreshold(0.8),
+	)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.True(t, docs[0].Score > 0.9)
+}
+
+func TestSimilaritySearchWithInvalidScoreThreshold(t *testing.T) {
+	t.Parallel()
+	mariadbURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", mariadbURL)
+	require.NoError(t, err)
+
+	store, err := mariadb.New(
+		ctx,
+		mariadb.WithDB(db),
+		mariadb.WithEmbedder(e),
+		mariadb.WithVectorDimensions(1536),
+		mariadb.WithPreDeleteDatabase(true),
+		mariadb.WithDatabaseName(makeNewCollectionName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, mariadbURL)
+
+	_, err = store.AddDocuments(ctx, []schema.Document{
+		{PageContent: "Tokyo"},
+		{PageContent: "Yokohama"},
+		{PageContent: "Osaka"},
+		{PageContent: "Nagoya"},
+		{PageContent: "Sapporo"},
+		{PageContent: "Fukuoka"},
+		{PageContent: "Dublin"},
+		{PageContent: "Paris"},
+		{PageContent: "London"},
+		{PageContent: "New York"},
+	})
+	require.NoError(t, err)
+
+	_, err = store.SimilaritySearch(
+		ctx,
+		"Which of these are cities in Japan",
+		10,
+		vectorstores.WithScoreThreshold(-0.8),
+	)
+	require.Error(t, err)
+
+	_, err = store.SimilaritySearch(
+		ctx,
+		"Which of these are cities in Japan",
+		10,
+		vectorstores.WithScoreThreshold(1.8),
+	)
+	require.Error(t, err)
+}
+
+// note, we can also use same llm to show this test, but need imply
+// openai embedding [dimensions](https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-dimensions) args.
+func TestSimilaritySearchWithDifferentDimensions(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mariadbURL := preCheckEnvSetting(t)
+	genaiKey := os.Getenv("GENAI_API_KEY")
+	if genaiKey == "" {
+		t.Skip("GENAI_API_KEY not set")
+	}
+	collectionName := makeNewCollectionName()
+
+	// use Google embedding (now default model is embedding-001, with dimensions:768) to add some data to collection
+	googleLLM, err := googleai.New(ctx, googleai.WithAPIKey(genaiKey))
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(googleLLM)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", mariadbURL)
+	require.NoError(t, err)
+
+	store, err := mariadb.New(
+		ctx,
+		mariadb.WithDB(db),
+		mariadb.WithEmbedder(e),
+		mariadb.WithPreDeleteDatabase(true),
+		mariadb.WithDatabaseName(collectionName),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, mariadbURL)
+
+	_, err = store.AddDocuments(ctx, []schema.Document{
+		{PageContent: "Beijing"},
+	})
+	require.NoError(t, err)
+
+	// use openai embedding (now default model is text-embedding-ada-002, with dimensions:1536) to add some data to same collection (same table)
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err = embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	store, err = mariadb.New(
+		ctx,
+		mariadb.WithDB(db),
+		mariadb.WithEmbedder(e),
+		mariadb.WithVectorDimensions(1536),
+		mariadb.WithPreDeleteDatabase(false),
+		mariadb.WithDatabaseName(collectionName),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, mariadbURL)
+
+	_, err = store.AddDocuments(ctx, []schema.Document{
+		{PageContent: "Tokyo"},
+		{PageContent: "Yokohama"},
+		{PageContent: "Osaka"},
+		{PageContent: "Nagoya"},
+		{PageContent: "Sapporo"},
+		{PageContent: "Fukuoka"},
+		{PageContent: "Dublin"},
+		{PageContent: "Paris"},
+		{PageContent: "London"},
+		{PageContent: "New York"},
+	})
+	require.NoError(t, err)
+
+	docs, err := store.SimilaritySearch(
+		ctx,
+		"Which of these are cities in Japan",
+		5,
+	)
+	require.NoError(t, err)
+	require.Len(t, docs, 5)
+}
+
+func TestMariaDBAsRetriever(t *testing.T) {
+	t.Parallel()
+	mariadbURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", mariadbURL)
+	require.NoError(t, err)
+
+	store, err := mariadb.New(
+		ctx,
+		mariadb.WithDB(db),
+		mariadb.WithEmbedder(e),
+		mariadb.WithVectorDimensions(1536),
+		mariadb.WithPreDeleteDatabase(true),
+		mariadb.WithDatabaseName(makeNewCollectionName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, mariadbURL)
+
+	_, err = store.AddDocuments(
+		ctx,
+		[]schema.Document{
+			{PageContent: "The color of the house is blue."},
+			{PageContent: "The color of the car is red."},
+			{PageContent: "The color of the desk is orange."},
+		},
+	)
+	require.NoError(t, err)
+
+	result, err := chains.Run(
+		ctx,
+		chains.NewRetrievalQAFromLLM(
+			llm,
+			vectorstores.ToRetriever(store, 1),
+		),
+		"What color is the desk?",
+	)
+	require.NoError(t, err)
+	require.True(t, strings.Contains(result, "orange"), "expected orange in result")
+}
+
+func TestMariaDBAsRetrieverWithScoreThreshold(t *testing.T) {
+	t.Parallel()
+	mariadbURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", mariadbURL)
+	require.NoError(t, err)
+
+	store, err := mariadb.New(
+		ctx,
+		mariadb.WithDB(db),
+		mariadb.WithEmbedder(e),
+		mariadb.WithVectorDimensions(1536),
+		mariadb.WithPreDeleteDatabase(true),
+		mariadb.WithDatabaseName(makeNewCollectionName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, mariadbURL)
+
+	_, err = store.AddDocuments(
+		context.Background(),
+		[]schema.Document{
+			{PageContent: "The color of the house is blue."},
+			{PageContent: "The color of the car is red."},
+			{PageContent: "The color of the desk is orange."},
+			{PageContent: "The color of the lamp beside the desk is black."},
+			{PageContent: "The color of the chair beside the desk is beige."},
+		},
+	)
+	require.NoError(t, err)
+
+	result, err := chains.Run(
+		ctx,
+		chains.NewRetrievalQAFromLLM(
+			llm,
+			vectorstores.ToRetriever(store, 5, vectorstores.WithScoreThreshold(0.8)),
+		),
+		"What colors is each piece of furniture next to the desk?",
+	)
+	require.NoError(t, err)
+
+	require.Contains(t, result, "orange", "expected orange in result")
+	require.Contains(t, result, "black", "expected black in result")
+	require.Contains(t, result, "beige", "expected beige in result")
+}
+
+func TestMariaDBAsRetrieverWithMetadataFilterNotSelected(t *testing.T) {
+	t.Parallel()
+	mariadbURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", mariadbURL)
+	require.NoError(t, err)
+
+	store, err := mariadb.New(
+		ctx,
+		mariadb.WithDB(db),
+		mariadb.WithEmbedder(e),
+		mariadb.WithVectorDimensions(1536),
+		mariadb.WithPreDeleteDatabase(true),
+		mariadb.WithDatabaseName(makeNewCollectionName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, mariadbURL)
+
+	_, err = store.AddDocuments(
+		ctx,
+		[]schema.Document{
+			{
+				PageContent: "in kitchen, The color of the lamp beside the desk is black.",
+				Metadata: map[string]any{
+					"location": "kitchen",
+				},
+			},
+			{
+				PageContent: "in bedroom, The color of the lamp beside the desk is blue.",
+				Metadata: map[string]any{
+					"location": "bedroom",
+				},
+			},
+			{
+				PageContent: "in office, The color of the lamp beside the desk is orange.",
+				Metadata: map[string]any{
+					"location": "office",
+				},
+			},
+			{
+				PageContent: "in sitting room, The color of the lamp beside the desk is purple.",
+				Metadata: map[string]any{
+					"location": "sitting room",
+				},
+			},
+			{
+				PageContent: "in patio, The color of the lamp beside the desk is yellow.",
+				Metadata: map[string]any{
+					"location": "patio",
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	result, err := chains.Run(
+		ctx,
+		chains.NewRetrievalQAFromLLM(
+			llm,
+			vectorstores.ToRetriever(store, 5),
+		),
+		"What color is the lamp in each room?",
+	)
+	require.NoError(t, err)
+	result = strings.ToLower(result)
+
+	require.Contains(t, result, "black", "expected black in result")
+	require.Contains(t, result, "blue", "expected blue in result")
+	require.Contains(t, result, "orange", "expected orange in result")
+	require.Contains(t, result, "purple", "expected purple in result")
+	require.Contains(t, result, "yellow", "expected yellow in result")
+}
+
+func TestMariaDBAsRetrieverWithMetadataFilters(t *testing.T) {
+	t.Parallel()
+	mariadbURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", mariadbURL)
+	require.NoError(t, err)
+
+	store, err := mariadb.New(
+		ctx,
+		mariadb.WithDB(db),
+		mariadb.WithEmbedder(e),
+		mariadb.WithVectorDimensions(1536),
+		mariadb.WithPreDeleteDatabase(true),
+		mariadb.WithDatabaseName(makeNewCollectionName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, mariadbURL)
+
+	_, err = store.AddDocuments(
+		context.Background(),
+		[]schema.Document{
+			{
+				PageContent: "In office, the color of the lamp beside the desk is orange.",
+				Metadata: map[string]any{
+					"location":    "office",
+					"square_feet": 100,
+				},
+			},
+			{
+				PageContent: "in sitting room, the color of the lamp beside the desk is purple.",
+				Metadata: map[string]any{
+					"location":    "sitting room",
+					"square_feet": 400,
+				},
+			},
+			{
+				PageContent: "in patio, the color of the lamp beside the desk is yellow.",
+				Metadata: map[string]any{
+					"location":    "patio",
+					"square_feet": 800,
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	filter := map[string]any{"location": "sitting room"}
+
+	result, err := chains.Run(
+		ctx,
+		chains.NewRetrievalQAFromLLM(
+			llm,
+			vectorstores.ToRetriever(store,
+				5,
+				vectorstores.WithFilters(filter))),
+		"What color is the lamp in each room?",
+	)
+	require.NoError(t, err)
+	require.Contains(t, result, "purple", "expected purple in result")
+	require.NotContains(t, result, "orange", "expected not orange in result")
+	require.NotContains(t, result, "yellow", "expected not yellow in result")
+}
+
+func TestDeduplicater(t *testing.T) {
+	t.Parallel()
+	mariadbURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", mariadbURL)
+	require.NoError(t, err)
+
+	store, err := mariadb.New(
+		ctx,
+		mariadb.WithDB(db),
+		mariadb.WithEmbedder(e),
+		mariadb.WithVectorDimensions(1536),
+		mariadb.WithPreDeleteDatabase(true),
+		mariadb.WithDatabaseName(makeNewCollectionName()),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, mariadbURL)
+
+	_, err = store.AddDocuments(context.Background(), []schema.Document{
+		{PageContent: "tokyo", Metadata: map[string]any{
+			"type": "city",
+		}},
+		{PageContent: "potato", Metadata: map[string]any{
+			"type": "vegetable",
+		}},
+	}, vectorstores.WithDeduplicater(
+		func(_ context.Context, doc schema.Document) bool {
+			return doc.PageContent == "tokyo"
+		},
+	))
+	require.NoError(t, err)
+
+	docs, err := store.Search(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.Equal(t, "potato", docs[0].PageContent)
+	require.Equal(t, "vegetable", docs[0].Metadata["type"])
+}
+
+func TestWithAllOptions(t *testing.T) {
+	t.Parallel()
+	mariadbURL := preCheckEnvSetting(t)
+	ctx := context.Background()
+
+	llm, err := openai.New(
+		openai.WithEmbeddingModel("text-embedding-ada-002"),
+	)
+	require.NoError(t, err)
+	e, err := embeddings.NewEmbedder(llm)
+	require.NoError(t, err)
+	require.NoError(t, err)
+	db, err := sql.Open("mysql", mariadbURL)
+	require.NoError(t, err)
+	defer db.Close()
+
+	store, err := mariadb.New(
+		ctx,
+		mariadb.WithDB(db),
+		mariadb.WithEmbedder(e),
+		mariadb.WithPreDeleteDatabase(true),
+		mariadb.WithDatabaseName(makeNewCollectionName()),
+		mariadb.WithCollectionTableName("collection_table_name"),
+		mariadb.WithEmbeddingTableName("embedding_table_name"),
+		mariadb.WithDatabaseMetadata(map[string]any{
+			"key": "value",
+		}),
+		mariadb.WithVectorDimensions(1536),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, mariadbURL)
+
+	_, err = store.AddDocuments(ctx, []schema.Document{
+		{PageContent: "tokyo", Metadata: map[string]any{
+			"country": "japan",
+		}},
+		{PageContent: "potato"},
+	})
+	require.NoError(t, err)
+
+	docs, err := store.SimilaritySearch(ctx, "japan", 1)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.Equal(t, "tokyo", docs[0].PageContent)
+	require.Equal(t, "japan", docs[0].Metadata["country"])
+
+	store, err = mariadb.New(
+		ctx,
+		mariadb.WithDB(db),
+		mariadb.WithEmbedder(e),
+		mariadb.WithPreDeleteDatabase(true),
+		mariadb.WithDatabaseName(makeNewCollectionName()),
+		mariadb.WithCollectionTableName("collection_table_name1"),
+		mariadb.WithEmbeddingTableName("embedding_table_name1"),
+		mariadb.WithDatabaseMetadata(map[string]any{
+			"key": "value",
+		}),
+		mariadb.WithVectorDimensions(1536),
+	)
+	require.NoError(t, err)
+
+	defer cleanupTestArtifacts(ctx, t, store, mariadbURL)
+
+	_, err = store.AddDocuments(ctx, []schema.Document{
+		{PageContent: "tokyo", Metadata: map[string]any{
+			"country": "japan",
+		}},
+		{PageContent: "potato"},
+	})
+	require.NoError(t, err)
+
+	docs, err = store.SimilaritySearch(ctx, "japan", 1)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.Equal(t, "tokyo", docs[0].PageContent)
+	require.Equal(t, "japan", docs[0].Metadata["country"])
+}

--- a/vectorstores/mariadb/options.go
+++ b/vectorstores/mariadb/options.go
@@ -1,0 +1,108 @@
+package mariadb
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/tmc/langchaingo/embeddings"
+)
+
+const (
+	DefaultDatabaseName             = "langchain"
+	DefaultPreDeleteDatabase        = false
+	DefaultEmbeddingStoreTableName  = "langchain_mariadb_embedding"
+	DefaultCollectionStoreTableName = "langchain_mariadb_collection"
+)
+
+// ErrInvalidOptions is returned when the options given are invalid.
+var ErrInvalidOptions = errors.New("invalid options")
+
+// Option is a function type that can be used to modify the client.
+type Option func(p *Store)
+
+// WithEmbedder is an option for setting the embedder to use. Must be set.
+func WithEmbedder(e embeddings.Embedder) Option {
+	return func(p *Store) {
+		p.embedder = e
+	}
+}
+
+// WithPreDeleteDatabase is an option for setting if the database should be deleted before creating.
+func WithPreDeleteDatabase(preDelete bool) Option {
+	return func(p *Store) {
+		p.preDeleteDatabase = preDelete
+	}
+}
+
+// WithDatabaseName is an option for specifying the database name.
+func WithDatabaseName(name string) Option {
+	return func(p *Store) {
+		p.databaseName = name
+	}
+}
+
+// WithEmbeddingTableName is an option for specifying the embedding table name.
+func WithEmbeddingTableName(name string) Option {
+	return func(p *Store) {
+		p.embeddingTableName = name
+	}
+}
+
+// WithCollectionTableName is an option for specifying the collection table name.
+func WithCollectionTableName(name string) Option {
+	return func(p *Store) {
+		p.collectionTableName = name
+	}
+}
+
+// WithConnectionURL is an option for specifying the MariaDB connection URL. Either this
+// or WithConn must be used.
+func WithConnectionURL(connectionURL string) Option {
+	return func(p *Store) {
+		p.connURL = connectionURL
+	}
+}
+
+// WithDB is an option for specifying the MariaDB connection.
+func WithDB(db DB) Option {
+	return func(p *Store) {
+		p.db = db
+	}
+}
+
+// WithDatabaseMetadata is an option for specifying the database metadata.
+func WithDatabaseMetadata(metadata map[string]any) Option {
+	return func(p *Store) {
+		p.databaseMetadata = metadata
+	}
+}
+
+// WithVectorDimensions is an option for specifying the vector size.
+func WithVectorDimensions(size int) Option {
+	return func(p *Store) {
+		p.vectorDimensions = size
+	}
+}
+
+func applyClientOptions(opts ...Option) (Store, error) {
+	o := &Store{
+		databaseName:        DefaultDatabaseName,
+		preDeleteDatabase:   DefaultPreDeleteDatabase,
+		embeddingTableName:  DefaultEmbeddingStoreTableName,
+		collectionTableName: DefaultCollectionStoreTableName,
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	if o.db == nil && o.connURL == "" {
+		return Store{}, fmt.Errorf("%w: missing mariadb connection", ErrInvalidOptions)
+	}
+
+	if o.embedder == nil {
+		return Store{}, fmt.Errorf("%w: missing embedder", ErrInvalidOptions)
+	}
+
+	return *o, nil
+}


### PR DESCRIPTION
## Summary
Add vector store implementations for MariaDB and Dolt databases, providing native vector similarity search capabilities.

## Features

### MariaDB Vector Store
- Full vector similarity search using MariaDB's native vector functions
- Support for cosine and L2 distance metrics
- Metadata filtering capabilities
- Document management (add, delete, search)
- Configurable collection names and embedding dimensions

### Dolt Vector Store
- Git-like version control for vector data
- Same API as MariaDB implementation
- Branch and merge capabilities for vector collections
- Full compatibility with MariaDB vector functions

## Implementation Details
- Both implementations share similar architecture for consistency
- Uses testcontainers for integration testing
- Proper database initialization and table creation
- Thread-safe operations with proper connection handling

## Testing
```bash
# Run MariaDB tests
go test -v ./vectorstores/mariadb/...

# Run Dolt tests  
go test -v ./vectorstores/dolt/...
```

## Dependencies
- Updated testcontainers to v0.38.0 for MariaDB module support
- Added testcontainers MariaDB module for testing

## Use Cases
- Applications requiring vector search with SQL databases
- Systems needing versioned vector data (Dolt)
- Projects already using MariaDB/MySQL infrastructure