### PR TITLE
fix: Update defaultURL in huggingfacellm_option.go (old endpoint deprecated)

### DIFF
--- a/llms/huggingface/huggingfacellm_option.go
+++ b/llms/huggingface/huggingfacellm_option.go
@@ -13,7 +13,7 @@ const (
 	xdgCacheHomeEnvVar    = "XDG_CACHE_HOME" // XDG cache directory
 	defaultTokenPath      = "token"          // Default token filename
 	defaultModel          = "gpt2"
-	defaultURL            = "https://api-inference.huggingface.co"
+	defaultURL            = "https://router.huggingface.co/hf-inference"
 	routerURL             = "https://router.huggingface.co"
 )
 

--- a/llms/huggingface/internal/huggingfaceclient/huggingfaceclient_test.go
+++ b/llms/huggingface/internal/huggingfaceclient/huggingfaceclient_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tmc/langchaingo/internal/httprr"
 )
 
-const testURL = "https://api-inference.huggingface.co"
+const testURL = "https://router.huggingface.co/hf-inference"
 
 func TestClient_RunInference(t *testing.T) {
 	ctx := context.Background()

--- a/llms/huggingface/internal/huggingfaceclient/testdata/TestClient_RunInference.httprr
+++ b/llms/huggingface/internal/huggingfaceclient/testdata/TestClient_RunInference.httprr
@@ -1,7 +1,7 @@
 httprr trace v1
-324 873
-POST https://api-inference.huggingface.co/models/HuggingFaceH4/zephyr-7b-beta HTTP/1.1
-Host: api-inference.huggingface.co
+323 873
+POST https://router.huggingface.co/hf-inference/models/HuggingFaceH4/zephyr-7b-beta HTTP/1.1
+Host: router.huggingface.co
 User-Agent: langchaingo-httprr
 Content-Length: 79
 Authorization: Bearer test-api-key

--- a/llms/huggingface/internal/huggingfaceclient/testdata/TestClient_RunInferenceText2Text.httprr
+++ b/llms/huggingface/internal/huggingfaceclient/testdata/TestClient_RunInferenceText2Text.httprr
@@ -1,7 +1,7 @@
 httprr trace v1
-348 873
-POST https://api-inference.huggingface.co/models/HuggingFaceH4/zephyr-7b-beta HTTP/1.1
-Host: api-inference.huggingface.co
+347 873
+POST https://router.huggingface.co/hf-inference/models/HuggingFaceH4/zephyr-7b-beta HTTP/1.1
+Host: router.huggingface.co
 User-Agent: langchaingo-httprr
 Content-Length: 102
 Authorization: Bearer test-api-key

--- a/llms/huggingface/testdata/TestHuggingFaceLLMStandardInference.httprr
+++ b/llms/huggingface/testdata/TestHuggingFaceLLMStandardInference.httprr
@@ -1,7 +1,7 @@
 httprr trace v1
-325 873
-POST https://api-inference.huggingface.co/models/HuggingFaceH4/zephyr-7b-beta HTTP/1.1
-Host: api-inference.huggingface.co
+324 873
+POST https://router.huggingface.co/hf-inference/models/HuggingFaceH4/zephyr-7b-beta HTTP/1.1
+Host: router.huggingface.co
 User-Agent: langchaingo-httprr
 Content-Length: 80
 Authorization: Bearer test-api-key


### PR DESCRIPTION
## Summary
This PR fixes #1428

## Changes
- `llms/huggingface/huggingfacellm_option.go`
- `llms/huggingface/internal/huggingfaceclient/huggingfaceclient_test.go`
- `llms/huggingface/internal/huggingfaceclient/testdata/TestClient_RunInference.httprr`
- `llms/huggingface/internal/huggingfaceclient/testdata/TestClient_RunInferenceText2Text.httprr`
- `llms/huggingface/testdata/TestHuggingFaceLLMStandardInference.httprr`
