### PR TITLE
documentloaders: add RecursiveDirectoryLoader that loads documents with allowed extensions from a directory

### DIFF
--- a/documentloaders/directory.go
+++ b/documentloaders/directory.go
@@ -43,7 +43,6 @@ func WithPDFOpts(pwd string) Option {
 	return func(c *RecursiveDirectoryLoader) { c.PDFPassword = pwd }
 }
 
-
 // RecursiveDirectoryLoader is a document loader that loads documents with allowed extensions from a directory.
 type RecursiveDirectoryLoader struct {
 	root     string

--- a/documentloaders/directory.go
+++ b/documentloaders/directory.go
@@ -1,0 +1,161 @@
+package documentloaders
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tmc/langchaingo/schema"
+	"github.com/tmc/langchaingo/textsplitter"
+)
+
+type Option func(*RecursiveDirectoryLoader)
+
+func WithRoot(root string) Option {
+	return func(l *RecursiveDirectoryLoader) { l.root = root }
+}
+
+func WithMaxDepth(d int) Option {
+	return func(l *RecursiveDirectoryLoader) { l.maxDepth = d }
+}
+
+func WithAllowExts(exts ...string) Option {
+	return func(l *RecursiveDirectoryLoader) {
+		l.allowExt = make(map[string]struct{}, len(exts))
+		for _, e := range exts {
+			e = strings.ToLower(strings.TrimPrefix(strings.TrimSpace(e), "."))
+			l.allowExt["."+e] = struct{}{}
+		}
+	}
+}
+
+func WithCSVOpts(cols []string) Option {
+	return func(c *RecursiveDirectoryLoader) {
+		c.Columns = cols
+	}
+}
+
+func WithPDFOpts(pwd string) Option {
+	return func(c *RecursiveDirectoryLoader) { c.PDFPassword = pwd }
+}
+
+
+// RecursiveDirectoryLoader is a document loader that loads documents with allowed extensions from a directory.
+type RecursiveDirectoryLoader struct {
+	root     string
+	maxDepth int
+	allowExt map[string]struct{}
+
+	Columns []string // CSV Columns
+
+	PDFPassword string // PDF password
+}
+
+var _ Loader = (*RecursiveDirectoryLoader)(nil)
+
+func NewRecursiveDirLoader(opts ...Option) *RecursiveDirectoryLoader {
+	l := &RecursiveDirectoryLoader{
+		root:     ".",
+		maxDepth: 1,
+		allowExt: map[string]struct{}{},
+	}
+	for _, opt := range opts {
+		opt(l)
+	}
+	return l
+}
+
+func (l *RecursiveDirectoryLoader) newLoader(f *os.File) (Loader, error) {
+	ext := filepath.Ext(f.Name())
+	switch ext {
+	case ".txt", ".md":
+		return NewText(f), nil
+	case ".csv":
+		return NewCSV(f, l.Columns...), nil
+	case ".pdf":
+		finfo, err := f.Stat()
+		if err != nil {
+			return nil, err
+		}
+		if l.PDFPassword != "" {
+			return NewPDF(f, finfo.Size(), WithPassword(l.PDFPassword)), nil
+		}
+		return NewPDF(f, finfo.Size()), nil
+	case ".html", ".htm":
+		return NewHTML(f), nil
+	default:
+		return nil, fmt.Errorf("unsupported file extension %q", ext)
+	}
+}
+
+// Load retrieves data from a Notion directory and returns a list of schema.Document objects.
+func (l *RecursiveDirectoryLoader) Load(ctx context.Context) ([]schema.Document, error) {
+	var docs []schema.Document
+
+	err := filepath.WalkDir(l.root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			rel, _ := filepath.Rel(l.root, path)
+			depth := strings.Count(rel, string(os.PathSeparator))
+			if depth >= l.maxDepth {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		ext := strings.ToLower(filepath.Ext(path))
+		if len(l.allowExt) > 0 {
+			if _, ok := l.allowExt[ext]; !ok {
+				return nil
+			}
+		}
+
+		var fileDocs []schema.Document
+		if err := func() error {
+			f, err := os.Open(path)
+			if err != nil {
+				return nil
+			}
+			defer f.Close()
+
+			loader, err := l.newLoader(f)
+			if err != nil {
+				return err
+			}
+
+			fileDocs, err = loader.Load(ctx)
+			if err != nil {
+				return err
+			}
+			for i := range fileDocs {
+				if fileDocs[i].Metadata == nil {
+					fileDocs[i].Metadata = make(map[string]any)
+				}
+				fileDocs[i].Metadata["source"] = path
+			}
+			return nil
+		}(); err != nil {
+			log.Printf("skip %s: %v", path, err)
+		} else {
+			docs = append(docs, fileDocs...)
+		}
+
+		return nil
+	})
+	return docs, err
+}
+
+// LoadAndSplit loads from a source and splits the documents using a text splitter.
+func (l *RecursiveDirectoryLoader) LoadAndSplit(ctx context.Context, splitter textsplitter.TextSplitter) ([]schema.Document, error) {
+	docs, err := l.Load(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return textsplitter.SplitDocuments(splitter, docs)
+}

--- a/documentloaders/directory_test.go
+++ b/documentloaders/directory_test.go
@@ -1,0 +1,121 @@
+package documentloaders
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRecursiveDirLoader_Options(t *testing.T) {
+	t.Run("default option", func(t *testing.T) {
+		l := NewRecursiveDirLoader()
+		assert.Equal(t, ".", l.root)
+		assert.Equal(t, 1, l.maxDepth)
+		assert.Empty(t, l.allowExt)
+	})
+
+	t.Run("custom option", func(t *testing.T) {
+		l := NewRecursiveDirLoader(
+			WithRoot("./testdata"),
+			WithMaxDepth(2),
+			WithAllowExts(".txt", ".csv"),
+			WithCSVOpts([]string{"name", "age", "city", "country"}),
+			WithPDFOpts("password1"),
+		)
+		assert.Contains(t, "./testdata", l.root)
+		assert.Equal(t, 2, l.maxDepth)
+		assert.Len(t, l.allowExt, 2)
+		assert.Contains(t, l.allowExt, ".txt")
+		assert.Contains(t, l.allowExt, ".csv")
+		assert.Equal(t, []string{"name", "age", "city", "country"}, l.Columns)
+		assert.Equal(t, "password1", l.PDFPassword)
+	})
+}
+
+func TestLoad_AllSupportedTypes(t *testing.T) {
+	ctx := context.Background()
+	root := "./testdata"
+
+	t.Run("txt", func(t *testing.T) {
+		l := NewRecursiveDirLoader(
+			WithRoot(root),
+			WithAllowExts(".txt"),
+		)
+		docs, err := l.Load(ctx)
+		require.NoError(t, err)
+		require.Len(t, docs, 1)
+		assert.Contains(t, docs[0].PageContent, "Foo Bar Baz")
+	})
+
+	t.Run("csv", func(t *testing.T) {
+		l := NewRecursiveDirLoader(
+			WithRoot(root),
+			WithCSVOpts([]string{"name", "age", "city", "country"}),
+			WithAllowExts(".csv"),
+		)
+		docs, err := l.Load(ctx)
+		require.NoError(t, err)
+		require.Len(t, docs, 20)
+		assert.Contains(t, docs[0].PageContent, "name: John Doe\nage: 25\ncity: New York\ncountry: United States")
+	})
+
+	t.Run("pdf valid password", func(t *testing.T) {
+		l := NewRecursiveDirLoader(
+			WithRoot(root),
+			WithMaxDepth(2),
+			WithAllowExts(".pdf"),
+			WithPDFOpts("password"),
+		)
+		docs, err := l.Load(ctx)
+		require.NoError(t, err)
+		assert.Len(t, docs, 4)
+		assert.Contains(t, docs[0].PageContent, "Simple PDF")
+	})
+
+	t.Run("pdf invalid password", func(t *testing.T) {
+		l := NewRecursiveDirLoader(
+			WithRoot(root),
+			WithMaxDepth(2),
+			WithAllowExts(".pdf"),
+			WithPDFOpts("password1"),
+		)
+		docs, err := l.Load(ctx)
+		require.NoError(t, err)
+		assert.Len(t, docs, 2)
+	})
+
+	t.Run("depth limit", func(t *testing.T) {
+		l := NewRecursiveDirLoader(
+			WithRoot(root),
+			WithMaxDepth(2),
+			WithAllowExts(".md"),
+		)
+		docs, err := l.Load(ctx)
+		require.NoError(t, err)
+		assert.Len(t, docs, 1)
+		assert.Contains(t, docs[0].PageContent, "hello md")
+	})
+
+	t.Run("all extensions", func(t *testing.T) {
+		l := NewRecursiveDirLoader(
+			WithRoot(root),
+			WithMaxDepth(3),
+			WithAllowExts(".txt", ".csv", ".html", ".md", ".pdf"),
+		)
+		docs, err := l.Load(ctx)
+		require.NoError(t, err)
+		require.Len(t, docs, 25)
+	})
+
+	t.Run("empty allowExt => all files", func(t *testing.T) {
+		l := NewRecursiveDirLoader(
+			WithRoot(root),
+			WithMaxDepth(3),
+		)
+		docs, err := l.Load(ctx)
+		require.NoError(t, err)
+		assert.Len(t, docs, 25)
+	})
+}

--- a/documentloaders/testdata/depth/test2.md
+++ b/documentloaders/testdata/depth/test2.md
@@ -1,0 +1,1 @@
+hello md


### PR DESCRIPTION
### PR Checklist

Fix #1384 

- [X] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [X] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [X] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
No
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
RecursiveDirectoryLoader is a document loader that loads documents with allowed extensions from a directory.
- [X] Describes the source of new concepts.

RecursiveDirectoryLoader walks through a directory and its sub-directories, loading every file whose extension is on the allow-list as a document. 
```
// RecursiveDirectoryLoader is a document loader that loads documents with allowed extensions from a directory.
type RecursiveDirectoryLoader struct {
	root     string
	maxDepth int
	allowExt map[string]struct{}

	Columns []string // CSV Columns

	PDFPassword string // PDF password
}
```
,See #1384 
- [X] References existing implementations as appropriate.
- [X] Contains test coverage for new functions.
<img width="851" height="53" alt="image" src="https://github.com/user-attachments/assets/86ef15ba-21b4-461a-8753-eb0f4f86eefb" />

- [X] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
