### PR TITLE
llms/openai: improve SSE comment handling in streaming responses

### DIFF
--- a/llms/openai/internal/openaiclient/chat_sse_test.go
+++ b/llms/openai/internal/openaiclient/chat_sse_test.go
@@ -1,0 +1,81 @@
+package openaiclient
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestParseStreamingChatResponse_SSEComments(t *testing.T) {
+	ctx := context.Background()
+	t.Parallel()
+
+	// Test the key SSE comment patterns
+	testCases := []struct {
+		name            string
+		body            string
+		expectedContent string
+	}{
+		{
+			name: "openrouter_comments",
+			body: `data: {"id":"1","object":"chat.completion.chunk","created":1234567890,"model":"test","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}
+: OPENROUTER PROCESSING
+: OPENROUTER PROCESSING
+data: {"id":"1","object":"chat.completion.chunk","created":1234567890,"model":"test","choices":[{"index":0,"delta":{"content":" World"},"finish_reason":null}]}
+data: {"id":"1","object":"chat.completion.chunk","created":1234567890,"model":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+data: [DONE]`,
+			expectedContent: "Hello World",
+		},
+		{
+			name: "comments_without_space",
+			body: `data: {"id":"1","object":"chat.completion.chunk","created":1234567890,"model":"test","choices":[{"index":0,"delta":{"content":"Test"},"finish_reason":null}]}
+:comment-without-space
+data: {"id":"1","object":"chat.completion.chunk","created":1234567890,"model":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+data: [DONE]`,
+			expectedContent: "Test",
+		},
+		{
+			name: "other_sse_fields",
+			body: `event: message
+id: 12345
+data: {"id":"1","object":"chat.completion.chunk","created":1234567890,"model":"test","choices":[{"index":0,"delta":{"content":"Data"},"finish_reason":null}]}
+retry: 1000
+data: {"id":"1","object":"chat.completion.chunk","created":1234567890,"model":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+data: [DONE]`,
+			expectedContent: "Data",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			
+			r := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString(tc.body)),
+			}
+
+			req := &ChatRequest{
+				StreamingFunc: func(_ context.Context, _ []byte) error {
+					return nil
+				},
+			}
+
+			resp, err := parseStreamingChatResponse(ctx, r, req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp == nil {
+				t.Fatal("response should not be nil")
+			}
+			if len(resp.Choices) == 0 {
+				t.Fatal("expected at least one choice")
+			}
+			if got := resp.Choices[0].Message.Content; got != tc.expectedContent {
+				t.Errorf("content mismatch: got %q, want %q", got, tc.expectedContent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR improves SSE (Server-Sent Events) handling in OpenAI streaming responses to properly follow the SSE specification.

## Changes

- Added proper handling for SSE comment lines (any line starting with ':')
- Added explicit check for 'data:' prefix before processing lines
- Skip other SSE fields (event:, id:, retry:) that aren't data
- Added comprehensive tests for various SSE comment patterns

## Context

This supersedes PR #1332 with a more complete implementation that:
1. Handles ALL comment formats (not just ': ' with space)
2. Properly skips non-data SSE fields
3. Follows the W3C SSE specification

## Testing

Added tests covering:
- OpenRouter-style comments (': OPENROUTER PROCESSING')
- Comments without spaces (':comment')
- Other SSE fields (event:, id:, retry:)

Fixes #942

cc @rickif (author of #1332)