### PR TITLE
fix: filter out open ai max token metadata

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -452,7 +452,27 @@ func (c *Client) createChat(ctx context.Context, payload *ChatRequest) (*ChatCom
 	}
 	// Build request payload
 
+	// Filter out internal metadata that shouldn't be sent to the API
+	originalMetadata := payload.Metadata
+	if payload.Metadata != nil {
+		filteredMetadata := make(map[string]any)
+		for k, v := range payload.Metadata {
+			// Skip internal openai: prefixed metadata fields
+			if !strings.HasPrefix(k, "openai:") {
+				filteredMetadata[k] = v
+			}
+		}
+		if len(filteredMetadata) > 0 {
+			payload.Metadata = filteredMetadata
+		} else {
+			payload.Metadata = nil
+		}
+	}
+
 	payloadBytes, err := json.Marshal(payload)
+	
+	// Restore original metadata
+	payload.Metadata = originalMetadata
 	if err != nil {
 		return nil, err
 	}

--- a/llms/openai/internal/openaiclient/openaiclient_test.go
+++ b/llms/openai/internal/openaiclient/openaiclient_test.go
@@ -1,7 +1,10 @@
 package openaiclient
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -265,4 +268,80 @@ func TestMakeEmbeddingRequest(t *testing.T) {
 		assert.Equal(t, "some_model", request.Model)
 		assert.Equal(t, 1234, request.Dimensions)
 	})
+}
+
+func TestInternalMetadataFiltering(t *testing.T) {
+	// Test that internal openai: prefixed metadata is filtered out from requests
+	client, err := New("test-api-key", "gpt-3.5-turbo", "", "", APITypeOpenAI, "", nil, "", nil)
+	require.NoError(t, err)
+
+	// Create a mock HTTP client to capture the request body
+	var capturedRequestBody []byte
+	mockClient := &mockHTTPClient{
+		doFunc: func(req *http.Request) (*http.Response, error) {
+			// Read the request body
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			capturedRequestBody = body
+			
+			// Return a minimal valid response to avoid errors
+			responseBody := `{"choices":[{"message":{"content":"test"}}],"usage":{"total_tokens":10}}`
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader([]byte(responseBody))),
+			}, nil
+		},
+	}
+	client.httpClient = mockClient
+
+	// Create request with both internal and external metadata
+	req := &ChatRequest{
+		Model: "gpt-3.5-turbo",
+		Messages: []*ChatMessage{
+			{Role: "user", Content: "test"},
+		},
+		Metadata: map[string]any{
+			"openai:use_legacy_max_tokens": true,     // Should be filtered out
+			"custom_field":                 "value",  // Should be preserved
+		},
+	}
+
+	// Make the request
+	_, _ = client.CreateChat(context.Background(), req)
+
+	// Verify the request body was captured
+	require.NotEmpty(t, capturedRequestBody)
+
+	// Parse the request body to check what was sent
+	var requestBody map[string]any
+	err = json.Unmarshal(capturedRequestBody, &requestBody)
+	require.NoError(t, err)
+
+	// Check metadata filtering
+	metadata, exists := requestBody["metadata"]
+	if exists {
+		metadataMap := metadata.(map[string]any)
+		// Internal metadata should be filtered out
+		assert.NotContains(t, metadataMap, "openai:use_legacy_max_tokens")
+		// External metadata should be preserved
+		assert.Contains(t, metadataMap, "custom_field")
+		assert.Equal(t, "value", metadataMap["custom_field"])
+	} else {
+		// If no metadata field exists, that means only internal metadata was present and got filtered out
+		t.Log("metadata field was completely filtered out - this is expected behavior")
+	}
+
+	// Verify original metadata is preserved in the request object
+	assert.Contains(t, req.Metadata, "openai:use_legacy_max_tokens")
+	assert.Contains(t, req.Metadata, "custom_field")
+}
+
+type mockHTTPClient struct {
+	doFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return m.doFunc(req)
 }


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

Thanks for https://github.com/tmc/langchaingo/pull/1371! This is working well, but certain open AI compatible APIs have rather strict schema validation in their requests. Looking at the Digital Ocean serverless inference as an example, my requests are receiving a 400 response with the following: `request body has an error: doesn't match schema #/components/schemas/CreateChatCompletionRequest: Error at \"/metadata/openai:use_legacy_max_tokens\": value must be a string\n"}`

This filters out the "internal use" metadata from the request prior to sending it.
