### PR TITLE
fix: llms/googleai - handle nullable JSON Schema types in tool parameters

### DIFF
--- a/llms/googleai/vertex/vertex.go
+++ b/llms/googleai/vertex/vertex.go
@@ -397,9 +397,9 @@ func convertTools(tools []llms.Tool) ([]*genai.Tool, error) {
 
 		schema := &genai.Schema{}
 		if ty, ok := params["type"]; ok {
-			tyString, ok := ty.(string)
-			if !ok {
-				return nil, fmt.Errorf("tool [%d]: expected string for type", i)
+			tyString := normalizeSchemaType(ty)
+			if tyString == "" {
+				return nil, fmt.Errorf("tool [%d]: expected string for type, got %T", i, ty)
 			}
 			schema.Type = convertToolSchemaType(tyString)
 		}
@@ -418,9 +418,9 @@ func convertTools(tools []llms.Tool) ([]*genai.Tool, error) {
 			schema.Properties[propName] = &genai.Schema{}
 
 			if ty, ok := valueMap["type"]; ok {
-				tyString, ok := ty.(string)
-				if !ok {
-					return nil, fmt.Errorf("tool [%d]: expected string for type", i)
+				tyString := normalizeSchemaType(ty)
+				if tyString == "" {
+					return nil, fmt.Errorf("tool [%d], property [%s]: expected string for type, got %T", i, propName, ty)
 				}
 				schema.Properties[propName].Type = convertToolSchemaType(tyString)
 			}
@@ -466,6 +466,37 @@ func convertTools(tools []llms.Tool) ([]*genai.Tool, error) {
 	genaiTools := []*genai.Tool{{FunctionDeclarations: genaiFuncDecls}}
 
 	return genaiTools, nil
+}
+
+// normalizeSchemaType handles JSON Schema type which can be either a string
+// ("string") or an array (["string", "null"]). Per JSON Schema specification,
+// the type keyword may be an array to allow multiple types. This commonly
+// occurs with nullable fields. When an array, we pick the first non-null type.
+// See: https://json-schema.org/understanding-json-schema/reference/type
+func normalizeSchemaType(ty any) string {
+	switch v := ty.(type) {
+	case string:
+		return v
+	case []any:
+		// Pick the first non-null type from the array
+		for _, t := range v {
+			if s, ok := t.(string); ok && s != "null" {
+				return s
+			}
+		}
+		// If only null, return empty
+		return ""
+	case []string:
+		// Handle typed string slice
+		for _, s := range v {
+			if s != "null" {
+				return s
+			}
+		}
+		return ""
+	default:
+		return ""
+	}
 }
 
 // convertToolSchemaType converts a tool's schema type from its langchaingo


### PR DESCRIPTION
## Summary
Fix JSON Schema type handling for nullable types in Google AI and Vertex AI integrations.

## Discovery Context
This issue was discovered while running [agent-benchmark](https://github.com/mykhaliev/agent-benchmark) tests against the [Windows MCP Server](https://github.com/sbroenne/mcp-windows) using Gemini 2.5 Pro via Vertex AI. The MCP SDK generates JSON schemas with nullable types (`["string", "null"]`) for optional parameters, which caused tool calls to fail.

## Problem
When tool parameters use nullable types per JSON Schema spec:
```json
{ "type": ["string", "null"] }
```
The integrations fail with:
```
tool [0], property [fieldName]: expected string for type, got []interface {}
```

## JSON Schema Spec Reference
Per [JSON Schema specification](https://json-schema.org/understanding-json-schema/reference/type):
> "The type keyword may be either a string or an array... An array of strings allows matching against more than one type."

## Solution
Added `normalizeSchemaType()` function that handles both forms:
- String: `"string"` → `"string"`
- Array: `["string", "null"]` → `"string"` (extracts first non-null type)

## Testing
- Added comprehensive unit tests for `normalizeSchemaType()`
- Added integration tests for nullable types at all nesting levels (single-level, nested objects, array items, deeply nested)
- All existing tests pass
- Verified with real Vertex AI API calls using agent-benchmark

## Files Changed
- `llms/googleai/googleai.go` - Added `normalizeSchemaType()` function and updated `convertSchemaRecursive()`
- `llms/googleai/googleai_unit_test.go` - Added tests for `normalizeSchemaType()` and nullable tool parameters
- `llms/googleai/vertex/vertex.go` - Added `normalizeSchemaType()` function and updated `convertTools()`
- `llms/googleai/vertex/vertex_unit_test.go` - Added tests for `normalizeSchemaType()` and nullable tool parameters
