### PR TITLE
googleai: add response schema support

### DIFF
--- a/llms/googleai/googleai.go
+++ b/llms/googleai/googleai.go
@@ -110,6 +110,21 @@ func (g *GoogleAI) GenerateContent(
 		model.ResponseMIMEType = ResponseMIMETypeJson
 	}
 
+	if opts.ResponseSchema != nil {
+		schema, ok := opts.ResponseSchema.(*genai.Schema)
+		if !ok {
+			return nil, fmt.Errorf("response schema must be *genai.Schema, got %T", opts.ResponseSchema)
+		}
+		if model.ResponseMIMEType != "" && model.ResponseMIMEType != ResponseMIMETypeJson {
+			return nil, fmt.Errorf("response schema requires response MIME type %q, got %q",
+				ResponseMIMETypeJson, model.ResponseMIMEType)
+		}
+		model.ResponseSchema = schema
+		if model.ResponseMIMEType == "" {
+			model.ResponseMIMEType = ResponseMIMETypeJson
+		}
+	}
+
 	var response *llms.ContentResponse
 
 	if len(messages) == 1 {

--- a/llms/googleai/googleai_test.go
+++ b/llms/googleai/googleai_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/generative-ai-go/genai"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/httputil"
@@ -352,6 +353,7 @@ func TestGoogleAIWithJSONMode(t *testing.T) {
 		context.Background(),
 		content,
 		llms.WithJSONMode(),
+		llms.WithResponseSchema(&genai.Schema{Type: genai.TypeArray, Items: &genai.Schema{Type: genai.TypeString}}),
 	)
 
 	if err != nil {

--- a/llms/googleai/testdata/TestGoogleAIWithJSONMode.httprr
+++ b/llms/googleai/testdata/TestGoogleAIWithJSONMode.httprr
@@ -1,14 +1,14 @@
 httprr trace v1
-814 1361
+861 1361
 POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?%24alt=json%3Benum-encoding%3Dint HTTP/1.1
 Host: generativelanguage.googleapis.com
 User-Agent: langchaingo-httprr
-Content-Length: 395
+Content-Length: 442
 Content-Type: application/json
 x-goog-api-client: gl-go/X.XX.X gccl/vX.XX.X genai-go/X.XX.X gapic/X.X.X gax/X.XX.X rest/UNKNOWN
 x-goog-request-params: model=models%2Fgemini-2.0-flash
 
-{"model":"models/gemini-2.0-flash","contents":[{"parts":[{"text":"List three colors as a JSON array"}],"role":"user"}],"safetySettings":[{"category":10,"threshold":3},{"category":7,"threshold":3},{"category":8,"threshold":3},{"category":9,"threshold":3}],"generationConfig":{"candidateCount":1,"maxOutputTokens":2048,"temperature":0.5,"topP":0.95,"topK":3,"responseMimeType":"application/json"}}HTTP/2.0 200 OK
+{"model":"models/gemini-2.0-flash","contents":[{"parts":[{"text":"List three colors as a JSON array"}],"role":"user"}],"safetySettings":[{"category":10,"threshold":3},{"category":7,"threshold":3},{"category":8,"threshold":3},{"category":9,"threshold":3}],"generationConfig":{"candidateCount":1,"maxOutputTokens":2048,"temperature":0.5,"topP":0.95,"topK":3,"responseMimeType":"application/json","responseSchema":{"type":5,"items":{"type":1}}}}HTTP/2.0 200 OK
 Content-Length: 983
 Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
 Content-Type: application/json; charset=UTF-8

--- a/llms/options.go
+++ b/llms/options.go
@@ -70,6 +70,10 @@ type CallOptions struct {
 	// application/json: JSON response in the response candidates.
 	ResponseMIMEType string `json:"response_mime_type,omitempty"`
 
+	// ResponseSchema specifies a provider-specific structured output schema.
+	// Google AI accepts *genai.Schema from github.com/google/generative-ai-go/genai.
+	ResponseSchema any `json:"response_schema,omitempty"`
+
 	// WebSearchOptions configures web search behavior for models that support it.
 	// Currently supported by OpenAI models like gpt-4o-search-preview.
 	WebSearchOptions *WebSearchOptions `json:"web_search_options,omitempty"`
@@ -326,6 +330,13 @@ func WithMetadata(metadata map[string]interface{}) CallOption {
 func WithResponseMIMEType(responseMIMEType string) CallOption {
 	return func(o *CallOptions) {
 		o.ResponseMIMEType = responseMIMEType
+	}
+}
+
+// WithResponseSchema sets a provider-specific structured output schema.
+func WithResponseSchema(schema any) CallOption {
+	return func(o *CallOptions) {
+		o.ResponseSchema = schema
 	}
 }
 


### PR DESCRIPTION
## Summary

Add Google AI native response schema support through `llms.WithResponseSchema`. Google AI accepts `*genai.Schema`, applies it to the generation request, and uses `application/json` when no response MIME type is set. Invalid schema types and incompatible MIME types return an error.

Partially addresses #1342.

## Testing

- Extended the existing HTTP replay test to verify the schema is sent in the generation request
- Google AI non-live tests
- `go test ./llms`
- `go vet ./llms ./llms/googleai`
- `make lint`