### PR TITLE
fix: Add extra_body to OpenAI client chat request

### DIFF
--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -210,6 +210,14 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		}
 	}
 
+	// Extract extra_body if provided
+	var extraBody map[string]any
+	if opts.Metadata != nil {
+		if v, ok := opts.Metadata["openai:extra_body"].(map[string]interface{}); ok {
+			extraBody = v
+		}
+	}
+
 	// Extract reasoning effort for thinking models
 	// Note: OpenAI o1/o3 models have built-in reasoning and don't support reasoning_effort parameter
 	// This is kept for future models that might support it (like GPT-5)
@@ -293,6 +301,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		FunctionCallBehavior: openaiclient.FunctionCallBehavior(opts.FunctionCallBehavior),
 		Seed:                 opts.Seed,
 		Metadata:             apiMetadata,
+		ExtraBody:            extraBody,
 	}
 	if opts.JSONMode {
 		req.ResponseFormat = ResponseFormatJSON

--- a/llms/openai/options.go
+++ b/llms/openai/options.go
@@ -51,8 +51,8 @@ func WithLegacyMaxTokensField() llms.CallOption {
 //	)
 func WithExtraBody(extraBody map[string]interface{}) llms.CallOption {
 	return func(opts *llms.CallOptions) {
-		// Only set if extraBody is not nil and not empty
-		if extraBody != nil && len(extraBody) > 0 {
+		// Only set if extraBody is not empty
+		if len(extraBody) > 0 {
 			if opts.Metadata == nil {
 				opts.Metadata = make(map[string]interface{})
 			}

--- a/llms/openai/options.go
+++ b/llms/openai/options.go
@@ -37,3 +37,26 @@ func WithLegacyMaxTokensField() llms.CallOption {
 		opts.Metadata["openai:use_legacy_max_tokens"] = true
 	}
 }
+
+// WithExtraBody allows passing custom parameters directly to the OpenAI API.
+// This is useful for beta features or new parameters not yet supported by the library.
+// Fields in extraBody will be merged into the JSON request body.
+//
+// Usage:
+//
+//	llm.GenerateContent(ctx, messages,
+//	    openai.WithExtraBody(map[string]interface{}{
+//	        "parallel_tool_calls": false,
+//	    }),
+//	)
+func WithExtraBody(extraBody map[string]interface{}) llms.CallOption {
+	return func(opts *llms.CallOptions) {
+		// Only set if extraBody is not nil and not empty
+		if extraBody != nil && len(extraBody) > 0 {
+			if opts.Metadata == nil {
+				opts.Metadata = make(map[string]interface{})
+			}
+			opts.Metadata["openai:extra_body"] = extraBody
+		}
+	}
+}

--- a/llms/openai/options_test.go
+++ b/llms/openai/options_test.go
@@ -73,3 +73,48 @@ func TestWithLegacyMaxTokensField(t *testing.T) {
 		t.Error("expected openai:use_legacy_max_tokens to be true")
 	}
 }
+
+func TestWithExtraBody(t *testing.T) {
+	opts := &llms.CallOptions{}
+
+	// Test that WithExtraBody sets the metadata
+	extraBody := map[string]interface{}{
+		"parallel_tool_calls": false,
+		"custom_param":        "test_value",
+	}
+	WithExtraBody(extraBody)(opts)
+	if opts.Metadata == nil {
+		t.Fatal("expected Metadata to be initialized")
+	}
+	if v, ok := opts.Metadata["openai:extra_body"].(map[string]interface{}); !ok {
+		t.Error("expected openai:extra_body to be set")
+	} else {
+		if v["parallel_tool_calls"] != false {
+			t.Error("expected parallel_tool_calls to be false")
+		}
+		if v["custom_param"] != "test_value" {
+			t.Error("expected custom_param to be test_value")
+		}
+	}
+
+	// Test with empty extra body - should not set metadata
+	opts2 := &llms.CallOptions{}
+	emptyExtra := map[string]interface{}{}
+	WithExtraBody(emptyExtra)(opts2)
+	// Empty extra body should not create metadata
+	if opts2.Metadata != nil {
+		if _, exists := opts2.Metadata["openai:extra_body"]; exists {
+			t.Error("expected openai:extra_body to not be set for empty map")
+		}
+	}
+
+	// Test with nil extra body - should not set metadata
+	opts3 := &llms.CallOptions{}
+	WithExtraBody(nil)(opts3)
+	// Nil extra body should not create metadata
+	if opts3.Metadata != nil {
+		if _, exists := opts3.Metadata["openai:extra_body"]; exists {
+			t.Error("expected openai:extra_body to not be set for nil")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
This PR fixes #1436 by adding support for the `extra_body` parameter to the OpenAI client, similar to the official Python client.

## Changes
- **Added `ExtraBody` field** to `ChatRequest` struct for passing custom parameters
- **Custom JSON marshaling** that merges `ExtraBody` fields into the request body
- **`WithExtraBody()` call option** for users to pass custom parameters via metadata
- **Comprehensive tests** for marshaling behavior, including edge cases (nil, empty, nested objects, field overrides)

## Use Case
This allows users to pass beta features or new OpenAI parameters (e.g., `parallel_tool_calls`) without requiring library updates:

```go
llm.GenerateContent(ctx, messages,
    openai.WithExtraBody(map[string]interface{}{
        "parallel_tool_calls": false,
    }),
)
```

## Testing
- All existing tests pass
- Added unit tests for `WithExtraBody` option
- Added comprehensive marshaling tests for `ExtraBody` field

---
Generated with Claude Code