### PR TITLE
docs: fix incorrect function name in memory documentation

### DIFF
--- a/docs/docs/modules/memory/index.mdx
+++ b/docs/docs/modules/memory/index.mdx
@@ -59,7 +59,7 @@ LangChainGo memory can persist to various backends:
 Chains automatically handle memory integration:
 
 ```go
-chain := chains.NewConversationChain(llm, memory)
+chain := chains.NewConversation(llm, memory)
 ```
 
 ### With Agents


### PR DESCRIPTION
## Summary

Corrects the function name in the memory documentation from `chains.NewConversationChain` to `chains.NewConversation` to match the actual API implementation.

## Changes

- Fixed incorrect function reference in 
- The actual function in the codebase is `NewConversation`, not `NewConversationChain`

Fixes #1391