### PR TITLE
fix: replace pgxconn with pgxpool to fix pgvector connection management issue

### DIFF
--- a/vectorstores/pgvector/pgvector.go
+++ b/vectorstores/pgvector/pgvector.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgvector/pgvector-go"
 	"github.com/tmc/langchaingo/embeddings"
 	"github.com/tmc/langchaingo/schema"
@@ -80,7 +81,7 @@ func New(ctx context.Context, opts ...Option) (Store, error) {
 		return Store{}, err
 	}
 	if store.conn == nil {
-		store.conn, err = pgx.Connect(ctx, store.connURL)
+		store.conn, err = pgxpool.New(ctx, store.connURL)
 		if err != nil {
 			return Store{}, err
 		}


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

This PR replaces the usage of pgconn with pgxpool in the pgvector integration to address the connection issue caused by `failed to deallocate cached statement(s): conn closed` errors in pgx.

Context cancellation may close the pgxconn, causing subsequent queries to fail. More detail in https://github.com/jackc/pgx/issues/2100.
pgxpool will automatically close the disconnected pgxconn and create a new one when necessary, resolving this issue.

