### PR TITLE
openai: add robust max_tokens support with backward compatibility

### DIFF
--- a/llms/openai/doc.go
+++ b/llms/openai/doc.go
@@ -1,0 +1,27 @@
+// Package openai provides an interface to OpenAI's language models.
+//
+// # Token Limits
+//
+// For setting token limits with OpenAI models, use openai.WithMaxCompletionTokens()
+// for clarity. The OpenAI API now uses max_completion_tokens as the field for
+// limiting output tokens.
+//
+//	// Recommended for clarity:
+//	llm.GenerateContent(ctx, messages,
+//	    openai.WithMaxCompletionTokens(100),
+//	)
+//
+//	// Also works (backward compatible):
+//	llm.GenerateContent(ctx, messages,
+//	    llms.WithMaxTokens(100),
+//	)
+//
+// Both options set the same underlying field. By default, the implementation sends
+// max_completion_tokens (modern field). For older OpenAI-compatible servers that
+// only support max_tokens, use WithLegacyMaxTokensField():
+//
+//	llm.GenerateContent(ctx, messages,
+//	    llms.WithMaxTokens(100),
+//	    openai.WithLegacyMaxTokensField(), // Forces use of max_tokens field
+//	)
+package openai

--- a/llms/openai/internal/openaiclient/chat_sse_test.go
+++ b/llms/openai/internal/openaiclient/chat_sse_test.go
@@ -51,7 +51,7 @@ data: [DONE]`,
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			
+
 			r := &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewBufferString(tc.body)),

--- a/llms/openai/internal/openaiclient/marshal_test.go
+++ b/llms/openai/internal/openaiclient/marshal_test.go
@@ -1,0 +1,73 @@
+package openaiclient
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestChatRequest_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name                    string
+		request                 ChatRequest
+		wantMaxTokens           bool
+		wantMaxCompletionTokens bool
+	}{
+		{
+			name: "only MaxCompletionTokens set",
+			request: ChatRequest{
+				Model:               "gpt-4",
+				MaxCompletionTokens: 100,
+			},
+			wantMaxTokens:           false,
+			wantMaxCompletionTokens: true,
+		},
+		{
+			name: "only MaxTokens set",
+			request: ChatRequest{
+				Model:     "gpt-4",
+				MaxTokens: 200,
+			},
+			wantMaxTokens:           true,
+			wantMaxCompletionTokens: false,
+		},
+		{
+			name: "both set - only MaxCompletionTokens sent",
+			request: ChatRequest{
+				Model:               "gpt-4",
+				MaxTokens:           300,
+				MaxCompletionTokens: 400,
+			},
+			wantMaxTokens:           false,
+			wantMaxCompletionTokens: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.request)
+			if err != nil {
+				t.Fatalf("failed to marshal: %v", err)
+			}
+
+			var result map[string]interface{}
+			if err := json.Unmarshal(data, &result); err != nil {
+				t.Fatalf("failed to unmarshal: %v", err)
+			}
+
+			hasMaxTokens := result["max_tokens"] != nil
+			hasMaxCompletionTokens := result["max_completion_tokens"] != nil
+
+			if hasMaxTokens != tt.wantMaxTokens {
+				t.Errorf("max_tokens presence: got %v, want %v", hasMaxTokens, tt.wantMaxTokens)
+			}
+			if hasMaxCompletionTokens != tt.wantMaxCompletionTokens {
+				t.Errorf("max_completion_tokens presence: got %v, want %v", hasMaxCompletionTokens, tt.wantMaxCompletionTokens)
+			}
+
+			// Never both
+			if hasMaxTokens && hasMaxCompletionTokens {
+				t.Error("Both max_tokens and max_completion_tokens are present - OpenAI API will reject!")
+			}
+		})
+	}
+}

--- a/llms/openai/max_tokens_test.go
+++ b/llms/openai/max_tokens_test.go
@@ -1,0 +1,111 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/openai/internal/openaiclient"
+)
+
+func TestMaxTokensFieldSerialization(t *testing.T) {
+	// This test verifies that only max_completion_tokens is sent,
+	// never max_tokens (which would cause an OpenAI API error)
+
+	tests := []struct {
+		name     string
+		request  openaiclient.ChatRequest
+		expected map[string]interface{}
+	}{
+		{
+			name: "MaxCompletionTokens is serialized",
+			request: openaiclient.ChatRequest{
+				Model:               "gpt-4",
+				MaxCompletionTokens: 100,
+				Temperature:         0.7,
+			},
+			expected: map[string]interface{}{
+				"model":                 "gpt-4",
+				"max_completion_tokens": float64(100),
+				"temperature":           0.7,
+			},
+		},
+		{
+			name: "Both fields set - only MaxCompletionTokens is sent",
+			request: openaiclient.ChatRequest{
+				Model:               "gpt-4",
+				MaxTokens:           100,
+				MaxCompletionTokens: 200,
+				Temperature:         0.7,
+			},
+			expected: map[string]interface{}{
+				"model":                 "gpt-4",
+				"max_completion_tokens": float64(200),
+				"temperature":           0.7,
+				// Note: max_tokens is NOT in the output due to MarshalJSON logic
+			},
+		},
+		{
+			name: "Only MaxTokens set - it IS serialized",
+			request: openaiclient.ChatRequest{
+				Model:       "gpt-4",
+				MaxTokens:   100,
+				Temperature: 0.7,
+			},
+			expected: map[string]interface{}{
+				"model":       "gpt-4",
+				"max_tokens":  float64(100),
+				"temperature": 0.7,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Marshal the request
+			data, err := json.Marshal(tt.request)
+			require.NoError(t, err)
+
+			// Unmarshal to a map to check fields
+			var result map[string]interface{}
+			err = json.Unmarshal(data, &result)
+			require.NoError(t, err)
+
+			// For tests with both fields, verify only one is present
+			hasMaxTokens := result["max_tokens"] != nil
+			hasMaxCompletionTokens := result["max_completion_tokens"] != nil
+
+			// Never both
+			if hasMaxTokens && hasMaxCompletionTokens {
+				t.Error("Both max_tokens and max_completion_tokens are present - API will error!")
+			}
+
+			// Verify expected fields
+			for key, expectedValue := range tt.expected {
+				actualValue, exists := result[key]
+				assert.True(t, exists, "field %s should exist", key)
+				assert.Equal(t, expectedValue, actualValue, "field %s value mismatch", key)
+			}
+		})
+	}
+}
+
+func TestMaxTokensBehaviorDocumentation(t *testing.T) {
+	// This test documents the expected behavior for users
+
+	t.Run("llms.WithMaxTokens sets max_completion_tokens", func(t *testing.T) {
+		opts := &llms.CallOptions{}
+		llms.WithMaxTokens(100)(opts)
+		assert.Equal(t, 100, opts.MaxTokens)
+		// In openaillm.go, this opts.MaxTokens value gets mapped to MaxCompletionTokens
+	})
+
+	t.Run("openai.WithMaxCompletionTokens is explicit", func(t *testing.T) {
+		opts := &llms.CallOptions{}
+		WithMaxCompletionTokens(100)(opts)
+		assert.Equal(t, 100, opts.MaxTokens)
+		// Same effect, but more explicit about what field is being set
+	})
+}

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -102,6 +102,14 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 
 		chatMsgs = append(chatMsgs, msg)
 	}
+	// Check if we should use the legacy max_tokens field
+	useLegacyMaxTokens := false
+	if opts.Metadata != nil {
+		if v, ok := opts.Metadata["openai:use_legacy_max_tokens"].(bool); ok {
+			useLegacyMaxTokens = v
+		}
+	}
+
 	req := &openaiclient.ChatRequest{
 		Model:                  opts.Model,
 		StopWords:              opts.StopWords,
@@ -113,7 +121,21 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		FrequencyPenalty:       opts.FrequencyPenalty,
 		PresencePenalty:        opts.PresencePenalty,
 
-		MaxCompletionTokens: opts.MaxTokens,
+		// Token handling: check metadata flag for legacy behavior
+		// By default use max_completion_tokens (modern field)
+		// If WithLegacyMaxTokensField() is used, use max_tokens instead
+		MaxCompletionTokens: func() int {
+			if useLegacyMaxTokens {
+				return 0 // Don't set max_completion_tokens
+			}
+			return opts.MaxTokens
+		}(),
+		MaxTokens: func() int {
+			if useLegacyMaxTokens {
+				return opts.MaxTokens // Set the legacy field
+			}
+			return 0 // Don't set max_tokens
+		}(),
 
 		ToolChoice:           opts.ToolChoice,
 		FunctionCallBehavior: openaiclient.FunctionCallBehavior(opts.FunctionCallBehavior),

--- a/llms/openai/options.go
+++ b/llms/openai/options.go
@@ -1,0 +1,39 @@
+package openai
+
+import "github.com/tmc/langchaingo/llms"
+
+// WithMaxCompletionTokens sets the max_completion_tokens field for token generation.
+// This is the recommended way to limit tokens with OpenAI models.
+//
+// Usage:
+//
+//	llm.GenerateContent(ctx, messages,
+//	    openai.WithMaxCompletionTokens(100),
+//	)
+//
+// Note: While llms.WithMaxTokens() still works for backward compatibility,
+// WithMaxCompletionTokens is preferred for clarity when using OpenAI.
+func WithMaxCompletionTokens(maxTokens int) llms.CallOption {
+	return func(opts *llms.CallOptions) {
+		opts.MaxTokens = maxTokens
+	}
+}
+
+// WithLegacyMaxTokensField forces the use of the max_tokens field instead of max_completion_tokens.
+// This is useful when connecting to older OpenAI-compatible inference servers that only
+// support the max_tokens field and don't recognize max_completion_tokens.
+//
+// Usage:
+//
+//	llm.GenerateContent(ctx, messages,
+//	    llms.WithMaxTokens(100),
+//	    openai.WithLegacyMaxTokensField(), // Forces use of max_tokens field
+//	)
+func WithLegacyMaxTokensField() llms.CallOption {
+	return func(opts *llms.CallOptions) {
+		if opts.Metadata == nil {
+			opts.Metadata = make(map[string]interface{})
+		}
+		opts.Metadata["openai:use_legacy_max_tokens"] = true
+	}
+}

--- a/llms/openai/options_test.go
+++ b/llms/openai/options_test.go
@@ -1,0 +1,75 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+func TestWithMaxCompletionTokens(t *testing.T) {
+	opts := &llms.CallOptions{}
+
+	// Test that WithMaxCompletionTokens sets MaxTokens
+	WithMaxCompletionTokens(100)(opts)
+	if opts.MaxTokens != 100 {
+		t.Errorf("expected MaxTokens=100, got %d", opts.MaxTokens)
+	}
+
+	// Test that it can be overridden
+	WithMaxCompletionTokens(200)(opts)
+	if opts.MaxTokens != 200 {
+		t.Errorf("expected MaxTokens=200, got %d", opts.MaxTokens)
+	}
+
+	// Test with zero value
+	WithMaxCompletionTokens(0)(opts)
+	if opts.MaxTokens != 0 {
+		t.Errorf("expected MaxTokens=0, got %d", opts.MaxTokens)
+	}
+}
+
+func TestOptionsCompatibility(t *testing.T) {
+	opts := &llms.CallOptions{}
+
+	// Test that both llms.WithMaxTokens and WithMaxCompletionTokens
+	// set the same field for compatibility
+	llms.WithMaxTokens(150)(opts)
+	if opts.MaxTokens != 150 {
+		t.Errorf("expected MaxTokens=150, got %d", opts.MaxTokens)
+	}
+
+	opts2 := &llms.CallOptions{}
+	WithMaxCompletionTokens(150)(opts2)
+	if opts2.MaxTokens != 150 {
+		t.Errorf("expected MaxTokens=150, got %d", opts2.MaxTokens)
+	}
+
+	// They should be equivalent
+	if opts.MaxTokens != opts2.MaxTokens {
+		t.Errorf("WithMaxTokens and WithMaxCompletionTokens should set the same field")
+	}
+}
+
+func TestWithLegacyMaxTokensField(t *testing.T) {
+	opts := &llms.CallOptions{}
+
+	// Test that WithLegacyMaxTokensField sets the metadata flag
+	WithLegacyMaxTokensField()(opts)
+	if opts.Metadata == nil {
+		t.Fatal("expected Metadata to be initialized")
+	}
+	if v, ok := opts.Metadata["openai:use_legacy_max_tokens"].(bool); !ok || !v {
+		t.Error("expected openai:use_legacy_max_tokens to be true")
+	}
+
+	// Test combining with WithMaxTokens
+	opts2 := &llms.CallOptions{}
+	llms.WithMaxTokens(200)(opts2)
+	WithLegacyMaxTokensField()(opts2)
+	if opts2.MaxTokens != 200 {
+		t.Errorf("expected MaxTokens=200, got %d", opts2.MaxTokens)
+	}
+	if v, ok := opts2.Metadata["openai:use_legacy_max_tokens"].(bool); !ok || !v {
+		t.Error("expected openai:use_legacy_max_tokens to be true")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the `max_tokens` vs `max_completion_tokens` conflict that causes OpenAI API errors.

## Problem

OpenAI's API returns 400 errors when both `max_tokens` and `max_completion_tokens` are sent. The o1 models require `max_completion_tokens`, but many OpenAI-compatible providers still need `max_tokens`.

## Solution

1. **MarshalJSON** ensures only one token field is sent
2. **WithMaxCompletionTokens()** - Explicit option for clarity
3. **WithLegacyMaxTokensField()** - Forces `max_tokens` for older servers

## Usage

```go
// Modern OpenAI (recommended)
llm.GenerateContent(ctx, messages,
    openai.WithMaxCompletionTokens(100),
)

// Legacy servers
llm.GenerateContent(ctx, messages,
    llms.WithMaxTokens(100),
    openai.WithLegacyMaxTokensField(),
)
```

Simpler than #1370 (380 lines vs 645+, no auto-detection magic).

Fixes issues from #1359 (reverted in #1369).