### PR TITLE
llms/ollama: fix panic when context is cancelled during streaming

### DIFF
--- a/llms/ollama/ollamallm.go
+++ b/llms/ollama/ollamallm.go
@@ -156,9 +156,15 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		return nil, err
 	}
 
+	// Handle case where Message might be nil (e.g., context cancelled during streaming)
+	content := ""
+	if resp.Message != nil {
+		content = resp.Message.Content
+	}
+
 	choices := []*llms.ContentChoice{
 		{
-			Content: resp.Message.Content,
+			Content: content,
 			GenerationInfo: map[string]any{
 				"CompletionTokens": resp.EvalCount,
 				"PromptTokens":     resp.PromptEvalCount,


### PR DESCRIPTION
Fixes #774

## Problem
Ollama streaming panics with nil pointer dereference when context is cancelled mid-stream.

## Solution
Add nil check for `resp.Message` before accessing its content.

```go
// Handle case where Message might be nil (e.g., context cancelled during streaming)
content := ""
if resp.Message != nil {
    content = resp.Message.Content
}
```

Similar to #1243 but cleaner (no unrelated changes).