### PR TITLE
fix: deekseek model tool call fail cause by "\nObservation" args input

### DIFF
--- a/agents/conversational.go
+++ b/agents/conversational.go
@@ -157,8 +157,10 @@ func (a *ConversationalAgent) parseOutput(output string) ([]schema.AgentAction, 
 		return nil, nil, fmt.Errorf("%w: %s", ErrUnableToParseOutput, output)
 	}
 
+	toolInput := strings.TrimSuffix(matches[2], "\nObservation:")
+	toolInput = strings.TrimSuffix(toolInput, "\nObservation")
 	return []schema.AgentAction{
-		{Tool: strings.TrimSpace(matches[1]), ToolInput: strings.TrimSpace(matches[2]), Log: output},
+		{Tool: strings.TrimSpace(matches[1]), ToolInput: strings.TrimSpace(toolInput), Log: output},
 	}, nil, nil
 }
 

--- a/agents/executor.go
+++ b/agents/executor.go
@@ -135,7 +135,9 @@ func (e *Executor) doAction(
 		}), nil
 	}
 
-	observation, err := tool.Call(ctx, strings.TrimSuffix(action.ToolInput, "\nObservation:"))
+	toolInput := strings.TrimSuffix(action.ToolInput, "\nObservation:")
+	toolInput = strings.TrimSuffix(toolInput, "\nObservation")
+	observation, err := tool.Call(ctx, toolInput)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### PR Checklist

- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
