### PR TITLE
anthropic: add optional callback handlers

### DIFF
--- a/llms/anthropic/anthropicllm_option.go
+++ b/llms/anthropic/anthropicllm_option.go
@@ -1,6 +1,7 @@
 package anthropic
 
 import (
+	"github.com/tmc/langchaingo/callbacks"
 	"github.com/tmc/langchaingo/llms/anthropic/internal/anthropicclient"
 )
 
@@ -22,6 +23,8 @@ type options struct {
 
 	// If supplied, the 'anthropic-beta' header will be added to the request with the given value.
 	anthropicBetaHeader string
+
+	callbackHandler callbacks.Handler
 }
 
 type Option func(*options)
@@ -68,5 +71,12 @@ func WithLegacyTextCompletionsAPI() Option {
 func WithAnthropicBetaHeader(value string) Option {
 	return func(opts *options) {
 		opts.anthropicBetaHeader = value
+	}
+}
+
+// WithCallback allows setting a custom Callback Handler.
+func WithCallback(callbackHandler callbacks.Handler) Option {
+	return func(opts *options) {
+		opts.callbackHandler = callbackHandler
 	}
 }

--- a/llms/anthropic/testdata/TestCallbacksHandler.httprr
+++ b/llms/anthropic/testdata/TestCallbacksHandler.httprr
@@ -1,0 +1,36 @@
+httprr trace v1
+363 1577
+POST https://api.anthropic.com/v1/messages HTTP/1.1
+Host: api.anthropic.com
+User-Agent: langchaingo-httprr
+Content-Length: 143
+Anthropic-Version: 2023-06-01
+Content-Type: application/json
+X-Api-Key: test-api-key
+
+{"model":"claude-3-5-sonnet-20240620","messages":[{"role":"user","content":[{"type":"text","text":"test"}]}],"max_tokens":2048,"temperature":0}HTTP/2.0 200 OK
+Content-Length: 545
+Anthropic-Organization-Id: 27796668-7351-40ac-acc4-024aee8995a5
+Anthropic-Ratelimit-Input-Tokens-Limit: 8000000
+Anthropic-Ratelimit-Input-Tokens-Remaining: 8000000
+Anthropic-Ratelimit-Input-Tokens-Reset: 2025-10-28T01:28:45Z
+Anthropic-Ratelimit-Output-Tokens-Limit: 1600000
+Anthropic-Ratelimit-Output-Tokens-Remaining: 1600000
+Anthropic-Ratelimit-Output-Tokens-Reset: 2025-10-28T01:28:46Z
+Anthropic-Ratelimit-Requests-Limit: 7000
+Anthropic-Ratelimit-Requests-Remaining: 6999
+Anthropic-Ratelimit-Requests-Reset: 2025-10-28T01:28:45Z
+Anthropic-Ratelimit-Tokens-Limit: 9600000
+Anthropic-Ratelimit-Tokens-Remaining: 9600000
+Anthropic-Ratelimit-Tokens-Reset: 2025-10-28T01:28:45Z
+Cf-Cache-Status: DYNAMIC
+Content-Type: application/json
+Date: Tue, 28 Oct 2025 01:28:46 GMT
+Request-Id: req_011CUYjF9xbqccQaBV2CiacU
+Server: cloudflare
+Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+Via: 1.1 google
+X-Envoy-Upstream-Service-Time: 1385
+X-Robots-Tag: none
+
+{"model":"claude-3-5-sonnet-20240620","id":"msg_013c6Lg9yEVks4fKNineCdwR","type":"message","role":"assistant","content":[{"type":"text","text":"This is a test response. How can I assist you today? Feel free to ask any questions or let me know if you need help with something specific."}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":8,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":34,"service_tier":"standard"}}


### PR DESCRIPTION
This pull request adds the ability to add callbacks to Anthropic LLM calls for observability and other use cases. It also adds the missing callback handler and tests. It follows the same patterns as OpenAI (which is fully implemented). 

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
