### PR TITLE
Fix duplicate AI messages for parallel tool calls (#1463)

### DIFF
--- a/agents/openai_functions_agent.go
+++ b/agents/openai_functions_agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/tmc/langchaingo/callbacks"
 	"github.com/tmc/langchaingo/chains"
@@ -270,85 +271,12 @@ func (o *OpenAIFunctionsAgent) ParseOutput(contentResp *llms.ContentResponse) (
 
 	// Check for new-style tool calls first
 	if len(choice.ToolCalls) > 0 {
-		// Handle multiple tool calls properly
-		actions := make([]schema.AgentAction, 0, len(choice.ToolCalls))
-
-		for _, toolCall := range choice.ToolCalls {
-			functionName := toolCall.FunctionCall.Name
-			toolInputStr := toolCall.FunctionCall.Arguments
-			toolInputMap := make(map[string]any, 0)
-			err := json.Unmarshal([]byte(toolInputStr), &toolInputMap)
-
-			toolInput := toolInputStr
-			if err == nil {
-				// Successfully parsed JSON, check for __arg1 pattern
-				if arg1, ok := toolInputMap["__arg1"]; ok {
-					toolInputCheck, ok := arg1.(string)
-					if ok {
-						toolInput = toolInputCheck
-					}
-				}
-			}
-			// If JSON parsing failed, use the raw string as tool input
-			// This handles cases like calculator expressions
-
-			contentMsg := "\n"
-			if choice.Content != "" {
-				contentMsg = fmt.Sprintf("responded: %s\n", choice.Content)
-			}
-
-			actions = append(actions, schema.AgentAction{
-				Tool:      functionName,
-				ToolInput: toolInput,
-				Log:       fmt.Sprintf("Invoking: %s with %s %s", functionName, toolInputStr, contentMsg),
-				ToolID:    toolCall.ID,
-			})
-		}
-
-		return actions, nil, nil
+		return o.parseToolCalls(choice)
 	}
 
 	// Check for legacy function call
 	if choice.FuncCall != nil {
-		functionCall := choice.FuncCall
-		functionName := functionCall.Name
-		toolInputStr := functionCall.Arguments
-		toolInputMap := make(map[string]any, 0)
-		err := json.Unmarshal([]byte(toolInputStr), &toolInputMap)
-		if err != nil {
-			// If it's not valid JSON, it might be a raw expression for the calculator
-			// Try to use it directly as tool input
-			return []schema.AgentAction{
-				{
-					Tool:      functionName,
-					ToolInput: toolInputStr,
-					Log:       fmt.Sprintf("Invoking: %s with %s\n", functionName, toolInputStr),
-					ToolID:    "", // Legacy function calls don't have tool IDs
-				},
-			}, nil, nil
-		}
-
-		toolInput := toolInputStr
-		if arg1, ok := toolInputMap["__arg1"]; ok {
-			toolInputCheck, ok := arg1.(string)
-			if ok {
-				toolInput = toolInputCheck
-			}
-		}
-
-		contentMsg := "\n"
-		if choice.Content != "" {
-			contentMsg = fmt.Sprintf("responded: %s\n", choice.Content)
-		}
-
-		return []schema.AgentAction{
-			{
-				Tool:      functionName,
-				ToolInput: toolInput,
-				Log:       fmt.Sprintf("Invoking: %s with %s \n %s \n", functionName, toolInputStr, contentMsg),
-				ToolID:    "", // Legacy function calls don't have tool IDs
-			},
-		}, nil, nil
+		return o.parseLegacyFunctionCall(choice)
 	}
 
 	// No function/tool call - this is a finish
@@ -358,4 +286,89 @@ func (o *OpenAIFunctionsAgent) ParseOutput(contentResp *llms.ContentResponse) (
 		},
 		Log: choice.Content,
 	}, nil
+}
+
+func (o *OpenAIFunctionsAgent) parseToolCalls(choice *llms.ContentChoice) ([]schema.AgentAction, *schema.AgentFinish, error) {
+	actions := make([]schema.AgentAction, 0, len(choice.ToolCalls))
+	contentMsg := "\n"
+	if choice.Content != "" {
+		contentMsg = fmt.Sprintf("responded: %s\n", choice.Content)
+	}
+
+	// Generate a shared log for all tool calls in this choice to ensure they are grouped together
+	// in constructScratchPad.
+	var logBuilder strings.Builder
+	logBuilder.WriteString(contentMsg)
+	for _, tc := range choice.ToolCalls {
+		logBuilder.WriteString(fmt.Sprintf("Invoking: %s with %s\n", tc.FunctionCall.Name, tc.FunctionCall.Arguments))
+	}
+	sharedLog := logBuilder.String()
+
+	for _, toolCall := range choice.ToolCalls {
+		functionName := toolCall.FunctionCall.Name
+		toolInputStr := toolCall.FunctionCall.Arguments
+		toolInputMap := make(map[string]any, 0)
+		err := json.Unmarshal([]byte(toolInputStr), &toolInputMap)
+
+		toolInput := toolInputStr
+		if err == nil {
+			// Successfully parsed JSON, check for __arg1 pattern
+			if arg1, ok := toolInputMap["__arg1"]; ok {
+				toolInputCheck, ok := arg1.(string)
+				if ok {
+					toolInput = toolInputCheck
+				}
+			}
+		}
+
+		actions = append(actions, schema.AgentAction{
+			Tool:      functionName,
+			ToolInput: toolInput,
+			Log:       sharedLog,
+			ToolID:    toolCall.ID,
+		})
+	}
+
+	return actions, nil, nil
+}
+
+func (o *OpenAIFunctionsAgent) parseLegacyFunctionCall(choice *llms.ContentChoice) ([]schema.AgentAction, *schema.AgentFinish, error) {
+	functionCall := choice.FuncCall
+	functionName := functionCall.Name
+	toolInputStr := functionCall.Arguments
+	toolInputMap := make(map[string]any, 0)
+	err := json.Unmarshal([]byte(toolInputStr), &toolInputMap)
+	if err != nil {
+		// If it's not valid JSON, it might be a raw expression for the calculator
+		return []schema.AgentAction{
+			{
+				Tool:      functionName,
+				ToolInput: toolInputStr,
+				Log:       fmt.Sprintf("Invoking: %s with %s\n", functionName, toolInputStr),
+				ToolID:    "",
+			},
+		}, nil, nil
+	}
+
+	toolInput := toolInputStr
+	if arg1, ok := toolInputMap["__arg1"]; ok {
+		toolInputCheck, ok := arg1.(string)
+		if ok {
+			toolInput = toolInputCheck
+		}
+	}
+
+	contentMsg := "\n"
+	if choice.Content != "" {
+		contentMsg = fmt.Sprintf("responded: %s\n", choice.Content)
+	}
+
+	return []schema.AgentAction{
+		{
+			Tool:      functionName,
+			ToolInput: toolInput,
+			Log:       fmt.Sprintf("Invoking: %s with %s \n %s \n", functionName, toolInputStr, contentMsg),
+			ToolID:    "",
+		},
+	}, nil, nil
 }


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages): **`agents: fix duplicate AI messages for parallel tool calls`**
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves: **Fixes #1463**
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

## Description
This PR resolves issue #1463 where the [OpenAIFunctionsAgent](cci:2://file:///Users/vishnu/Desktop/Go_learn/langchaingo/agents/openai_functions_agent.go:20:0-32:1) generated multiple duplicate AI messages in the conversation history (scratchpad) when the LLM returned multiple tool calls in a single response turn.

**The Fix**:
The [constructScratchPad](cci:1://file:///Users/vishnu/Desktop/Go_learn/langchaingo/agents/openai_functions_agent.go:199:0-261:1) function groups sequential tool calls into a single `AIChatMessage` only if they share the same [Log](cci:2://file:///Users/vishnu/Desktop/Go_learn/langchaingo/callbacks/log.go:13:0-13:24) string. Previously, [ParseOutput](cci:1://file:///Users/vishnu/Desktop/Go_learn/langchaingo/agents/openai_functions_agent.go:263:0-368:1) generated a unique [Log](cci:2://file:///Users/vishnu/Desktop/Go_learn/langchaingo/callbacks/log.go:13:0-13:24) for every tool call (stating only one tool at a time), which caused the grouping logic to fail and create multiple AI message turns. 

I refactored [ParseOutput](cci:1://file:///Users/vishnu/Desktop/Go_learn/langchaingo/agents/openai_functions_agent.go:263:0-368:1) to generate a `sharedLog` string that summarizes all tools being invoked in that response. By making the [Log](cci:2://file:///Users/vishnu/Desktop/Go_learn/langchaingo/callbacks/log.go:13:0-13:24) identical for all actions in a choice, [constructScratchPad](cci:1://file:///Users/vishnu/Desktop/Go_learn/langchaingo/agents/openai_functions_agent.go:199:0-261:1) now correctly collapses them into a single message with multiple [ToolCalls](cci:1://file:///Users/vishnu/Desktop/Go_learn/langchaingo/agents/openai_functions_agent_test.go:171:0-210:1).

**Verification**:
- Added a targeted reproduction test case [TestConstructScratchPadGrouping](cci:1://file:///Users/vishnu/Desktop/Go_learn/langchaingo/agents/reproduce_1463_test.go:9:0-40:1) in [agents/reproduce_1463_test.go](cci:7://file:///Users/vishnu/Desktop/Go_learn/langchaingo/agents/reproduce_1463_test.go:0:0-0:0) (verified that 2 parallel tool calls result in 1 AI message + 2 Tool responses).
- Verified that existing tests in [openai_functions_agent_test.go](cci:7://file:///Users/vishnu/Desktop/Go_learn/langchaingo/agents/openai_functions_agent_test.go:0:0-0:0) (including [TestOpenAIFunctionsAgent_ParseOutput_MultipleToolCalls](cci:1://file:///Users/vishnu/Desktop/Go_learn/langchaingo/agents/openai_functions_agent_test.go:171:0-210:1)) still pass.

Fixes #1463