### PR TITLE
fix: Upgrade mongo internal and memory handling to Mong driver V2

### DIFF
--- a/internal/mongodb/client.go
+++ b/internal/mongodb/client.go
@@ -3,13 +3,13 @@ package mongodb
 import (
 	"context"
 
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
-	"go.mongodb.org/mongo-driver/mongo/readpref"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
 )
 
 func NewClient(ctx context.Context, url string) (*mongo.Client, error) {
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(url))
+	client, err := mongo.Connect(options.Client().ApplyURI(url))
 	if err != nil {
 		return nil, err
 	}

--- a/memory/mongo/mongo_chat_history.go
+++ b/memory/mongo/mongo_chat_history.go
@@ -7,8 +7,8 @@ import (
 	"github.com/tmc/langchaingo/internal/mongodb"
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/schema"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 const (
@@ -41,14 +41,16 @@ func NewMongoDBChatMessageHistory(ctx context.Context, options ...ChatMessageHis
 		return nil, err
 	}
 
-	client, err := mongodb.NewClient(ctx, h.url)
-	if err != nil {
-		return nil, err
+	if h.client == nil {
+		client, err := mongodb.NewClient(ctx, h.url)
+		if err != nil {
+			return nil, err
+		}
+
+		h.client = client
 	}
 
-	h.client = client
-
-	h.collection = client.Database(h.databaseName).Collection(h.collectionName)
+	h.collection = h.client.Database(h.databaseName).Collection(h.collectionName)
 	// create session id index
 	if _, err := h.collection.Indexes().CreateOne(ctx, mongo.IndexModel{Keys: bson.D{{Key: mongoSessionIDKey, Value: 1}}}); err != nil {
 		return nil, err

--- a/memory/mongo/mongo_chat_history_options.go
+++ b/memory/mongo/mongo_chat_history_options.go
@@ -2,6 +2,8 @@ package mongo
 
 import (
 	"errors"
+
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 const (
@@ -26,7 +28,7 @@ func applyMongoDBChatOptions(options ...ChatMessageHistoryOption) (*ChatMessageH
 		option(h)
 	}
 
-	if h.url == "" {
+	if h.url == "" && h.client == nil {
 		return nil, errMongoInvalidURL
 	}
 	if h.sessionID == "" {
@@ -62,5 +64,11 @@ func WithCollectionName(name string) ChatMessageHistoryOption {
 func WithDataBaseName(name string) ChatMessageHistoryOption {
 	return func(p *ChatMessageHistory) {
 		p.databaseName = name
+	}
+}
+
+func WithDataBaseClient(client *mongo.Client) ChatMessageHistoryOption {
+	return func(p *ChatMessageHistory) {
+		p.client = client
 	}
 }


### PR DESCRIPTION
Introduced a new option to allow users to inject a custom MongoDB client (`WithDataBaseClient`). Updated existing logic to handle cases where a client is provided instead of generating a new one. Modified imports to use the updated `v2` MongoDB driver package.

Fixes: #1443 


### PR Checklist

- [X] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [X] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [X] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [X] Describes the source of new concepts.
- [X] References existing implementations as appropriate.
- [X] Contains test coverage for new functions.
- [X] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
