### PR TITLE
examples: fix typo in openai-chat-example.go of maximum tokens per generation, old: 104 tokens, fix: 1024 tokens

### DIFF
--- a/examples/openai-chat-example/openai_chat_example.go
+++ b/examples/openai-chat-example/openai_chat_example.go
@@ -22,14 +22,14 @@ func main() {
 	}
 
 	// if _, err := llm.GenerateContent(ctx, content,
-	// 	llms.WithMaxTokens(104),
+	// 	llms.WithMaxTokens(1024),
 	// 	llms.WithStreamingFunc(func(ctx context.Context, chunk []byte) error {
 	// 		fmt.Print(string(chunk))
 	// 		return nil
 	// 	})); err != nil {
 	// 	log.Fatal(err)
 	// }
-	r, err := llm.GenerateContent(ctx, content, llms.WithMaxTokens(104))
+	r, err := llm.GenerateContent(ctx, content, llms.WithMaxTokens(1024))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Fixing a typo of llms.WithMaxtokens(104) to llms.WithMaxtokens(1024) in examples/openai-chat-example/openai-chat-example.go. In README says that it should be 1024, so I fixed it. It is a small fix pr, nothing special


### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
