### PR TITLE
fix: typo in structured outputparser

### DIFF
--- a/outputparser/structured.go
+++ b/outputparser/structured.go
@@ -115,7 +115,7 @@ func (p Structured) GetFormatInstructions() string {
 		jsonLines += "\t" + fmt.Sprintf(
 			_structuredLineTemplate,
 			rs.Name,
-			"string", /* type of the filed*/
+			"string", /* type of the field*/
 			rs.Description,
 		)
 	}


### PR DESCRIPTION
Fix typo in outputparser -> structured.go

### PR Checklist
- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as memory: add interfaces for X, Y or util: add whizzbang helpers).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses what the PR is solving, or reference the issue that it solves (e.g. Fixes #123).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [golangci-lint](https://golangci-lint.run/) checks.
