### PR TITLE
modify-an-errors

### DIFF
--- a/docs/docs/tutorials/log-analyzer.md
+++ b/docs/docs/tutorials/log-analyzer.md
@@ -332,7 +332,7 @@ Log Summary:
 
 Top Error Patterns:
 {{range .top_errors}}
-- {{.pattern}} ({{.count}} occurrences)
+- {{.Pattern}} ({{.Count}} occurrences)
 {{end}}
 
 Recent Log Sample:


### PR DESCRIPTION
```go

Top Error Patterns:
{{range .top_errors}}
- {{.pattern}} ({{.count}} occurrences)
{{end}}
```
需要改成
```go
Top Error Patterns:
{{range .top_errors}}
- {{.Pattern}} ({{.Count}} occurrences)
{{end}}
```

因为在fomat的时候{{range .top_errors}}传入的是一个analysis.TopErrors,
```go
type LogAnalysis struct {
	TotalEntries    int            `json:"total_entries"`
	ErrorCount      int            `json:"error_count"`
	WarningCount    int            `json:"warning_count"`
	TopErrors       []ErrorPattern `json:"top_errors"`
	TimeRange       TimeRange      `json:"time_range"`
	Recommendations []string       `json:"recommendations"`
	Anomalies       []Anomaly      `json:"anomalies"`
}

type ErrorPattern struct {
	Pattern string `json:"pattern"`
	Count   int    `json:"count"`
	Example string `json:"example"`
}
```
这里ErrorPattern字段Pattern和Count字段首字母都是大写的，所以上述的字段引用也要大写，当然把ErrorPattern中的两个字段首字母改成小写也可以，因为在format格式化字段引用的时候，他是通过反射来find对应的字段引用,并不是json
```go
func getField(v reflect.Value, name string) reflect.Value {
    // 如果 v 是结构体
    if v.Kind() == reflect.Struct {
        field := v.FieldByName(name) // 
        if !field.IsValid() {
            // error：can't evaluate field xxx
        }
        return field
    }
    // ...
}
```