### PR TITLE
feat: add API key support to Ollama client and options

### DIFF
--- a/llms/ollama/internal/ollamaclient/ollamaclient.go
+++ b/llms/ollama/internal/ollamaclient/ollamaclient.go
@@ -18,6 +18,7 @@ import (
 
 type Client struct {
 	base       *url.URL
+	apiKey     string
 	httpClient *http.Client
 }
 
@@ -37,7 +38,7 @@ func checkError(resp *http.Response, body []byte) error {
 	return apiError
 }
 
-func NewClient(ourl *url.URL, ohttp *http.Client) (*Client, error) {
+func NewClient(ourl *url.URL, apiKey string, ohttp *http.Client) (*Client, error) {
 	if ourl == nil {
 		scheme, hostport, ok := strings.Cut(os.Getenv("OLLAMA_HOST"), "://")
 		if !ok {
@@ -64,6 +65,7 @@ func NewClient(ourl *url.URL, ohttp *http.Client) (*Client, error) {
 
 	client := Client{
 		base:       ourl,
+		apiKey:     apiKey,
 		httpClient: ohttp,
 	}
 
@@ -90,6 +92,7 @@ func (c *Client) do(ctx context.Context, method, path string, reqData, respData 
 
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", c.apiKey)
 
 	respObj, err := c.httpClient.Do(request)
 	if err != nil {

--- a/llms/ollama/internal/ollamaclient/ollamaclient_test.go
+++ b/llms/ollama/internal/ollamaclient/ollamaclient_test.go
@@ -66,7 +66,7 @@ func TestClient_Generate(t *testing.T) {
 	parsedURL, err := url.Parse(baseURL)
 	require.NoError(t, err)
 
-	client, err := NewClient(parsedURL, rr.Client())
+	client, err := NewClient(parsedURL, "", rr.Client())
 	require.NoError(t, err)
 
 	stream := false
@@ -112,7 +112,7 @@ func TestClient_GenerateStream(t *testing.T) {
 	parsedURL, err := url.Parse(baseURL)
 	require.NoError(t, err)
 
-	client, err := NewClient(parsedURL, rr.Client())
+	client, err := NewClient(parsedURL, "", rr.Client())
 	require.NoError(t, err)
 
 	stream := true
@@ -157,7 +157,7 @@ func TestClient_GenerateChat(t *testing.T) {
 	parsedURL, err := url.Parse(baseURL)
 	require.NoError(t, err)
 
-	client, err := NewClient(parsedURL, rr.Client())
+	client, err := NewClient(parsedURL, "", rr.Client())
 	require.NoError(t, err)
 
 	req := &ChatRequest{
@@ -208,7 +208,7 @@ func TestClient_GenerateChatStream(t *testing.T) {
 	parsedURL, err := url.Parse(baseURL)
 	require.NoError(t, err)
 
-	client, err := NewClient(parsedURL, rr.Client())
+	client, err := NewClient(parsedURL, "", rr.Client())
 	require.NoError(t, err)
 
 	req := &ChatRequest{
@@ -257,7 +257,7 @@ func TestClient_CreateEmbedding(t *testing.T) {
 	parsedURL, err := url.Parse(baseURL)
 	require.NoError(t, err)
 
-	client, err := NewClient(parsedURL, rr.Client())
+	client, err := NewClient(parsedURL, "", rr.Client())
 	require.NoError(t, err)
 
 	req := &EmbeddingRequest{
@@ -298,7 +298,7 @@ func TestClient_GenerateChatWithThink(t *testing.T) {
 	parsedURL, err := url.Parse(baseURL)
 	require.NoError(t, err)
 
-	client, err := NewClient(parsedURL, rr.Client())
+	client, err := NewClient(parsedURL, "", rr.Client())
 	require.NoError(t, err)
 
 	req := &ChatRequest{

--- a/llms/ollama/ollamallm.go
+++ b/llms/ollama/ollamallm.go
@@ -37,7 +37,7 @@ func New(opts ...Option) (*LLM, error) {
 		opt(&o)
 	}
 
-	client, err := ollamaclient.NewClient(o.ollamaServerURL, o.httpClient)
+	client, err := ollamaclient.NewClient(o.ollamaServerURL, o.apiKey, o.httpClient)
 	if err != nil {
 		return nil, err
 	}

--- a/llms/ollama/options.go
+++ b/llms/ollama/options.go
@@ -11,6 +11,7 @@ import (
 
 type options struct {
 	ollamaServerURL     *url.URL
+	apiKey              string
 	httpClient          *http.Client
 	model               string
 	ollamaOptions       ollamaclient.Options
@@ -76,6 +77,13 @@ func WithServerURL(rawURL string) Option {
 		if err != nil {
 			log.Fatal(err)
 		}
+	}
+}
+
+// WithBearerAuthentication Set the http authentication header for proxied requests to Ollama. Use this to protect your Ollama instance when it is exposed to the public internet.
+func WithBearerAuthentication(key string) Option {
+	return func(opts *options) {
+		opts.apiKey = "Bearer " + key
 	}
 }
 


### PR DESCRIPTION
resolves #1472

There are lots of ollama services unprotected and publicly exposed to the internet. To prevent this, ollama recommends you to use a reverse proxy to secure your access. But then there is no option to connect to it via langchain. So I added support to this to add a bearer token to your http request.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
