### PR TITLE
internal/httprr, vectorstores/azureaisearch: fix race conditions in tests

### DIFF
--- a/internal/httprr/rr.go
+++ b/internal/httprr/rr.go
@@ -167,6 +167,13 @@ func Recording(file string) (bool, error) {
 	return false, nil
 }
 
+// getRecordForTesting safely gets the current record flag value for testing.
+func getRecordForTesting() string {
+	recordMu.Lock()
+	defer recordMu.Unlock()
+	return *record
+}
+
 // setRecordForTesting sets the record flag value for testing purposes.
 // It returns a function that restores the original value.
 func setRecordForTesting(value string) func() {

--- a/internal/httprr/rr_test.go
+++ b/internal/httprr/rr_test.go
@@ -190,7 +190,7 @@ var badResponseTrace = []byte("httprr trace v1\n" +
 	"\r\n")
 
 func TestErrors(t *testing.T) {
-	t.Parallel()
+	// Cannot run in parallel because it modifies global record flag
 	dir := t.TempDir()
 	var resp *http.Response
 	var err error

--- a/internal/httprr/rr_unit_test.go
+++ b/internal/httprr/rr_unit_test.go
@@ -516,18 +516,18 @@ func TestTestWriter(t *testing.T) {
 }
 
 func TestSetRecordForTesting(t *testing.T) {
-	t.Parallel()
+	// Cannot run in parallel because it modifies global record flag
 
 	// Get original value
-	originalValue := *record
+	originalValue := getRecordForTesting()
 
 	// Set test value
 	restore := setRecordForTesting("test-value")
-	assert.Equal(t, "test-value", *record)
+	assert.Equal(t, "test-value", getRecordForTesting())
 
 	// Restore original value
 	restore()
-	assert.Equal(t, originalValue, *record)
+	assert.Equal(t, originalValue, getRecordForTesting())
 }
 
 func TestRecordReplayClose(t *testing.T) {

--- a/vectorstores/azureaisearch/azureaisearch_unit_test.go
+++ b/vectorstores/azureaisearch/azureaisearch_unit_test.go
@@ -1254,6 +1254,7 @@ func TestConcurrentOperations(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		requestCount++
+		currentCount := requestCount
 		mu.Unlock()
 
 		// Simulate some processing time
@@ -1262,7 +1263,7 @@ func TestConcurrentOperations(t *testing.T) {
 				Value: []map[string]interface{}{
 					{
 						"@search.score": 0.9,
-						"content":       fmt.Sprintf("Result %d", requestCount),
+						"content":       fmt.Sprintf("Result %d", currentCount),
 						"metadata":      `{}`,
 					},
 				},


### PR DESCRIPTION
Fix race conditions detected when running tests with -race flag.

In internal/httprr, add getRecordForTesting function for thread-safe access to global record flag and remove t.Parallel from tests that modify global state.

In vectorstores/azureaisearch, fix concurrent access to request counter by capturing value in local variable while holding mutex.