### PR TITLE
llms/openai: openai client: return context.Canceled instead of new error declaration

### DIFF
--- a/llms/openai/internal/openaiclient/openaiclient.go
+++ b/llms/openai/internal/openaiclient/openaiclient.go
@@ -225,7 +225,7 @@ func sanitizeHTTPError(err error) error {
 
 	// Check for context cancellation
 	if errors.Is(err, context.Canceled) {
-		return errors.New("request cancelled")
+		return context.Canceled
 	}
 
 	// Check for network timeout errors

--- a/llms/openai/internal/openaiclient/openaiclient_test.go
+++ b/llms/openai/internal/openaiclient/openaiclient_test.go
@@ -374,8 +374,7 @@ func TestSanitizeHTTPError(t *testing.T) {
 	t.Run("context cancelled", func(t *testing.T) {
 		err := context.Canceled
 		sanitized := sanitizeHTTPError(err)
-		assert.Error(t, sanitized)
-		assert.Equal(t, "request cancelled", sanitized.Error())
+		assert.ErrorIs(t, sanitized, context.Canceled)
 	})
 
 	t.Run("network timeout", func(t *testing.T) {


### PR DESCRIPTION
Returning the standard `context.Canceled` error from `llms/openai/internal/openaiclient/openaiclient.go` instead of a new declaration, so callers can evaluate it down the line.

Moreover, since cancelled can be spelled with both 1 and 2 `L`, it is error prone. Go's standard declaration uses 1 `L`.

before

```go
completion, err := llms.GenerateFromSinglePrompt(ctx, model, "prompt")

if err != nil && strings.Contains(err.Error(), "cancelled") {
	// handle canceled context
}
```

after

```go
completion, err := llms.GenerateFromSinglePrompt(ctx, model, "prompt")

if errors.Is(err, context.Canceled) {
	// handle canceled context
}
```

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
