### PR TITLE
tools/scraper: fix context cancellation hanging

### DIFF
--- a/tools/scraper/scraper.go
+++ b/tools/scraper/scraper.go
@@ -212,11 +212,18 @@ func (s Scraper) Call(ctx context.Context, input string) (string, error) {
 		return "", fmt.Errorf("%s: %w", ErrScrapingFailed, err)
 	}
 
+	// Wait for scraping to complete with context cancellation support
+	done := make(chan struct{})
+	go func() {
+		c.Wait()
+		close(done)
+	}()
+
 	select {
 	case <-ctx.Done():
 		return "", ctx.Err()
-	default:
-		c.Wait()
+	case <-done:
+		// Scraping completed normally
 	}
 
 	// Append all scraped links


### PR DESCRIPTION
Fixes an issue where the web scraper would hang indefinitely when the context is cancelled during the Wait() operation.

The scraper was checking for context cancellation before calling c.Wait(), but not during the wait operation itself. This caused the scraper to hang when a context was cancelled while scraping was in progress.

Solution:
- Moved c.Wait() into a separate goroutine
- Use select statement to handle both normal completion and context cancellation
- Ensures immediate return when context is cancelled

This change is complementary to PR #1295 which adds max pages limiting.