### PR TITLE
llms/ollama: Add generation duration metrics to GenerateContent response

### DIFF
--- a/llms/ollama/ollamallm.go
+++ b/llms/ollama/ollamallm.go
@@ -211,8 +211,12 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		"PromptTokens":     resp.PromptEvalCount,
 		"TotalTokens":      resp.EvalCount + resp.PromptEvalCount,
 		// Add empty thinking fields for cross-provider compatibility
-		"ThinkingContent": "", // Ollama doesn't separate thinking content
-		"ThinkingTokens":  0,  // Ollama doesn't track thinking tokens separately
+		"ThinkingContent":    "", // Ollama doesn't separate thinking content
+		"ThinkingTokens":     0,  // Ollama doesn't track thinking tokens separately
+		"PromptEvalDuration": resp.PromptEvalDuration,
+		"EvalDuration":       resp.EvalDuration,
+		"LoadDuration":       resp.LoadDuration,
+		"TotalDuration":      resp.TotalDuration,
 	}
 
 	// If context caching is enabled, track cache usage


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.


### Problem
- Duration metrics (PromptEvalDuration, EvalDuration, LoadDuration, TotalDuration) were available from the LLM response.
- These values were missing from the genInfo map, so they could not be accessed downstream for analysis or monitoring.

### Solution
- Added the missing duration metrics into the genInfo variable within GenerateContent:
    - PromptEvalDuration – time spent evaluating the prompt.
    - EvalDuration – time spent generating tokens.
    - LoadDuration – time spent loading the model/resources.
    - TotalDuration – total request duration.
- Ensures duration metrics are included in the response for observability and performance insights.