### PR TITLE
feat: add support for deprecated max_tokens open ai param

### DIFF
--- a/llms/openai/base_url_test.go
+++ b/llms/openai/base_url_test.go
@@ -1,0 +1,95 @@
+package openai
+
+import (
+	"testing"
+)
+
+func TestIsUsingCustomBaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		options  []Option
+		expected bool
+	}{
+		{
+			name:     "Default OpenAI URL",
+			options:  []Option{},
+			expected: false,
+		},
+		{
+			name:     "Explicit default OpenAI URL",
+			options:  []Option{WithBaseURL("https://api.openai.com/v1")},
+			expected: false,
+		},
+		{
+			name:     "Custom base URL (OpenRouter)",
+			options:  []Option{WithBaseURL("https://openrouter.ai/api/v1")},
+			expected: true,
+		},
+		{
+			name:     "Custom base URL (local)",
+			options:  []Option{WithBaseURL("http://localhost:8080/v1")},
+			expected: true,
+		},
+		{
+			name:     "Azure URL",
+			options:  []Option{WithBaseURL("https://myinstance.openai.azure.com")},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create client with test options
+			opts := append(tt.options, WithToken("test-token"))
+			llm, err := New(opts...)
+			if err != nil {
+				t.Fatalf("Failed to create OpenAI client: %v", err)
+			}
+
+			result := llm.IsUsingCustomBaseURL()
+			if result != tt.expected {
+				t.Errorf("IsUsingCustomBaseURL() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetBaseURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		options     []Option
+		expectedURL string
+	}{
+		{
+			name:        "Default OpenAI URL",
+			options:     []Option{},
+			expectedURL: "https://api.openai.com/v1",
+		},
+		{
+			name:        "Custom base URL (OpenRouter)",
+			options:     []Option{WithBaseURL("https://openrouter.ai/api/v1")},
+			expectedURL: "https://openrouter.ai/api/v1",
+		},
+		{
+			name:        "Custom base URL (local)",
+			options:     []Option{WithBaseURL("http://localhost:8080/v1")},
+			expectedURL: "http://localhost:8080/v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create client with test options
+			opts := append(tt.options, WithToken("test-token"))
+			llm, err := New(opts...)
+			if err != nil {
+				t.Fatalf("Failed to create OpenAI client: %v", err)
+			}
+
+			result := llm.GetBaseURL()
+			if result != tt.expectedURL {
+				t.Errorf("GetBaseURL() = %v, want %v", result, tt.expectedURL)
+			}
+		})
+	}
+}

--- a/llms/openai/helpers.go
+++ b/llms/openai/helpers.go
@@ -1,0 +1,28 @@
+package openai
+
+import "github.com/tmc/langchaingo/llms"
+
+// IsOpenAIModel returns true if the provided model is an OpenAI LLM instance.
+// This is useful for type checking when you have a generic llms.Model.
+func IsOpenAIModel(model llms.Model) bool {
+	_, ok := model.(*LLM)
+	return ok
+}
+
+// GetOpenAIBaseURL returns the base URL if the model is an OpenAI LLM, otherwise returns empty string.
+// This is a convenience function for working with generic llms.Model interfaces.
+func GetOpenAIBaseURL(model llms.Model) string {
+	if openaiLLM, ok := model.(*LLM); ok {
+		return openaiLLM.GetBaseURL()
+	}
+	return ""
+}
+
+// IsOpenAIUsingCustomBaseURL returns true if the model is an OpenAI LLM using a custom base URL.
+// Returns false if the model is not an OpenAI LLM or is using the default OpenAI URL.
+func IsOpenAIUsingCustomBaseURL(model llms.Model) bool {
+	if openaiLLM, ok := model.(*LLM); ok {
+		return openaiLLM.IsUsingCustomBaseURL()
+	}
+	return false
+}

--- a/llms/openai/helpers_test.go
+++ b/llms/openai/helpers_test.go
@@ -1,0 +1,117 @@
+package openai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+// Mock LLM for testing
+type mockNonOpenAILLM struct{}
+
+func (m *mockNonOpenAILLM) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
+	return "", nil
+}
+
+func (m *mockNonOpenAILLM) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
+	return nil, nil
+}
+
+func TestIsOpenAIModel(t *testing.T) {
+	// Test with OpenAI model
+	openaiLLM, err := New(WithToken("test-token"))
+	if err != nil {
+		t.Fatalf("Failed to create OpenAI LLM: %v", err)
+	}
+
+	if !IsOpenAIModel(openaiLLM) {
+		t.Error("IsOpenAIModel should return true for OpenAI LLM")
+	}
+
+	// Test with non-OpenAI model
+	mockLLM := &mockNonOpenAILLM{}
+	if IsOpenAIModel(mockLLM) {
+		t.Error("IsOpenAIModel should return false for non-OpenAI LLM")
+	}
+}
+
+func TestGetOpenAIBaseURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		options     []Option
+		expectedURL string
+	}{
+		{
+			name:        "Default OpenAI URL",
+			options:     []Option{WithToken("test-token")},
+			expectedURL: "https://api.openai.com/v1",
+		},
+		{
+			name:        "Custom base URL",
+			options:     []Option{WithToken("test-token"), WithBaseURL("https://openrouter.ai/api/v1")},
+			expectedURL: "https://openrouter.ai/api/v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			openaiLLM, err := New(tt.options...)
+			if err != nil {
+				t.Fatalf("Failed to create OpenAI LLM: %v", err)
+			}
+
+			url := GetOpenAIBaseURL(openaiLLM)
+			if url != tt.expectedURL {
+				t.Errorf("GetOpenAIBaseURL() = %v, want %v", url, tt.expectedURL)
+			}
+		})
+	}
+
+	// Test with non-OpenAI model
+	mockLLM := &mockNonOpenAILLM{}
+	url := GetOpenAIBaseURL(mockLLM)
+	if url != "" {
+		t.Errorf("GetOpenAIBaseURL should return empty string for non-OpenAI LLM, got %v", url)
+	}
+}
+
+func TestIsOpenAIUsingCustomBaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		options  []Option
+		expected bool
+	}{
+		{
+			name:     "Default OpenAI URL",
+			options:  []Option{WithToken("test-token")},
+			expected: false,
+		},
+		{
+			name:     "Custom base URL",
+			options:  []Option{WithToken("test-token"), WithBaseURL("https://openrouter.ai/api/v1")},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			openaiLLM, err := New(tt.options...)
+			if err != nil {
+				t.Fatalf("Failed to create OpenAI LLM: %v", err)
+			}
+
+			result := IsOpenAIUsingCustomBaseURL(openaiLLM)
+			if result != tt.expected {
+				t.Errorf("IsOpenAIUsingCustomBaseURL() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+
+	// Test with non-OpenAI model
+	mockLLM := &mockNonOpenAILLM{}
+	result := IsOpenAIUsingCustomBaseURL(mockLLM)
+	if result {
+		t.Error("IsOpenAIUsingCustomBaseURL should return false for non-OpenAI LLM")
+	}
+}

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -34,7 +34,7 @@ type ChatRequest struct {
 	Temperature float64        `json:"temperature"`
 	TopP        float64        `json:"top_p,omitempty"`
 	// Deprecated: Use MaxCompletionTokens
-	MaxTokens           int      `json:"-"`
+	MaxTokens           int      `json:"max_tokens,omitempty"`
 	MaxCompletionTokens int      `json:"max_completion_tokens,omitempty"`
 	N                   int      `json:"n,omitempty"`
 	StopWords           []string `json:"stop,omitempty"`

--- a/llms/openai/internal/openaiclient/openaiclient.go
+++ b/llms/openai/internal/openaiclient/openaiclient.go
@@ -208,3 +208,8 @@ func (c *Client) buildAzureURL(suffix string, model string) string {
 		baseURL, model, suffix, c.apiVersion,
 	)
 }
+
+// GetBaseURL returns the base URL being used by the client.
+func (c *Client) GetBaseURL() string {
+	return c.baseURL
+}

--- a/llms/openai/token_options.go
+++ b/llms/openai/token_options.go
@@ -1,0 +1,38 @@
+package openai
+
+import "github.com/tmc/langchaingo/llms"
+
+// WithMaxCompletionTokens specifies the maximum number of completion tokens to generate.
+// This is the recommended way to limit token generation in OpenAI models and corresponds
+// to the max_completion_tokens field in the OpenAI API.
+//
+// This is an OpenAI-specific option that should be used instead of the generic
+// llms.WithMaxTokens for better control and to avoid API errors.
+func WithMaxCompletionTokens(maxCompletionTokens int) llms.CallOption {
+	return func(opts *llms.CallOptions) {
+		// Store in MaxTokens for backward compatibility with the existing client logic,
+		// but mark it specially so we know it's for max_completion_tokens
+		opts.MaxTokens = maxCompletionTokens
+		// Use metadata to store that this is specifically max_completion_tokens
+		if opts.Metadata == nil {
+			opts.Metadata = make(map[string]interface{})
+		}
+		opts.Metadata["_openai_use_max_completion_tokens"] = true
+	}
+}
+
+// WithDeprecatedMaxTokens specifies the maximum number of tokens using the deprecated max_tokens field.
+// This is provided for compatibility with OpenAI-compatible providers that still require this field.
+//
+// Note: OpenAI's official API will return a 400 error if both max_tokens and max_completion_tokens
+// are set. Use this only when working with providers that require the deprecated field.
+func WithDeprecatedMaxTokens(maxTokens int) llms.CallOption {
+	return func(opts *llms.CallOptions) {
+		opts.MaxTokens = maxTokens
+		// Use metadata to store that this should use the deprecated max_tokens field
+		if opts.Metadata == nil {
+			opts.Metadata = make(map[string]interface{})
+		}
+		opts.Metadata["_openai_use_deprecated_max_tokens"] = true
+	}
+}

--- a/llms/openai/token_options_test.go
+++ b/llms/openai/token_options_test.go
@@ -1,0 +1,302 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/openai/internal/openaiclient"
+)
+
+// Helper function to create and test token options mapping
+func testTokenOptionsMapping(t *testing.T, options []llms.CallOption, expectedMaxCompletionTokens, expectedMaxTokens int, description string) {
+	// Apply options to get CallOptions
+	opts := llms.CallOptions{}
+	for _, opt := range options {
+		opt(&opts)
+	}
+
+	// Create the request struct using the same logic as the OpenAI client
+	req := createTestChatRequest(opts)
+
+	// Verify the field values
+	if req.MaxCompletionTokens != expectedMaxCompletionTokens {
+		t.Errorf("MaxCompletionTokens = %v, want %v. %s",
+			req.MaxCompletionTokens, expectedMaxCompletionTokens, description)
+	}
+
+	// Use a helper to avoid directly accessing deprecated field
+	actualMaxTokens := getMaxTokensForTest(req)
+	if actualMaxTokens != expectedMaxTokens {
+		t.Errorf("MaxTokens = %v, want %v. %s",
+			actualMaxTokens, expectedMaxTokens, description)
+	}
+
+	// Verify that both fields are never set simultaneously
+	if req.MaxCompletionTokens > 0 && actualMaxTokens > 0 {
+		t.Errorf("Both MaxCompletionTokens (%v) and MaxTokens (%v) are set, which would cause API error",
+			req.MaxCompletionTokens, actualMaxTokens)
+	}
+}
+
+// Helper function to create a chat request for testing
+func createTestChatRequest(opts llms.CallOptions) *openaiclient.ChatRequest {
+	return &openaiclient.ChatRequest{
+		Model:    "gpt-3.5-turbo",
+		Messages: []*openaiclient.ChatMessage{{Role: "user", Content: "test"}},
+		MaxCompletionTokens: func() int {
+			// Check if this should explicitly use max_completion_tokens field
+			if opts.Metadata != nil {
+				if useMaxCompletion, ok := opts.Metadata["_openai_use_max_completion_tokens"].(bool); ok && useMaxCompletion {
+					return opts.MaxTokens
+				}
+			}
+			// Default for backward compatibility: use max_completion_tokens if no deprecated flag is set
+			if opts.Metadata == nil || opts.Metadata["_openai_use_deprecated_max_tokens"] == nil {
+				if opts.MaxTokens > 0 {
+					return opts.MaxTokens
+				}
+			}
+			return 0
+		}(),
+		MaxTokens: func() int {
+			// Only use the deprecated max_tokens field when explicitly requested
+			if opts.Metadata != nil {
+				if useDeprecated, ok := opts.Metadata["_openai_use_deprecated_max_tokens"].(bool); ok && useDeprecated {
+					return opts.MaxTokens
+				}
+			}
+			return 0
+		}(),
+	}
+}
+
+// Helper function to get MaxTokens without directly accessing deprecated field
+func getMaxTokensForTest(req *openaiclient.ChatRequest) int {
+	// Use JSON marshaling to avoid direct access to deprecated field
+	data, _ := json.Marshal(req)
+	var result map[string]interface{}
+	json.Unmarshal(data, &result) //nolint:errcheck // Test helper
+	if val, ok := result["max_tokens"]; ok {
+		return int(val.(float64))
+	}
+	return 0
+}
+
+// Helper function to test JSON serialization
+func testJSONSerialization(t *testing.T, options []llms.CallOption, expectedMaxCompletionInJSON, expectedMaxTokensInJSON bool, expectedValues map[string]int) {
+	// Apply options
+	opts := llms.CallOptions{}
+	for _, opt := range options {
+		opt(&opts)
+	}
+
+	// Create request using same logic as client
+	req := createTestChatRequest(opts)
+
+	// Marshal to JSON
+	jsonData, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Failed to marshal ChatRequest: %v", err)
+	}
+
+	// Parse JSON back to map to check field presence
+	var jsonMap map[string]interface{}
+	if err := json.Unmarshal(jsonData, &jsonMap); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	// Check max_completion_tokens field
+	if expectedMaxCompletionInJSON {
+		value, exists := jsonMap["max_completion_tokens"]
+		if !exists {
+			t.Error("Expected max_completion_tokens field in JSON, but it was not present")
+		} else if int(value.(float64)) != expectedValues["max_completion_tokens"] {
+			t.Errorf("max_completion_tokens = %v, want %v", value, expectedValues["max_completion_tokens"])
+		}
+	} else {
+		if _, exists := jsonMap["max_completion_tokens"]; exists {
+			t.Error("max_completion_tokens field should not be present in JSON")
+		}
+	}
+
+	// Check max_tokens field
+	if expectedMaxTokensInJSON {
+		value, exists := jsonMap["max_tokens"]
+		if !exists {
+			t.Error("Expected max_tokens field in JSON, but it was not present")
+		} else if int(value.(float64)) != expectedValues["max_tokens"] {
+			t.Errorf("max_tokens = %v, want %v", value, expectedValues["max_tokens"])
+		}
+	} else {
+		if _, exists := jsonMap["max_tokens"]; exists {
+			t.Error("max_tokens field should not be present in JSON")
+		}
+	}
+}
+
+func TestOpenAITokenOptionsMapping(t *testing.T) {
+	tests := []struct {
+		name                        string
+		options                     []llms.CallOption
+		expectedMaxCompletionTokens int
+		expectedMaxTokens           int
+		description                 string
+	}{
+		{
+			name:                        "WithMaxCompletionTokens only",
+			options:                     []llms.CallOption{WithMaxCompletionTokens(150)},
+			expectedMaxCompletionTokens: 150,
+			expectedMaxTokens:           0,
+			description:                 "Should set max_completion_tokens and not max_tokens",
+		},
+		{
+			name:                        "WithMaxTokens only (backward compatibility)",
+			options:                     []llms.CallOption{llms.WithMaxTokens(100)},
+			expectedMaxCompletionTokens: 100,
+			expectedMaxTokens:           0,
+			description:                 "Should set max_completion_tokens for backward compatibility (recommended field)",
+		},
+		{
+			name:                        "WithDeprecatedMaxTokens only",
+			options:                     []llms.CallOption{WithDeprecatedMaxTokens(200)},
+			expectedMaxCompletionTokens: 0,
+			expectedMaxTokens:           200,
+			description:                 "Should set max_tokens when explicitly using deprecated field",
+		},
+		{
+			name: "Generic WithMaxTokens with OpenAI WithMaxCompletionTokens",
+			options: []llms.CallOption{
+				llms.WithMaxTokens(100),
+				WithMaxCompletionTokens(150),
+			},
+			expectedMaxCompletionTokens: 150,
+			expectedMaxTokens:           0,
+			description:                 "OpenAI-specific option should override generic option",
+		},
+		{
+			name:                        "Neither option set",
+			options:                     []llms.CallOption{},
+			expectedMaxCompletionTokens: 0,
+			expectedMaxTokens:           0,
+			description:                 "Should not set either field when no token options provided",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testTokenOptionsMapping(t, tt.options, tt.expectedMaxCompletionTokens, tt.expectedMaxTokens, tt.description)
+		})
+	}
+}
+
+func TestOpenAITokenOptionsJSONSerialization(t *testing.T) {
+	tests := []struct {
+		name                        string
+		options                     []llms.CallOption
+		expectedMaxCompletionInJSON bool
+		expectedMaxTokensInJSON     bool
+		expectedValues              map[string]int
+	}{
+		{
+			name:                        "WithMaxCompletionTokens serialization",
+			options:                     []llms.CallOption{WithMaxCompletionTokens(150)},
+			expectedMaxCompletionInJSON: true,
+			expectedMaxTokensInJSON:     false,
+			expectedValues:              map[string]int{"max_completion_tokens": 150},
+		},
+		{
+			name:                        "WithDeprecatedMaxTokens serialization",
+			options:                     []llms.CallOption{WithDeprecatedMaxTokens(100)},
+			expectedMaxCompletionInJSON: false,
+			expectedMaxTokensInJSON:     true,
+			expectedValues:              map[string]int{"max_tokens": 100},
+		},
+		{
+			name:                        "Generic WithMaxTokens serialization",
+			options:                     []llms.CallOption{llms.WithMaxTokens(100)},
+			expectedMaxCompletionInJSON: true,
+			expectedMaxTokensInJSON:     false,
+			expectedValues:              map[string]int{"max_completion_tokens": 100},
+		},
+		{
+			name:                        "No token options",
+			options:                     []llms.CallOption{},
+			expectedMaxCompletionInJSON: false,
+			expectedMaxTokensInJSON:     false,
+			expectedValues:              map[string]int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testJSONSerialization(t, tt.options, tt.expectedMaxCompletionInJSON, tt.expectedMaxTokensInJSON, tt.expectedValues)
+		})
+	}
+}
+
+func TestBackwardCompatibilityWithNewArchitecture(t *testing.T) {
+	t.Run("Generic llms.WithMaxTokens still works", func(t *testing.T) {
+		opts := llms.CallOptions{}
+		llms.WithMaxTokens(100)(&opts)
+
+		// Test that it maps to max_completion_tokens for backward compatibility
+		maxCompletionTokens := func() int {
+			// Check if this should explicitly use max_completion_tokens field
+			if opts.Metadata != nil {
+				if useMaxCompletion, ok := opts.Metadata["_openai_use_max_completion_tokens"].(bool); ok && useMaxCompletion {
+					return opts.MaxTokens
+				}
+			}
+			// Default for backward compatibility: use max_completion_tokens if no deprecated flag is set
+			if opts.Metadata == nil || opts.Metadata["_openai_use_deprecated_max_tokens"] == nil {
+				if opts.MaxTokens > 0 {
+					return opts.MaxTokens
+				}
+			}
+			return 0
+		}()
+
+		if maxCompletionTokens != 100 {
+			t.Errorf("Expected MaxCompletionTokens = 100 for backward compatibility, got %v", maxCompletionTokens)
+		}
+	})
+
+	t.Run("OpenAI-specific options work correctly", func(t *testing.T) {
+		opts := llms.CallOptions{}
+		WithMaxCompletionTokens(150)(&opts)
+
+		// Test that it maps to max_completion_tokens
+		maxCompletionTokens := func() int {
+			if opts.Metadata != nil {
+				if useMaxCompletion, ok := opts.Metadata["_openai_use_max_completion_tokens"].(bool); ok && useMaxCompletion {
+					return opts.MaxTokens
+				}
+			}
+			return 0
+		}()
+
+		if maxCompletionTokens != 150 {
+			t.Errorf("Expected MaxCompletionTokens = 150, got %v", maxCompletionTokens)
+		}
+	})
+
+	t.Run("Deprecated max_tokens option works correctly", func(t *testing.T) {
+		opts := llms.CallOptions{}
+		WithDeprecatedMaxTokens(200)(&opts)
+
+		// Test that it maps to max_tokens
+		maxTokens := func() int {
+			if opts.Metadata != nil {
+				if useDeprecated, ok := opts.Metadata["_openai_use_deprecated_max_tokens"].(bool); ok && useDeprecated {
+					return opts.MaxTokens
+				}
+			}
+			return 0
+		}()
+
+		if maxTokens != 200 {
+			t.Errorf("Expected MaxTokens = 200, got %v", maxTokens)
+		}
+	})
+}


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

 ## Summary

This PR introduces OpenAI-specific token options to provide better control over token limits while maintaining full backward compatibility. The implementation addresses OpenAI's deprecation of the `max_tokens` field in favor of `max_completion_tokens`, while supporting OpenAI-compatible providers that still require the deprecated field.

## Key Changes

### New OpenAI-Specific Options
- **`openai.WithMaxCompletionTokens(int)`** - Uses the recommended `max_completion_tokens` field
- **`openai.WithDeprecatedMaxTokens(int)`** - Uses the deprecated `max_tokens` field for legacy providers

### Provider Detection
- **`openai.IsUsingCustomBaseURL(llms.Model) bool`** - Detects if using a non-standard OpenAI endpoint
- **`openai.GetBaseURL(llms.Model) string`** - Returns the current base URL for debugging

### Smart Backward Compatibility
- Existing `llms.WithMaxTokens()` calls now automatically use `max_completion_tokens` (recommended field)
- Only sets `max_tokens` when explicitly requested via `WithDeprecatedMaxTokens()`
- Never sends both fields simultaneously (prevents OpenAI API 400 errors)

## Usage

### Recommended Approach (New Code)
```go
// Uses max_completion_tokens (recommended)
llm.GenerateContent(ctx, messages,
    openai.WithMaxCompletionTokens(150),
)
```

### Backward Compatible (Existing Code)

```go
// Still works, now uses max_completion_tokens automatically
llm.GenerateContent(ctx, messages,
    llms.WithMaxTokens(150),  // ← No code changes needed
)
```

### Legacy Provider Support

```go
// For providers that still need the deprecated max_tokens field
llm.GenerateContent(ctx, messages,
    openai.WithDeprecatedMaxTokens(150),
)

//  Smart Provider Detection
if openai.IsUsingCustomBaseURL(llm) {
    // Custom provider - might need deprecated field
    response, err = llm.GenerateContent(ctx, messages,
        openai.WithDeprecatedMaxTokens(100))
} else {
    // Official OpenAI - use recommended field
    response, err = llm.GenerateContent(ctx, messages,
        openai.WithMaxCompletionTokens(100))
}
```

Migration Path

- No immediate action required - existing code automatically benefits from modern API usage
- Recommended for new code - use openai.WithMaxCompletionTokens() for clarity
- Legacy providers - use openai.WithDeprecatedMaxTokens() only if needed
