### PR TITLE
llms/openai: sanitize HTTP errors to prevent API key exposure

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -507,7 +507,7 @@ func (c *Client) createChat(ctx context.Context, payload *ChatRequest) (*ChatCom
 	// Send request
 	r, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, sanitizeHTTPError(err)
 	}
 	defer r.Body.Close()
 

--- a/llms/openai/internal/openaiclient/embeddings.go
+++ b/llms/openai/internal/openaiclient/embeddings.go
@@ -52,7 +52,7 @@ func (c *Client) createEmbedding(ctx context.Context, payload *embeddingPayload)
 
 	r, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("send request: %w", err)
+		return nil, sanitizeHTTPError(err)
 	}
 	defer r.Body.Close()
 


### PR DESCRIPTION
Fixes #1393

## Changes
- Add sanitizeHTTPError() function to detect and mask sensitive error details
- Wrap HTTP errors in context deadline/cancellation errors
- Update chat.go and embeddings.go to use sanitization
- Add comprehensive test coverage for error sanitization

## Testing  
- All existing tests pass
- New unit tests cover context deadline, network errors, and other sensitive cases