### PR TITLE
llms: preserve reasoning_content in MessageContent for tool calling   round-trip

### DIFF
--- a/llms/generatecontent.go
+++ b/llms/generatecontent.go
@@ -14,6 +14,13 @@ import (
 type MessageContent struct {
 	Role  ChatMessageType
 	Parts []ContentPart
+
+	// ReasoningContent is used with reasoning models (e.g. deepseek-reasoner)
+	// to preserve the reasoning content in assistant messages for round-trip
+	// conversations. When the API returns reasoning_content in an assistant
+	// message (e.g. alongside tool_calls), this field must be included when
+	// sending the message back as part of conversation history.
+	ReasoningContent string
 }
 
 // TextPart creates TextContent from a given string.

--- a/llms/marshaling.go
+++ b/llms/marshaling.go
@@ -14,25 +14,29 @@ func (mc MessageContent) MarshalJSON() ([]byte, error) {
 	if hasSingleTextPart {
 		tp, _ := mc.Parts[0].(TextContent)
 		return json.Marshal(struct {
-			Role ChatMessageType `json:"role"`
-			Text string          `json:"text"`
-		}{Role: mc.Role, Text: tp.Text})
+			Role             ChatMessageType `json:"role"`
+			Text             string          `json:"text"`
+			ReasoningContent string          `json:"reasoning_content,omitempty"`
+		}{Role: mc.Role, Text: tp.Text, ReasoningContent: mc.ReasoningContent})
 	}
 
 	return json.Marshal(struct {
-		Role  ChatMessageType `json:"role"`
-		Parts []ContentPart   `json:"parts"`
+		Role             ChatMessageType `json:"role"`
+		Parts            []ContentPart   `json:"parts"`
+		ReasoningContent string          `json:"reasoning_content,omitempty"`
 	}{
-		Role:  mc.Role,
-		Parts: mc.Parts,
+		Role:             mc.Role,
+		Parts:            mc.Parts,
+		ReasoningContent: mc.ReasoningContent,
 	})
 }
 
 func (mc *MessageContent) UnmarshalJSON(data []byte) error {
 	var m struct {
-		Role  ChatMessageType `json:"role"`
-		Text  string          `json:"text"`
-		Parts []struct {
+		Role             ChatMessageType `json:"role"`
+		Text             string          `json:"text"`
+		ReasoningContent string          `json:"reasoning_content"`
+		Parts            []struct {
 			Type     string `json:"type"`
 			Text     string `json:"text,omitempty"`
 			ImageURL struct {
@@ -60,6 +64,7 @@ func (mc *MessageContent) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	mc.Role = m.Role
+	mc.ReasoningContent = m.ReasoningContent
 
 	for _, part := range m.Parts {
 		switch part.Type {

--- a/llms/marshaling_test.go
+++ b/llms/marshaling_test.go
@@ -188,7 +188,7 @@ role: user
 	}
 }
 
-func TestUnmarshalJSONMessageContent(t *testing.T) {
+func TestUnmarshalJSONMessageContent(t *testing.T) { //nolint:funlen // We make an exception given the number of test cases.
 	t.Parallel()
 	tests := []struct {
 		name    string
@@ -259,6 +259,18 @@ func TestUnmarshalJSONMessageContent(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:  "assistant message with reasoning_content",
+			input: `{"role":"assistant","text":"final answer","reasoning_content":"step-by-step reasoning"}`,
+			want: MessageContent{
+				Role: "assistant",
+				Parts: []ContentPart{
+					TextContent{Text: "final answer"},
+				},
+				ReasoningContent: "step-by-step reasoning",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -321,6 +333,29 @@ func TestMarshalJSONMessageContent(t *testing.T) {
 				},
 			},
 			want:    `{"role":"user","parts":[{}]}`,
+			wantErr: false,
+		},
+		{
+			name: "assistant message with reasoning_content",
+			input: MessageContent{
+				Role: "assistant",
+				Parts: []ContentPart{
+					TextContent{Text: "final answer"},
+				},
+				ReasoningContent: "step-by-step reasoning",
+			},
+			want:    `{"role":"assistant","text":"final answer","reasoning_content":"step-by-step reasoning"}`,
+			wantErr: false,
+		},
+		{
+			name: "message without reasoning_content omits field",
+			input: MessageContent{
+				Role: "user",
+				Parts: []ContentPart{
+					TextContent{Text: "Hello"},
+				},
+			},
+			want:    `{"role":"user","text":"Hello"}`,
 			wantErr: false,
 		},
 	}
@@ -484,6 +519,28 @@ role: assistant
 					ToolCallResponse{ToolCallID: "456", Name: "screwdriver", Content: "turn"},
 				},
 			},
+		},
+		{
+			name: "assistant message with reasoning_content and tool calls",
+			in: MessageContent{
+				Role: "assistant",
+				Parts: []ContentPart{
+					ToolCall{Type: "function", ID: "tc01", FunctionCall: &FunctionCall{Name: "calculator", Arguments: `{"a":15,"b":28}`}},
+				},
+				ReasoningContent: "I need to use the calculator to add 15 and 28",
+			},
+			assertedJSON: `{"role":"assistant","parts":[{"type":"tool_call","tool_call":{"function":{"name":"calculator","arguments":"{\"a\":15,\"b\":28}"},"id":"tc01","type":"function"}}],"reasoning_content":"I need to use the calculator to add 15 and 28"}`,
+		},
+		{
+			name: "assistant message with reasoning_content single text",
+			in: MessageContent{
+				Role: "assistant",
+				Parts: []ContentPart{
+					TextContent{Text: "The answer is 43"},
+				},
+				ReasoningContent: "I calculated 15 + 28 = 43",
+			},
+			assertedJSON: `{"role":"assistant","text":"The answer is 43","reasoning_content":"I calculated 15 + 28 = 43"}`,
 		},
 	}
 

--- a/llms/openai/internal/openaiclient/chat_test.go
+++ b/llms/openai/internal/openaiclient/chat_test.go
@@ -122,3 +122,37 @@ func TestChatMessage_MarshalUnmarshal_WithReasoning(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, msg, msg2)
 }
+
+func TestChatMessage_MarshalUnmarshal_WithReasoningAndToolCalls(t *testing.T) {
+	t.Parallel()
+	msg := ChatMessage{
+		Role:             "assistant",
+		Content:          "",
+		ReasoningContent: "I need to use the calculator to add 15 and 28",
+		ToolCalls: []ToolCall{
+			{
+				ID:   "call_123",
+				Type: ToolTypeFunction,
+				Function: ToolFunction{
+					Name:      "calculator",
+					Arguments: `{"a":15,"b":28}`,
+				},
+			},
+		},
+	}
+	text, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	// Verify reasoning_content is present in serialized JSON
+	assert.Contains(t, string(text), `"reasoning_content"`)
+	assert.Contains(t, string(text), `"tool_calls"`)
+
+	// Round-trip: unmarshal back
+	var msg2 ChatMessage
+	err = json.Unmarshal(text, &msg2)
+	require.NoError(t, err)
+	require.Equal(t, msg.ReasoningContent, msg2.ReasoningContent)
+	require.Equal(t, len(msg.ToolCalls), len(msg2.ToolCalls))
+	require.Equal(t, msg.ToolCalls[0].ID, msg2.ToolCalls[0].ID)
+	require.Equal(t, msg.ToolCalls[0].Function.Name, msg2.ToolCalls[0].Function.Name)
+}

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -151,6 +151,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 			msg.Role = RoleSystem
 		case llms.ChatMessageTypeAI:
 			msg.Role = RoleAssistant
+			msg.ReasoningContent = mc.ReasoningContent
 		case llms.ChatMessageTypeHuman:
 			msg.Role = RoleUser
 			// For models without system support, prepend system content to first user message


### PR DESCRIPTION
# fix: preserve `reasoning_content` in tool calling round-trip for deepseek-reasoner

Closes #1478

## Summary

- Fix `reasoning_content` being lost during conversation round-trip when using `deepseek-reasoner` with tool calling
- The DeepSeek API requires every assistant message to include `reasoning_content` -- without it, the API returns HTTP 400: `Missing reasoning_content field in the assistant message`
- This is the same class of bug that was found in the Python LangChain library

## Problem

The `reasoning_content` field was correctly parsed from API responses (PR #1121) but could not be sent back in subsequent requests because:

1. `MessageContent` struct had no `ReasoningContent` field -- users couldn't attach reasoning content to assistant messages in conversation history
2. The `MessageContent` -> `ChatMessage` conversion in the OpenAI provider didn't transfer reasoning content

## Changes

| File | Change |
|------|--------|
| `llms/generatecontent.go` | Add `ReasoningContent string` field to `MessageContent` struct |
| `llms/openai/openaillm.go` | Copy `mc.ReasoningContent` to `msg.ReasoningContent` when converting AI messages |
| `llms/marshaling.go` | Update `MarshalJSON`/`UnmarshalJSON` to include `reasoning_content` (with omitempty) |
| `llms/marshaling_test.go` | Add test cases for reasoning_content marshal/unmarshal/roundtrip |
| `llms/openai/internal/openaiclient/chat_test.go` | Add test for ChatMessage with reasoning + tool_calls |

## Usage

After this fix, users can preserve `reasoning_content` in the tool calling round-trip:

```go
// Step 1: Get response with reasoning + tool calls
resp, _ := llm.GenerateContent(ctx, messages, llms.WithTools(tools))
choice := resp.Choices[0]

// Step 2: Build assistant message preserving reasoning_content
assistantMsg := llms.MessageContent{
    Role:             llms.ChatMessageTypeAI,
    Parts:            []llms.ContentPart{choice.ToolCalls[0]},
    ReasoningContent: choice.ReasoningContent,  // <-- now possible!
}

// Step 3: Send back with tool result -- no more HTTP 400
resp2, _ := llm.GenerateContent(ctx, []llms.MessageContent{
    userMsg,
    assistantMsg,
    toolResultMsg,
}, llms.WithTools(tools))
```

## Test plan

- [x] Added unit test: `ChatMessage` marshal/unmarshal with `ReasoningContent` + `ToolCalls`
- [x] Added unit test: `MessageContent` marshal/unmarshal with `reasoning_content`
- [x] Added unit test: round-trip `MessageContent` with `reasoning_content` + tool calls (JSON and YAML)
- [x] All existing tests pass (`go test ./llms/...`)
- [x] Verified with live DeepSeek API: two-step tool calling flow completes successfully

## Notes

- The fix is minimal and backward-compatible -- `ReasoningContent` defaults to empty string and is omitted from JSON when empty
- The `OpenAIFunctionsAgent` also doesn't propagate `reasoning_content` through its scratchpad (`agents/openai_functions_agent.go`). This is a separate issue that can be addressed in a follow-up PR
- DeepSeek API docs on thinking with tools: https://api-docs.deepseek.com/guides/thinking_with_tools

