### PR TITLE
examples: update examples to v0.1.14-pre.2

### DIFF
--- a/examples/anthropic-completion-example/go.mod
+++ b/examples/anthropic-completion-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/anthropic-completion-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/anthropic-tool-call-example/go.mod
+++ b/examples/anthropic-tool-call-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/anthropic-tool-call-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/anthropic-vision-example/go.mod
+++ b/examples/anthropic-vision-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/anthropic-vision-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/bedrock-claude3-vision-example/go.mod
+++ b/examples/bedrock-claude3-vision-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/bedrock-claude3-vision-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3 // indirect

--- a/examples/bedrock-provider-example/go.mod
+++ b/examples/bedrock-provider-example/go.mod
@@ -4,7 +4,7 @@ go 1.23.8
 
 toolchain go1.24.6
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3 // indirect
@@ -26,5 +26,3 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pkoukk/tiktoken-go v0.1.6 // indirect
 )
-
-replace github.com/tmc/langchaingo => ../..

--- a/examples/caching-llm-example/go.mod
+++ b/examples/caching-llm-example/go.mod
@@ -4,7 +4,7 @@ go 1.24.3
 
 require (
 	github.com/mitchellh/go-wordwrap v1.0.1
-	github.com/tmc/langchaingo v0.1.14-pre.1
+	github.com/tmc/langchaingo v0.1.14-pre.2
 )
 
 require (

--- a/examples/chains-conversation-memory-sqlite/go.mod
+++ b/examples/chains-conversation-memory-sqlite/go.mod
@@ -4,7 +4,7 @@ go 1.24.3
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.28
-	github.com/tmc/langchaingo v0.1.14-pre.1
+	github.com/tmc/langchaingo v0.1.14-pre.2
 )
 
 require (

--- a/examples/chroma-vectorstore-example/go.mod
+++ b/examples/chroma-vectorstore-example/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.6
 require (
 	github.com/amikos-tech/chroma-go v0.1.4
 	github.com/google/uuid v1.6.0
-	github.com/tmc/langchaingo v0.1.14-pre.1
+	github.com/tmc/langchaingo v0.1.14-pre.2
 )
 
 require (

--- a/examples/cohere-llm-example/go.mod
+++ b/examples/cohere-llm-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/cohere-llm-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/cohere-ai/tokenizer v1.1.2 // indirect

--- a/examples/cybertron-embedding-example/go.mod
+++ b/examples/cybertron-embedding-example/go.mod
@@ -5,7 +5,7 @@ go 1.24.3
 require (
 	github.com/chewxy/math32 v1.11.1
 	github.com/google/uuid v1.6.0
-	github.com/tmc/langchaingo v0.1.14-pre.1
+	github.com/tmc/langchaingo v0.1.14-pre.2
 )
 
 require (

--- a/examples/deepseek-completion-example/go.mod
+++ b/examples/deepseek-completion-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/deepseek-completion-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/document-qa-example/go.mod
+++ b/examples/document-qa-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/document-qa-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/ernie-chat-example/go.mod
+++ b/examples/ernie-chat-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/ernie-chat-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/ernie-completion-example/go.mod
+++ b/examples/ernie-completion-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/ernie-completion-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/ernie-function-call-example/go.mod
+++ b/examples/ernie-function-call-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/ernie-function-call-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/google-alloydb-chat-message-history-example/go.mod
+++ b/examples/google-alloydb-chat-message-history-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/google-alloydb-chat-message-history-e
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	cloud.google.com/go v0.116.0 // indirect

--- a/examples/google-alloydb-vectorstore-example/go.mod
+++ b/examples/google-alloydb-vectorstore-example/go.mod
@@ -3,7 +3,7 @@ module github.com/tmc/langchaingo/examples/google-alloydb-vectorstore-example
 go 1.24.3
 
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	cloud.google.com/go v0.116.0 // indirect

--- a/examples/google-cloudsql-chat-message-history-example/go.mod
+++ b/examples/google-cloudsql-chat-message-history-example/go.mod
@@ -3,7 +3,7 @@ module github.com/tmc/langchaingo/examples/google-cloudsql-chat-message-history-
 go 1.24.3
 
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	cloud.google.com/go/auth v0.14.0 // indirect

--- a/examples/google-cloudsql-vectorstore-example/go.mod
+++ b/examples/google-cloudsql-vectorstore-example/go.mod
@@ -3,7 +3,7 @@ module github.com/tmc/langchaingo/examples/google-cloudsql-vectorstore-example
 go 1.24.3
 
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	cloud.google.com/go v0.116.0 // indirect

--- a/examples/googleai-completion-example/go.mod
+++ b/examples/googleai-completion-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/googleai-completion-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	cloud.google.com/go v0.116.0 // indirect

--- a/examples/googleai-streaming-example/go.mod
+++ b/examples/googleai-streaming-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/googleai-streaming-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	cloud.google.com/go v0.116.0 // indirect

--- a/examples/googleai-tool-call-example/go.mod
+++ b/examples/googleai-tool-call-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/googleai-tool-call-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	cloud.google.com/go v0.116.0 // indirect

--- a/examples/groq-completion-example/go.mod
+++ b/examples/groq-completion-example/go.mod
@@ -4,7 +4,7 @@ go 1.24.3
 
 require (
 	github.com/joho/godotenv v1.5.1
-	github.com/tmc/langchaingo v0.1.14-pre.1
+	github.com/tmc/langchaingo v0.1.14-pre.2
 )
 
 require (

--- a/examples/huggingface-llm-example/go.mod
+++ b/examples/huggingface-llm-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/huggingface-llm-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/huggingface-milvus-vectorstore-example/go.mod
+++ b/examples/huggingface-milvus-vectorstore-example/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.6
 
 require (
 	github.com/milvus-io/milvus-sdk-go/v2 v2.4.0
-	github.com/tmc/langchaingo v0.1.14-pre.1
+	github.com/tmc/langchaingo v0.1.14-pre.2
 )
 
 require (

--- a/examples/json-mode-example/go.mod
+++ b/examples/json-mode-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/json-mode-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	cloud.google.com/go v0.116.0 // indirect

--- a/examples/llamafile-completion-example/go.mod
+++ b/examples/llamafile-completion-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/llamafile-completion-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/llm-chain-example/go.mod
+++ b/examples/llm-chain-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/llm-chain-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/llmmath-chain-example/go.mod
+++ b/examples/llmmath-chain-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/llmmath-chain-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/llmsummarization-chain-example/go.mod
+++ b/examples/llmsummarization-chain-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/llmsummarization-chain-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	cloud.google.com/go v0.116.0 // indirect

--- a/examples/local-llm-example/go.mod
+++ b/examples/local-llm-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/local-llm-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/maritaca-example/go.mod
+++ b/examples/maritaca-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/maritaca-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 
 require (

--- a/examples/mistral-completion-example/go.mod
+++ b/examples/mistral-completion-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/mistral-completion-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/mistral-embedding-example/go.mod
+++ b/examples/mistral-embedding-example/go.mod
@@ -4,7 +4,7 @@ go 1.23.8
 
 toolchain go1.24.6
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/mistral-summarization-example/go.mod
+++ b/examples/mistral-summarization-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/mistral-summarization-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/AssemblyAI/assemblyai-go-sdk v1.3.0 // indirect

--- a/examples/mongovector-vectorstore-example/go.mod
+++ b/examples/mongovector-vectorstore-example/go.mod
@@ -5,7 +5,7 @@ go 1.23.8
 toolchain go1.24.6
 
 require (
-	github.com/tmc/langchaingo v0.1.14-pre.1
+	github.com/tmc/langchaingo v0.1.14-pre.2
 	go.mongodb.org/mongo-driver/v2 v2.0.0
 )
 

--- a/examples/mrkl-agent-example/go.mod
+++ b/examples/mrkl-agent-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/mrkl-agent-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/nvidia-chat-completion/go.mod
+++ b/examples/nvidia-chat-completion/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/nvidia-chat-completion
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/ollama-chat-example/go.mod
+++ b/examples/ollama-chat-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/ollama-chat-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/ollama-chroma-vectorstore-example/go.mod
+++ b/examples/ollama-chroma-vectorstore-example/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.6
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/tmc/langchaingo v0.1.14-pre.1
+	github.com/tmc/langchaingo v0.1.14-pre.2
 )
 
 require (

--- a/examples/ollama-completion-example/go.mod
+++ b/examples/ollama-completion-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/ollama-completion-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/ollama-functions-example/go.mod
+++ b/examples/ollama-functions-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/ollama-functions-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/ollama-stream-example/go.mod
+++ b/examples/ollama-stream-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/ollama-stream-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/openai-chat-example/go.mod
+++ b/examples/openai-chat-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/openai-chat-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/openai-completion-example-with-http-debugging/go.mod
+++ b/examples/openai-completion-example-with-http-debugging/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/openai-completion-example-with-http-d
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/openai-completion-example/go.mod
+++ b/examples/openai-completion-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/openai-completion-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/openai-embeddings-example/go.mod
+++ b/examples/openai-embeddings-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/openai-embeddings-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/openai-function-call-example/go.mod
+++ b/examples/openai-function-call-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/openai-function-call-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/openai-function-call-streaming-example/go.mod
+++ b/examples/openai-function-call-streaming-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/openai-function-call-streaming-exampl
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/openai-gpt4-turbo-example/go.mod
+++ b/examples/openai-gpt4-turbo-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/openai-gpt4-turbo-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/openai-gpt4o-example/go.mod
+++ b/examples/openai-gpt4o-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/openai-gpt4o-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/openai-gpt4o-mutil-content/go.mod
+++ b/examples/openai-gpt4o-mutil-content/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/openai-gpt4o-mutil-content
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/openai-jsonformat-example/go.mod
+++ b/examples/openai-jsonformat-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/openai-jsonformat-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/openai-o1-example/go.mod
+++ b/examples/openai-o1-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/openai-o1-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/openai-readme/go.mod
+++ b/examples/openai-readme/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/openai-readme
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/openrouter-llm-example/go.mod
+++ b/examples/openrouter-llm-example/go.mod
@@ -4,7 +4,7 @@ go 1.23.8
 
 toolchain go1.24.6
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 
 require (

--- a/examples/perplexity-completion-example/go.mod
+++ b/examples/perplexity-completion-example/go.mod
@@ -4,7 +4,7 @@ go 1.24.3
 
 require (
 	github.com/joho/godotenv v1.5.1
-	github.com/tmc/langchaingo v0.1.14-pre.1
+	github.com/tmc/langchaingo v0.1.14-pre.2
 )
 
 require (

--- a/examples/pgvector-vectorstore-example/go.mod
+++ b/examples/pgvector-vectorstore-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/pgvector-vectorstore-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/pinecone-vectorstore-example/go.mod
+++ b/examples/pinecone-vectorstore-example/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.6
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/tmc/langchaingo v0.1.14-pre.1
+	github.com/tmc/langchaingo v0.1.14-pre.2
 )
 
 require (

--- a/examples/postgresql-database-chain-example/go.mod
+++ b/examples/postgresql-database-chain-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/postgresql-database-chain-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/prompt-template-example/go.mod
+++ b/examples/prompt-template-example/go.mod
@@ -4,7 +4,7 @@ go 1.23.8
 
 toolchain go1.24.6
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/qdrant-vectorstore-example/go.mod
+++ b/examples/qdrant-vectorstore-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/qdrant-vectorstore-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect

--- a/examples/redis-vectorstore-example/go.mod
+++ b/examples/redis-vectorstore-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/redis-vectorstore-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/sequential-chain-example/go.mod
+++ b/examples/sequential-chain-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/sequential-chain-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/sql-database-chain-example/go.mod
+++ b/examples/sql-database-chain-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/sql-database-chain-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/vertex-completion-example/go.mod
+++ b/examples/vertex-completion-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/vertex-completion-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 
 require (

--- a/examples/vertex-embedding-example/go.mod
+++ b/examples/vertex-embedding-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/vertex-embedding-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	cloud.google.com/go v0.116.0 // indirect

--- a/examples/watsonx-llm-example/go.mod
+++ b/examples/watsonx-llm-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/watsonx-llm-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/IBM/watsonx-go v1.0.0 // indirect

--- a/examples/zapier-llm-example/go.mod
+++ b/examples/zapier-llm-example/go.mod
@@ -2,7 +2,7 @@ module github.com/tmc/langchaingo/examples/zapier-llm-example
 
 go 1.24.3
 
-require github.com/tmc/langchaingo v0.1.14-pre.1
+require github.com/tmc/langchaingo v0.1.14-pre.2
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/examples/zep-memory-chain-example/go.mod
+++ b/examples/zep-memory-chain-example/go.mod
@@ -4,7 +4,7 @@ go 1.24.3
 
 require (
 	github.com/getzep/zep-go v1.0.4
-	github.com/tmc/langchaingo v0.1.14-pre.1
+	github.com/tmc/langchaingo v0.1.14-pre.2
 )
 
 require (


### PR DESCRIPTION
Update all example project go.mod files to reference v0.1.14-pre.2 instead of v0.1.14-pre.1. This ensures examples use the latest pre-release version with recent fixes and improvements.