### PR TITLE
fix(llm): chat_messages with json tag

### DIFF
--- a/llms/chat_messages.go
+++ b/llms/chat_messages.go
@@ -186,6 +186,8 @@ func (c ChatMessageModel) ToChatMessage() ChatMessage {
 		return AIChatMessage{Content: c.Data.Content}
 	case string(ChatMessageTypeHuman):
 		return HumanChatMessage{Content: c.Data.Content}
+	case string(ChatMessageTypeSystem):
+		return SystemChatMessage{Content: c.Data.Content}
 	default:
 		slog.Warn("convert to chat message failed with invalid message type", "type", c.Type)
 		return nil


### PR DESCRIPTION
Problem:
When sending chat messages history through json, it gets unsconsistent struct behavior because of missing json tags at the structs.

Solution:
Add json tags to missing structs.