### PR TITLE
anthropic: add improved streaming thinking/reasoning token support

### DIFF
--- a/llms/anthropic/anthropicllm.go
+++ b/llms/anthropic/anthropicllm.go
@@ -146,17 +146,18 @@ func generateMessagesContent(ctx context.Context, o *LLM, messages []llms.Messag
 	betaHeaders, thinking := extractThinkingOptions(o, opts)
 
 	result, err := o.client.CreateMessage(ctx, &anthropicclient.MessageRequest{
-		Model:         opts.Model,
-		Messages:      chatMessages,
-		System:        systemPrompt,
-		MaxTokens:     opts.MaxTokens,
-		StopWords:     opts.StopWords,
-		Temperature:   opts.Temperature,
-		TopP:          opts.TopP,
-		Tools:         tools,
-		Thinking:      thinking,
-		BetaHeaders:   betaHeaders,
-		StreamingFunc: opts.StreamingFunc,
+		Model:                  opts.Model,
+		Messages:               chatMessages,
+		System:                 systemPrompt,
+		MaxTokens:              opts.MaxTokens,
+		StopWords:              opts.StopWords,
+		Temperature:            opts.Temperature,
+		TopP:                   opts.TopP,
+		Tools:                  tools,
+		Thinking:               thinking,
+		BetaHeaders:            betaHeaders,
+		StreamingFunc:          opts.StreamingFunc,
+		StreamingReasoningFunc: opts.StreamingReasoningFunc,
 	})
 	if err != nil {
 		if o.CallbacksHandler != nil {

--- a/llms/anthropic/internal/anthropicclient/anthropicclient.go
+++ b/llms/anthropic/internal/anthropicclient/anthropicclient.go
@@ -141,24 +141,26 @@ type MessageRequest struct {
 	Thinking *ThinkingConfig `json:"thinking,omitempty"`
 
 	// BetaHeaders are additional beta feature headers to include
-	BetaHeaders   []string                                      `json:"-"`
-	StreamingFunc func(ctx context.Context, chunk []byte) error `json:"-"`
+	BetaHeaders            []string                                                      `json:"-"`
+	StreamingFunc          func(ctx context.Context, chunk []byte) error                `json:"-"`
+	StreamingReasoningFunc func(ctx context.Context, reasoningChunk, chunk []byte) error `json:"-"`
 }
 
 // CreateMessage creates message for the messages api.
 func (c *Client) CreateMessage(ctx context.Context, r *MessageRequest) (*MessageResponsePayload, error) {
 	resp, err := c.createMessage(ctx, &messagePayload{
-		Model:         r.Model,
-		Messages:      r.Messages,
-		System:        r.System,
-		Temperature:   r.Temperature,
-		MaxTokens:     r.MaxTokens,
-		StopWords:     r.StopWords,
-		TopP:          r.TopP,
-		Tools:         r.Tools,
-		Stream:        r.Stream,
-		Thinking:      r.Thinking,
-		StreamingFunc: r.StreamingFunc,
+		Model:                  r.Model,
+		Messages:               r.Messages,
+		System:                 r.System,
+		Temperature:            r.Temperature,
+		MaxTokens:              r.MaxTokens,
+		StopWords:              r.StopWords,
+		TopP:                   r.TopP,
+		Tools:                  r.Tools,
+		Stream:                 r.Stream,
+		Thinking:               r.Thinking,
+		StreamingFunc:          r.StreamingFunc,
+		StreamingReasoningFunc: r.StreamingReasoningFunc,
 	}, r.BetaHeaders)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
Adds improved real-time streaming support for thinking/reasoning tokens in the Anthropic client, enabling thinking content to appear ahead of responses instead of after completion.

## Changes
- Add StreamingReasoningFunc field to messagePayload and MessageRequest
- Modify handleThinkingDelta() to call streaming callback in real-time
- Wire up callback from llms.CallOptions through anthropicllm.go to internal client
- Update setMessageDefaults() to enable streaming when reasoning func present

## Implementation Details
Follows the same pattern as OpenAI client (llms/openai/internal/openaiclient/chat.go:638-663). When thinking_delta events arrive from the Anthropic API, they're immediately passed to the StreamingReasoningFunc callback instead of being buffered until response completion.

## Testing
- All existing tests pass
- Tested with cgpt integration confirming real-time grey thinking display
- Thinking tokens now stream before response content (matching ollama UX)