### PR TITLE
Add reasoning effort configuration for chat models

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -17,6 +17,20 @@ const (
 	defaultChatModel = "gpt-3.5-turbo"
 )
 
+// ReasoningEffort constrains effort on reasoning for reasoning models.
+type ReasoningEffort string
+
+const (
+	// ReasoningEffortMinimal reduces reasoning effort to minimum level
+	ReasoningEffortMinimal ReasoningEffort = "minimal"
+	// ReasoningEffortLow uses low reasoning effort
+	ReasoningEffortLow ReasoningEffort = "low"
+	// ReasoningEffortMedium uses medium reasoning effort (default)
+	ReasoningEffortMedium ReasoningEffort = "medium"
+	// ReasoningEffortHigh uses high reasoning effort
+	ReasoningEffortHigh ReasoningEffort = "high"
+)
+
 var ErrContentExclusive = errors.New("only one of Content / MultiContent allowed in message")
 
 type StreamOptions struct {
@@ -79,6 +93,11 @@ type ChatRequest struct {
 
 	// Metadata allows you to specify additional information that will be passed to the model.
 	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// ReasoningEffort constrains effort on reasoning for reasoning models.
+	// Currently supported values are minimal, low, medium, and high.
+	// Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning.
+	ReasoningEffort ReasoningEffort `json:"reasoning_effort,omitempty"`
 }
 
 // MarshalJSON ensures that only one of MaxTokens or MaxCompletionTokens is sent.
@@ -484,7 +503,7 @@ func (c *Client) createChat(ctx context.Context, payload *ChatRequest) (*ChatCom
 	}
 
 	payloadBytes, err := json.Marshal(payload)
-	
+
 	// Restore original metadata
 	payload.Metadata = originalMetadata
 	if err != nil {

--- a/llms/openai/internal/openaiclient/openaiclient.go
+++ b/llms/openai/internal/openaiclient/openaiclient.go
@@ -38,7 +38,8 @@ type Client struct {
 	// required when APIType is APITypeAzure or APITypeAzureAD
 	apiVersion string
 
-	ResponseFormat *ResponseFormat
+	ResponseFormat  *ResponseFormat
+	ReasoningEffort ReasoningEffort
 }
 
 // Option is an option for the OpenAI client.
@@ -60,19 +61,20 @@ type Doer interface {
 // New returns a new OpenAI client.
 func New(token string, model string, baseURL string, organization string,
 	apiType APIType, apiVersion string, httpClient Doer, embeddingModel string,
-	responseFormat *ResponseFormat,
+	responseFormat *ResponseFormat, reasoningEffort ReasoningEffort,
 	opts ...Option,
 ) (*Client, error) {
 	c := &Client{
-		token:          token,
-		Model:          model,
-		EmbeddingModel: embeddingModel,
-		baseURL:        strings.TrimSuffix(baseURL, "/"),
-		organization:   organization,
-		apiType:        apiType,
-		apiVersion:     apiVersion,
-		httpClient:     httpClient,
-		ResponseFormat: responseFormat,
+		token:           token,
+		Model:           model,
+		EmbeddingModel:  embeddingModel,
+		baseURL:         strings.TrimSuffix(baseURL, "/"),
+		organization:    organization,
+		apiType:         apiType,
+		apiVersion:      apiVersion,
+		httpClient:      httpClient,
+		ResponseFormat:  responseFormat,
+		ReasoningEffort: reasoningEffort,
 	}
 	if c.baseURL == "" {
 		c.baseURL = defaultBaseURL
@@ -162,6 +164,9 @@ func (c *Client) CreateChat(ctx context.Context, r *ChatRequest) (*ChatCompletio
 		} else {
 			r.Model = c.Model
 		}
+	}
+	if r.ReasoningEffort == "" && c.ReasoningEffort != "" {
+		r.ReasoningEffort = c.ReasoningEffort
 	}
 	resp, err := c.createChat(ctx, r)
 	if err != nil {

--- a/llms/openai/internal/openaiclient/openaiclient_test.go
+++ b/llms/openai/internal/openaiclient/openaiclient_test.go
@@ -32,7 +32,7 @@ func setupTestClient(t *testing.T, model string) *Client {
 		apiKey = key
 	}
 
-	client, err := New(apiKey, model, "", "", APITypeOpenAI, "", rr.Client(), "", nil)
+	client, err := New(apiKey, model, "", "", APITypeOpenAI, "", rr.Client(), "", nil, "")
 	require.NoError(t, err)
 	return client
 }
@@ -50,7 +50,7 @@ func TestClient_CreateChatCompletion(t *testing.T) {
 		apiKey = key
 	}
 
-	client, err := New(apiKey, "gpt-3.5-turbo", "", "", APITypeOpenAI, "", rr.Client(), "", nil)
+	client, err := New(apiKey, "gpt-3.5-turbo", "", "", APITypeOpenAI, "", rr.Client(), "", nil, "")
 	require.NoError(t, err)
 
 	req := &ChatRequest{
@@ -84,7 +84,7 @@ func TestClient_CreateChatCompletionStream(t *testing.T) {
 		apiKey = key
 	}
 
-	client, err := New(apiKey, "gpt-3.5-turbo", "", "", APITypeOpenAI, "", rr.Client(), "", nil)
+	client, err := New(apiKey, "gpt-3.5-turbo", "", "", APITypeOpenAI, "", rr.Client(), "", nil, "")
 	require.NoError(t, err)
 
 	var chunks []string
@@ -123,7 +123,7 @@ func TestClient_CreateEmbedding(t *testing.T) {
 		apiKey = key
 	}
 
-	client, err := New(apiKey, "", "", "", APITypeOpenAI, "", rr.Client(), "text-embedding-ada-002", nil)
+	client, err := New(apiKey, "", "", "", APITypeOpenAI, "", rr.Client(), "text-embedding-ada-002", nil, "")
 	require.NoError(t, err)
 
 	req := &EmbeddingRequest{
@@ -151,7 +151,7 @@ func TestClient_CreateEmbeddingWithDimensions(t *testing.T) {
 		apiKey = key
 	}
 
-	client, err := New(apiKey, "", "", "", APITypeOpenAI, "", rr.Client(), "text-embedding-3-small", nil, WithEmbeddingDimensions(256))
+	client, err := New(apiKey, "", "", "", APITypeOpenAI, "", rr.Client(), "text-embedding-3-small", nil, "", WithEmbeddingDimensions(256))
 	require.NoError(t, err)
 
 	req := &EmbeddingRequest{
@@ -179,7 +179,7 @@ func TestClient_FunctionCall(t *testing.T) {
 		apiKey = key
 	}
 
-	client, err := New(apiKey, "gpt-3.5-turbo", "", "", APITypeOpenAI, "", rr.Client(), "", nil)
+	client, err := New(apiKey, "gpt-3.5-turbo", "", "", APITypeOpenAI, "", rr.Client(), "", nil, "")
 	require.NoError(t, err)
 
 	req := &ChatRequest{
@@ -228,7 +228,7 @@ func TestClient_WithResponseFormat(t *testing.T) {
 	}
 
 	responseFormat := &ResponseFormat{Type: "json_object"}
-	client, err := New(apiKey, "gpt-3.5-turbo", "", "", APITypeOpenAI, "", rr.Client(), "", responseFormat)
+	client, err := New(apiKey, "gpt-3.5-turbo", "", "", APITypeOpenAI, "", rr.Client(), "", responseFormat, "")
 	require.NoError(t, err)
 
 	req := &ChatRequest{
@@ -253,7 +253,7 @@ func TestClient_WithResponseFormat(t *testing.T) {
 
 func TestMakeEmbeddingRequest(t *testing.T) {
 	t.Run("without dimensions", func(t *testing.T) {
-		client, err := New("", "gpt-3.5-turbo", "", "", APITypeOpenAI, "", nil, "", nil)
+		client, err := New("", "gpt-3.5-turbo", "", "", APITypeOpenAI, "", nil, "", nil, "")
 		require.NoError(t, err)
 
 		request := client.makeEmbeddingPayload(&EmbeddingRequest{Model: "some_model"})
@@ -261,7 +261,7 @@ func TestMakeEmbeddingRequest(t *testing.T) {
 		assert.Equal(t, 0, request.Dimensions)
 	})
 	t.Run("with dimensions", func(t *testing.T) {
-		client, err := New("", "gpt-3.5-turbo", "", "", APITypeOpenAI, "", nil, "", nil)
+		client, err := New("", "gpt-3.5-turbo", "", "", APITypeOpenAI, "", nil, "", nil, "")
 		require.NoError(t, err)
 
 		request := client.makeEmbeddingPayload(&EmbeddingRequest{Model: "some_model", Dimensions: 1234})
@@ -272,7 +272,7 @@ func TestMakeEmbeddingRequest(t *testing.T) {
 
 func TestInternalMetadataFiltering(t *testing.T) {
 	// Test that internal openai: prefixed metadata is filtered out from requests
-	client, err := New("test-api-key", "gpt-3.5-turbo", "", "", APITypeOpenAI, "", nil, "", nil)
+	client, err := New("test-api-key", "gpt-3.5-turbo", "", "", APITypeOpenAI, "", nil, "", nil, "")
 	require.NoError(t, err)
 
 	// Create a mock HTTP client to capture the request body
@@ -285,7 +285,7 @@ func TestInternalMetadataFiltering(t *testing.T) {
 				return nil, err
 			}
 			capturedRequestBody = body
-			
+
 			// Return a minimal valid response to avoid errors
 			responseBody := `{"choices":[{"message":{"content":"test"}}],"usage":{"total_tokens":10}}`
 			return &http.Response{
@@ -303,8 +303,8 @@ func TestInternalMetadataFiltering(t *testing.T) {
 			{Role: "user", Content: "test"},
 		},
 		Metadata: map[string]any{
-			"openai:use_legacy_max_tokens": true,     // Should be filtered out
-			"custom_field":                 "value",  // Should be preserved
+			"openai:use_legacy_max_tokens": true,    // Should be filtered out
+			"custom_field":                 "value", // Should be preserved
 		},
 	}
 

--- a/llms/openai/internal/openaiclient/reasoning_effort_test.go
+++ b/llms/openai/internal/openaiclient/reasoning_effort_test.go
@@ -1,0 +1,105 @@
+package openaiclient
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestChatRequestReasoningEffort(t *testing.T) {
+	tests := []struct {
+		name            string
+		reasoningEffort ReasoningEffort
+		expectedJSON    string
+	}{
+		{
+			name:            "minimal reasoning effort",
+			reasoningEffort: ReasoningEffortMinimal,
+			expectedJSON:    `"reasoning_effort":"minimal"`,
+		},
+		{
+			name:            "low reasoning effort",
+			reasoningEffort: ReasoningEffortLow,
+			expectedJSON:    `"reasoning_effort":"low"`,
+		},
+		{
+			name:            "medium reasoning effort",
+			reasoningEffort: ReasoningEffortMedium,
+			expectedJSON:    `"reasoning_effort":"medium"`,
+		},
+		{
+			name:            "high reasoning effort",
+			reasoningEffort: ReasoningEffortHigh,
+			expectedJSON:    `"reasoning_effort":"high"`,
+		},
+		{
+			name:            "empty reasoning effort omitted",
+			reasoningEffort: "",
+			expectedJSON:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := ChatRequest{
+				Model:           "gpt-4",
+				Messages:        []*ChatMessage{{Role: "user", Content: "test"}},
+				Temperature:     0.7,
+				ReasoningEffort: tt.reasoningEffort,
+			}
+
+			jsonBytes, err := json.Marshal(req)
+			if err != nil {
+				t.Fatalf("Failed to marshal ChatRequest: %v", err)
+			}
+
+			jsonStr := string(jsonBytes)
+			if tt.expectedJSON == "" {
+				// Should not contain reasoning_effort field
+				if !jsonContains(jsonStr, "reasoning_effort") {
+					// This is expected - empty reasoning effort should be omitted
+				} else {
+					t.Errorf("Expected reasoning_effort to be omitted from JSON, but it was present: %s", jsonStr)
+				}
+			} else {
+				// Should contain the expected reasoning_effort value
+				if !jsonContains(jsonStr, tt.expectedJSON) {
+					t.Errorf("Expected JSON to contain %s, got: %s", tt.expectedJSON, jsonStr)
+				}
+			}
+		})
+	}
+}
+
+func jsonContains(json, substring string) bool {
+	return len(substring) > 0 && len(json) > 0 &&
+		(json[0] == '{' || json[0] == '[') &&
+		len(json) > len(substring) &&
+		indexOf(json, substring) >= 0
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestReasoningEffortConstants(t *testing.T) {
+	tests := []struct {
+		constant ReasoningEffort
+		expected string
+	}{
+		{ReasoningEffortMinimal, "minimal"},
+		{ReasoningEffortLow, "low"},
+		{ReasoningEffortMedium, "medium"},
+		{ReasoningEffortHigh, "high"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.constant) != tt.expected {
+			t.Errorf("Expected constant %v to equal %s, got %s", tt.constant, tt.expected, string(tt.constant))
+		}
+	}
+}

--- a/llms/openai/llm.go
+++ b/llms/openai/llm.go
@@ -52,7 +52,7 @@ func newClient(opts ...Option) (*options, *openaiclient.Client, error) {
 	}
 	cli, err := openaiclient.New(options.token, options.model, options.baseURL, options.organization,
 		openaiclient.APIType(options.apiType), options.apiVersion, options.httpClient, options.embeddingModel,
-		options.responseFormat, clientOptions...,
+		options.responseFormat, openaiclient.ReasoningEffort(options.reasoningEffort), clientOptions...,
 	)
 	return options, cli, err
 }

--- a/llms/openai/openaillm_option.go
+++ b/llms/openai/openaillm_option.go
@@ -41,6 +41,7 @@ type options struct {
 	embeddingDimensions int
 
 	callbackHandler callbacks.Handler
+	reasoningEffort openaiclient.ReasoningEffort
 }
 
 // Option is a functional option for the OpenAI client.
@@ -55,8 +56,19 @@ type ResponseFormatJSONSchema = openaiclient.ResponseFormatJSONSchema
 // ResponseFormatJSONSchemaProperty is the JSON Schema property in structured output.
 type ResponseFormatJSONSchemaProperty = openaiclient.ResponseFormatJSONSchemaProperty
 
+// ReasoningEffort constrains effort on reasoning for reasoning models.
+type ReasoningEffort = openaiclient.ReasoningEffort
+
 // ResponseFormatJSON is the JSON response format.
 var ResponseFormatJSON = &ResponseFormat{Type: "json_object"} //nolint:gochecknoglobals
+
+// Reasoning effort constants
+const (
+	ReasoningEffortMinimal = ReasoningEffort(openaiclient.ReasoningEffortMinimal)
+	ReasoningEffortLow     = ReasoningEffort(openaiclient.ReasoningEffortLow)
+	ReasoningEffortMedium  = ReasoningEffort(openaiclient.ReasoningEffortMedium)
+	ReasoningEffortHigh    = ReasoningEffort(openaiclient.ReasoningEffortHigh)
+)
 
 // WithToken passes the OpenAI API token to the client. If not set, the token
 // is read from the OPENAI_API_KEY environment variable.
@@ -144,5 +156,14 @@ func WithCallback(callbackHandler callbacks.Handler) Option {
 func WithResponseFormat(responseFormat *ResponseFormat) Option {
 	return func(opts *options) {
 		opts.responseFormat = responseFormat
+	}
+}
+
+// WithReasoningEffort constrains effort on reasoning for reasoning models.
+// Currently supported values are minimal, low, medium, and high.
+// Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning.
+func WithReasoningEffort(reasoningEffort ReasoningEffort) Option {
+	return func(opts *options) {
+		opts.reasoningEffort = reasoningEffort
 	}
 }

--- a/llms/openai/reasoning_effort_test.go
+++ b/llms/openai/reasoning_effort_test.go
@@ -1,0 +1,65 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/tmc/langchaingo/llms/openai/internal/openaiclient"
+)
+
+func TestReasoningEffortOption(t *testing.T) {
+	tests := []struct {
+		name            string
+		reasoningEffort ReasoningEffort
+		expectedAPI     openaiclient.ReasoningEffort
+	}{
+		{
+			name:            "minimal effort",
+			reasoningEffort: ReasoningEffortMinimal,
+			expectedAPI:     openaiclient.ReasoningEffortMinimal,
+		},
+		{
+			name:            "low effort",
+			reasoningEffort: ReasoningEffortLow,
+			expectedAPI:     openaiclient.ReasoningEffortLow,
+		},
+		{
+			name:            "medium effort",
+			reasoningEffort: ReasoningEffortMedium,
+			expectedAPI:     openaiclient.ReasoningEffortMedium,
+		},
+		{
+			name:            "high effort",
+			reasoningEffort: ReasoningEffortHigh,
+			expectedAPI:     openaiclient.ReasoningEffortHigh,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create options with reasoning effort
+			opt := &options{}
+			WithReasoningEffort(tt.reasoningEffort)(opt)
+
+			// Verify the option was set correctly
+			if opt.reasoningEffort != openaiclient.ReasoningEffort(tt.expectedAPI) {
+				t.Errorf("Expected reasoning effort %v, got %v", tt.expectedAPI, opt.reasoningEffort)
+			}
+		})
+	}
+}
+
+func TestReasoningEffortConstants(t *testing.T) {
+	// Test that our constants match the internal client constants
+	if ReasoningEffortMinimal != ReasoningEffort(openaiclient.ReasoningEffortMinimal) {
+		t.Errorf("ReasoningEffortMinimal constant mismatch")
+	}
+	if ReasoningEffortLow != ReasoningEffort(openaiclient.ReasoningEffortLow) {
+		t.Errorf("ReasoningEffortLow constant mismatch")
+	}
+	if ReasoningEffortMedium != ReasoningEffort(openaiclient.ReasoningEffortMedium) {
+		t.Errorf("ReasoningEffortMedium constant mismatch")
+	}
+	if ReasoningEffortHigh != ReasoningEffort(openaiclient.ReasoningEffortHigh) {
+		t.Errorf("ReasoningEffortHigh constant mismatch")
+	}
+}


### PR DESCRIPTION
Introduce a configuration option for reasoning effort in chat models, allowing users to specify the level of reasoning effort (minimal, low, medium, high) for optimized performance and response times. This includes updates to the client, request structure, and corresponding tests.

[This PR](https://github.com/tmc/langchaingo/pull/1129) implements similar changes but has been stuck since early February due to tests. With the recent GPT-5 release, the reasoning effort configuration becomes even more important.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
