### PR TITLE
feat: Add Web search tool for OpenAI Client

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -83,6 +83,10 @@ type ChatRequest struct {
 
 	// Metadata allows you to specify additional information that will be passed to the model.
 	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// WebSearchOptions configures web search behavior for search-enabled models
+	// like gpt-4o-search-preview and gpt-4o-mini-search-preview.
+	WebSearchOptions *WebSearchOptions `json:"web_search_options,omitempty"`
 }
 
 // MarshalJSON ensures that only one of MaxTokens or MaxCompletionTokens is sent.
@@ -150,6 +154,39 @@ type ToolType string
 const (
 	ToolTypeFunction ToolType = "function"
 )
+
+// WebSearchOptions configures web search behavior for OpenAI models.
+// This is used with search-enabled models like gpt-4o-search-preview.
+type WebSearchOptions struct {
+	// SearchContextSize controls how much context is gathered from web search.
+	// Valid values: "low", "medium", "high". Higher values provide more context
+	// but increase latency and cost.
+	SearchContextSize string `json:"search_context_size,omitempty"`
+
+	// UserLocation provides approximate user location for localized search results.
+	UserLocation *UserLocation `json:"user_location,omitempty"`
+}
+
+// UserLocation represents the user's approximate location for web search.
+type UserLocation struct {
+	// Type must be "approximate" for user-provided location.
+	Type string `json:"type"`
+
+	// Approximate contains the approximate location details.
+	Approximate *ApproximateLocation `json:"approximate,omitempty"`
+}
+
+// ApproximateLocation contains approximate location information.
+type ApproximateLocation struct {
+	// Country is the two-letter ISO country code (e.g., "US", "GB").
+	Country string `json:"country,omitempty"`
+
+	// City is the city name (e.g., "San Francisco", "London").
+	City string `json:"city,omitempty"`
+
+	// Region is the region or state (e.g., "California", "London").
+	Region string `json:"region,omitempty"`
+}
 
 // Tool is a tool to use in a chat request.
 type Tool struct {

--- a/llms/openai/internal/openaiclient/marshal_test.go
+++ b/llms/openai/internal/openaiclient/marshal_test.go
@@ -167,6 +167,116 @@ func TestChatRequest_TemperatureMarshalJSON(t *testing.T) {
 	}
 }
 
+func TestChatRequest_WebSearchOptionsMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		request ChatRequest
+		want    map[string]interface{}
+	}{
+		{
+			name: "no web search options",
+			request: ChatRequest{
+				Model: "gpt-4o-search-preview",
+			},
+			want: nil,
+		},
+		{
+			name: "empty web search options",
+			request: ChatRequest{
+				Model:            "gpt-4o-search-preview",
+				WebSearchOptions: &WebSearchOptions{},
+			},
+			want: map[string]interface{}{},
+		},
+		{
+			name: "web search with search context size",
+			request: ChatRequest{
+				Model: "gpt-4o-search-preview",
+				WebSearchOptions: &WebSearchOptions{
+					SearchContextSize: "high",
+				},
+			},
+			want: map[string]interface{}{
+				"search_context_size": "high",
+			},
+		},
+		{
+			name: "web search with user location",
+			request: ChatRequest{
+				Model: "gpt-4o-search-preview",
+				WebSearchOptions: &WebSearchOptions{
+					SearchContextSize: "medium",
+					UserLocation: &UserLocation{
+						Type: "approximate",
+						Approximate: &ApproximateLocation{
+							Country: "US",
+							City:    "San Francisco",
+							Region:  "California",
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"search_context_size": "medium",
+				"user_location": map[string]interface{}{
+					"type": "approximate",
+					"approximate": map[string]interface{}{
+						"country": "US",
+						"city":    "San Francisco",
+						"region":  "California",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.request)
+			if err != nil {
+				t.Fatalf("failed to marshal: %v", err)
+			}
+
+			var result map[string]interface{}
+			if err := json.Unmarshal(data, &result); err != nil {
+				t.Fatalf("failed to unmarshal: %v", err)
+			}
+
+			webSearchOpts, hasWebSearch := result["web_search_options"]
+			if tt.want == nil {
+				if hasWebSearch {
+					t.Errorf("expected no web_search_options, got %v", webSearchOpts)
+				}
+			} else {
+				if !hasWebSearch {
+					t.Fatal("expected web_search_options to be present")
+				}
+				// Check that it's properly serialized
+				webSearchMap, ok := webSearchOpts.(map[string]interface{})
+				if !ok {
+					t.Fatalf("web_search_options is not a map: %T", webSearchOpts)
+				}
+				if tt.want["search_context_size"] != nil {
+					if webSearchMap["search_context_size"] != tt.want["search_context_size"] {
+						t.Errorf("search_context_size: got %v, want %v",
+							webSearchMap["search_context_size"], tt.want["search_context_size"])
+					}
+				}
+				if tt.want["user_location"] != nil {
+					userLoc, ok := webSearchMap["user_location"].(map[string]interface{})
+					if !ok {
+						t.Fatalf("user_location is not a map: %T", webSearchMap["user_location"])
+					}
+					wantUserLoc := tt.want["user_location"].(map[string]interface{})
+					if userLoc["type"] != wantUserLoc["type"] {
+						t.Errorf("user_location.type: got %v, want %v", userLoc["type"], wantUserLoc["type"])
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestIsReasoningModel(t *testing.T) {
 	tests := []struct {
 		model    string

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -293,6 +293,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		FunctionCallBehavior: openaiclient.FunctionCallBehavior(opts.FunctionCallBehavior),
 		Seed:                 opts.Seed,
 		Metadata:             apiMetadata,
+		WebSearchOptions:     webSearchOptionsFromCallOptions(opts.WebSearchOptions),
 	}
 	if opts.JSONMode {
 		req.ResponseFormat = ResponseFormatJSON
@@ -497,4 +498,27 @@ func toolCallFromToolCall(tc llms.ToolCall) openaiclient.ToolCall {
 			Arguments: tc.FunctionCall.Arguments,
 		},
 	}
+}
+
+// webSearchOptionsFromCallOptions converts llms.WebSearchOptions to openaiclient.WebSearchOptions.
+func webSearchOptionsFromCallOptions(opts *llms.WebSearchOptions) *openaiclient.WebSearchOptions {
+	if opts == nil {
+		return nil
+	}
+	result := &openaiclient.WebSearchOptions{
+		SearchContextSize: opts.SearchContextSize,
+	}
+	if opts.UserLocation != nil {
+		result.UserLocation = &openaiclient.UserLocation{
+			Type: opts.UserLocation.Type,
+		}
+		if opts.UserLocation.Approximate != nil {
+			result.UserLocation.Approximate = &openaiclient.ApproximateLocation{
+				Country: opts.UserLocation.Approximate.Country,
+				City:    opts.UserLocation.Approximate.City,
+				Region:  opts.UserLocation.Approximate.Region,
+			}
+		}
+	}
+	return result
 }

--- a/llms/openai/options_test.go
+++ b/llms/openai/options_test.go
@@ -73,3 +73,108 @@ func TestWithLegacyMaxTokensField(t *testing.T) {
 		t.Error("expected openai:use_legacy_max_tokens to be true")
 	}
 }
+
+func TestWithWebSearch(t *testing.T) {
+	// Test with nil options (default behavior)
+	opts := &llms.CallOptions{}
+	llms.WithWebSearch(nil)(opts)
+	if opts.WebSearchOptions == nil {
+		t.Fatal("expected WebSearchOptions to be initialized")
+	}
+
+	// Test with custom search context size
+	opts2 := &llms.CallOptions{}
+	llms.WithWebSearch(&llms.WebSearchOptions{
+		SearchContextSize: "high",
+	})(opts2)
+	if opts2.WebSearchOptions == nil {
+		t.Fatal("expected WebSearchOptions to be set")
+	}
+	if opts2.WebSearchOptions.SearchContextSize != "high" {
+		t.Errorf("expected SearchContextSize=high, got %s", opts2.WebSearchOptions.SearchContextSize)
+	}
+
+	// Test with user location
+	opts3 := &llms.CallOptions{}
+	llms.WithWebSearch(&llms.WebSearchOptions{
+		SearchContextSize: "medium",
+		UserLocation: &llms.UserLocation{
+			Type: "approximate",
+			Approximate: &llms.ApproximateLocation{
+				Country: "US",
+				City:    "San Francisco",
+				Region:  "California",
+			},
+		},
+	})(opts3)
+	if opts3.WebSearchOptions == nil {
+		t.Fatal("expected WebSearchOptions to be set")
+	}
+	if opts3.WebSearchOptions.UserLocation == nil {
+		t.Fatal("expected UserLocation to be set")
+	}
+	if opts3.WebSearchOptions.UserLocation.Type != "approximate" {
+		t.Errorf("expected Type=approximate, got %s", opts3.WebSearchOptions.UserLocation.Type)
+	}
+	if opts3.WebSearchOptions.UserLocation.Approximate == nil {
+		t.Fatal("expected Approximate to be set")
+	}
+	if opts3.WebSearchOptions.UserLocation.Approximate.Country != "US" {
+		t.Errorf("expected Country=US, got %s", opts3.WebSearchOptions.UserLocation.Approximate.Country)
+	}
+	if opts3.WebSearchOptions.UserLocation.Approximate.City != "San Francisco" {
+		t.Errorf("expected City=San Francisco, got %s", opts3.WebSearchOptions.UserLocation.Approximate.City)
+	}
+	if opts3.WebSearchOptions.UserLocation.Approximate.Region != "California" {
+		t.Errorf("expected Region=California, got %s", opts3.WebSearchOptions.UserLocation.Approximate.Region)
+	}
+}
+
+func TestWebSearchOptionsConversion(t *testing.T) {
+	// Test nil conversion
+	result := webSearchOptionsFromCallOptions(nil)
+	if result != nil {
+		t.Error("expected nil result for nil input")
+	}
+
+	// Test basic conversion
+	opts := &llms.WebSearchOptions{
+		SearchContextSize: "high",
+	}
+	result = webSearchOptionsFromCallOptions(opts)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.SearchContextSize != "high" {
+		t.Errorf("expected SearchContextSize=high, got %s", result.SearchContextSize)
+	}
+
+	// Test full conversion with user location
+	opts2 := &llms.WebSearchOptions{
+		SearchContextSize: "medium",
+		UserLocation: &llms.UserLocation{
+			Type: "approximate",
+			Approximate: &llms.ApproximateLocation{
+				Country: "GB",
+				City:    "London",
+				Region:  "London",
+			},
+		},
+	}
+	result2 := webSearchOptionsFromCallOptions(opts2)
+	if result2 == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result2.UserLocation == nil {
+		t.Fatal("expected UserLocation to be set")
+	}
+	if result2.UserLocation.Type != "approximate" {
+		t.Errorf("expected Type=approximate, got %s", result2.UserLocation.Type)
+	}
+	if result2.UserLocation.Approximate == nil {
+		t.Fatal("expected Approximate to be set")
+	}
+	if result2.UserLocation.Approximate.Country != "GB" {
+		t.Errorf("expected Country=GB, got %s", result2.UserLocation.Approximate.Country)
+	}
+}

--- a/llms/options.go
+++ b/llms/options.go
@@ -69,6 +69,10 @@ type CallOptions struct {
 	// Supported MIME types are: text/plain: (default) Text output.
 	// application/json: JSON response in the response candidates.
 	ResponseMIMEType string `json:"response_mime_type,omitempty"`
+
+	// WebSearchOptions configures web search behavior for models that support it.
+	// Currently supported by OpenAI models like gpt-4o-search-preview.
+	WebSearchOptions *WebSearchOptions `json:"web_search_options,omitempty"`
 }
 
 // Tool is a tool that can be used by the model.
@@ -108,6 +112,39 @@ type FunctionReference struct {
 
 // FunctionCallBehavior is the behavior to use when calling functions.
 type FunctionCallBehavior string
+
+// WebSearchOptions configures web search behavior for models that support web search.
+// This is currently supported by OpenAI models like gpt-4o-search-preview.
+type WebSearchOptions struct {
+	// SearchContextSize controls how much context is gathered from web search.
+	// Valid values: "low", "medium", "high". Higher values provide more context
+	// but increase latency and cost.
+	SearchContextSize string `json:"search_context_size,omitempty"`
+
+	// UserLocation provides approximate user location for localized search results.
+	UserLocation *UserLocation `json:"user_location,omitempty"`
+}
+
+// UserLocation represents the user's approximate location for web search.
+type UserLocation struct {
+	// Type must be "approximate" for user-provided location.
+	Type string `json:"type"`
+
+	// Approximate contains the approximate location details.
+	Approximate *ApproximateLocation `json:"approximate,omitempty"`
+}
+
+// ApproximateLocation contains approximate location information.
+type ApproximateLocation struct {
+	// Country is the two-letter ISO country code (e.g., "US", "GB").
+	Country string `json:"country,omitempty"`
+
+	// City is the city name (e.g., "San Francisco", "London").
+	City string `json:"city,omitempty"`
+
+	// Region is the region or state (e.g., "California", "London").
+	Region string `json:"region,omitempty"`
+}
 
 const (
 	// FunctionCallBehaviorNone will not call any functions.
@@ -289,5 +326,18 @@ func WithMetadata(metadata map[string]interface{}) CallOption {
 func WithResponseMIMEType(responseMIMEType string) CallOption {
 	return func(o *CallOptions) {
 		o.ResponseMIMEType = responseMIMEType
+	}
+}
+
+// WithWebSearch enables web search for models that support it.
+// Use with OpenAI models like gpt-4o-search-preview and gpt-4o-mini-search-preview.
+// Pass nil for default web search behavior, or provide WebSearchOptions to customize.
+func WithWebSearch(options *WebSearchOptions) CallOption {
+	return func(o *CallOptions) {
+		if options == nil {
+			o.WebSearchOptions = &WebSearchOptions{}
+		} else {
+			o.WebSearchOptions = options
+		}
 	}
 }


### PR DESCRIPTION
Fixes #1333

## Changes
- Add WebSearchOptions, UserLocation, and ApproximateLocation types to support OpenAI web search
- Add WithWebSearch call option for enabling web search on supported models (gpt-4o-search-preview)
- Implement conversion from llms types to OpenAI client types
- Add comprehensive tests for web search options marshaling and conversion

## Usage
```go
llm.GenerateContent(ctx, messages,
    llms.WithWebSearch(&llms.WebSearchOptions{
        SearchContextSize: "high",
        UserLocation: &llms.UserLocation{
            Type: "approximate",
            Approximate: &llms.ApproximateLocation{
                Country: "US",
                City:    "San Francisco",
            },
        },
    }),
)
```