### PR TITLE
feat(memory): Add explicit GetMemoryKey method to token and window buffer memory types

### DIFF
--- a/memory/token_buffer.go
+++ b/memory/token_buffer.go
@@ -90,6 +90,11 @@ func (tb *ConversationTokenBuffer) Clear(ctx context.Context) error {
 	return tb.ConversationBuffer.Clear(ctx)
 }
 
+// GetMemoryKey uses ConversationBuffer method for getting the memory key.
+func (tb *ConversationTokenBuffer) GetMemoryKey(ctx context.Context) string {
+	return tb.ConversationBuffer.GetMemoryKey(ctx)
+}
+
 func (tb *ConversationTokenBuffer) getNumTokensFromMessages(ctx context.Context) (int, error) {
 	messages, err := tb.ChatHistory.Messages(ctx)
 	if err != nil {

--- a/memory/token_buffer_test.go
+++ b/memory/token_buffer_test.go
@@ -108,3 +108,18 @@ func TestTokenBufferMemoryWithPreLoadedHistory(t *testing.T) {
 	expected := map[string]any{"history": "Human: bar\nAI: foo"}
 	assert.Equal(t, expected, result)
 }
+
+func TestTokenBufferMemoryGetMemoryKey(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	llm := newTestOpenAIClient(t)
+
+	// Test with default memory key
+	m1 := NewConversationTokenBuffer(llm, 2000)
+	assert.Equal(t, "history", m1.GetMemoryKey(ctx))
+
+	// Test with custom memory key
+	m2 := NewConversationTokenBuffer(llm, 2000, WithMemoryKey("custom_key"))
+	assert.Equal(t, "custom_key", m2.GetMemoryKey(ctx))
+}

--- a/memory/window_buffer.go
+++ b/memory/window_buffer.go
@@ -100,3 +100,8 @@ func (wb *ConversationWindowBuffer) cutMessages(message []llms.ChatMessage) ([]l
 func (wb *ConversationWindowBuffer) Clear(ctx context.Context) error {
 	return wb.ConversationBuffer.Clear(ctx)
 }
+
+// GetMemoryKey uses ConversationBuffer method for getting the memory key.
+func (wb *ConversationWindowBuffer) GetMemoryKey(ctx context.Context) string {
+	return wb.ConversationBuffer.GetMemoryKey(ctx)
+}

--- a/memory/window_buffer_test.go
+++ b/memory/window_buffer_test.go
@@ -101,6 +101,19 @@ func TestWindowBufferMemoryWithPreLoadedHistory(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
+func TestWindowBufferMemoryGetMemoryKey(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Test with default memory key
+	m1 := NewConversationWindowBuffer(2)
+	assert.Equal(t, "history", m1.GetMemoryKey(ctx))
+
+	// Test with custom memory key
+	m2 := NewConversationWindowBuffer(2, WithMemoryKey("custom_key"))
+	assert.Equal(t, "custom_key", m2.GetMemoryKey(ctx))
+}
+
 func TestConversationWindowBuffer_cutMessages(t *testing.T) {
 	t.Parallel()
 	type fields struct {


### PR DESCRIPTION
## Description

This PR adds explicit `GetMemoryKey` method implementations to `ConversationTokenBuffer` and `ConversationWindowBuffer` types in the memory package.

## Motivation

Both `ConversationTokenBuffer` and `ConversationWindowBuffer` embed `ConversationBuffer` and implement the `schema.Memory` interface. While Go's struct embedding forwards method calls to the embedded type, all other Memory interface methods (`MemoryVariables`, `LoadMemoryVariables`, `SaveContext`, `Clear`) are explicitly implemented with proper documentation comments - except `GetMemoryKey`.

This inconsistency can lead to:
- Confusion when browsing the API documentation
- Missing methods in IDE autocompletion for these specific types
- Incomplete documentation when viewing the type definition

## Changes

- Added `GetMemoryKey` method to `ConversationTokenBuffer` in `memory/token_buffer.go`
- Added `GetMemoryKey` method to `ConversationWindowBuffer` in `memory/window_buffer.go`
- Added unit tests for both methods in their respective test files

## Testing

Added unit tests that verify:
- Default memory key ("history") is returned correctly
- Custom memory keys set via `WithMemoryKey` option are returned correctly

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code improvement (non-breaking change that improves code quality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update