### PR TITLE
llms/openai: add store field support for metadata requests

### DIFF
--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -82,7 +82,12 @@ type ChatRequest struct {
 	FunctionCallBehavior FunctionCallBehavior `json:"function_call,omitempty"`
 
 	// Metadata allows you to specify additional information that will be passed to the model.
+	// Note: OpenAI requires store: true when using metadata.
 	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// Store controls whether the request is stored for later retrieval.
+	// This is required when using metadata per OpenAI's API.
+	Store bool `json:"store,omitempty"`
 
 	// WebSearchOptions configures web search behavior for search-enabled models
 	// like gpt-4o-search-preview and gpt-4o-mini-search-preview.

--- a/llms/openai/internal/openaiclient/marshal_test.go
+++ b/llms/openai/internal/openaiclient/marshal_test.go
@@ -321,3 +321,93 @@ func TestIsReasoningModel(t *testing.T) {
 		})
 	}
 }
+
+func TestChatRequest_StoreFieldMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name         string
+		request      ChatRequest
+		wantStore    bool
+		wantMetadata bool
+	}{
+		{
+			name: "no metadata - store should not be present",
+			request: ChatRequest{
+				Model: "gpt-4",
+			},
+			wantStore:    false,
+			wantMetadata: false,
+		},
+		{
+			name: "with metadata - store should be true",
+			request: ChatRequest{
+				Model: "gpt-4",
+				Metadata: map[string]any{
+					"feature": "support",
+				},
+				Store: true,
+			},
+			wantStore:    true,
+			wantMetadata: true,
+		},
+		{
+			name: "store explicitly set to false with metadata",
+			request: ChatRequest{
+				Model: "gpt-4",
+				Metadata: map[string]any{
+					"team": "ai",
+				},
+				Store: false,
+			},
+			wantStore:    false,
+			wantMetadata: true,
+		},
+		{
+			name: "store explicitly set to true without metadata",
+			request: ChatRequest{
+				Model: "gpt-4",
+				Store: true,
+			},
+			wantStore:    true,
+			wantMetadata: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.request)
+			if err != nil {
+				t.Fatalf("failed to marshal: %v", err)
+			}
+
+			var result map[string]interface{}
+			if err := json.Unmarshal(data, &result); err != nil {
+				t.Fatalf("failed to unmarshal: %v", err)
+			}
+
+			hasStore := result["store"] != nil
+			hasMetadata := result["metadata"] != nil
+
+			if tt.wantStore && !hasStore {
+				t.Errorf("expected store to be present in JSON: %s", string(data))
+			}
+			if !tt.wantStore && hasStore {
+				t.Errorf("expected store to NOT be present in JSON: %s", string(data))
+			}
+			if tt.wantMetadata && !hasMetadata {
+				t.Errorf("expected metadata to be present in JSON: %s", string(data))
+			}
+			if !tt.wantMetadata && hasMetadata {
+				t.Errorf("expected metadata to NOT be present in JSON: %s", string(data))
+			}
+
+			if hasStore {
+				storeVal, ok := result["store"].(bool)
+				if !ok {
+					t.Errorf("store is not a bool: %T", result["store"])
+				} else if storeVal != tt.wantStore {
+					t.Errorf("store value: got %v, want %v", storeVal, tt.wantStore)
+				}
+			}
+		})
+	}
+}

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -293,6 +293,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		FunctionCallBehavior: openaiclient.FunctionCallBehavior(opts.FunctionCallBehavior),
 		Seed:                 opts.Seed,
 		Metadata:             apiMetadata,
+		Store:                len(apiMetadata) > 0,
 		WebSearchOptions:     webSearchOptionsFromCallOptions(opts.WebSearchOptions),
 	}
 	if opts.JSONMode {

--- a/llms/openai/options_test.go
+++ b/llms/openai/options_test.go
@@ -178,3 +178,55 @@ func TestWebSearchOptionsConversion(t *testing.T) {
 		t.Errorf("expected Country=GB, got %s", result2.UserLocation.Approximate.Country)
 	}
 }
+
+func TestWithMetadataSetsStoreField(t *testing.T) {
+	// Test that using llms.WithMetadata results in the Store field being set
+	// This tests the integration in openaillm.go where apiMetadata is populated
+	// and Store is set based on whether metadata is present
+
+	// Simulate the filtering logic from openaillm.go
+	opts := &llms.CallOptions{}
+	metadata := map[string]interface{}{
+		"feature":     "support",
+		"environment": "local",
+		"team":        "ai",
+	}
+	llms.WithMetadata(metadata)(opts)
+
+	// Verify metadata is set
+	if opts.Metadata == nil {
+		t.Fatal("expected Metadata to be set")
+	}
+
+	// Simulate the filtering that happens in openaillm.go
+	apiMetadata := make(map[string]any)
+	for k, v := range opts.Metadata {
+		if k == "thinking_config" { // simulating the HasPrefix check
+			continue
+		}
+		apiMetadata[k] = v
+	}
+
+	// Verify that when metadata is present, Store should be true
+	store := len(apiMetadata) > 0
+	if !store {
+		t.Error("expected Store to be true when metadata is present")
+	}
+
+	// Test with empty metadata
+	opts2 := &llms.CallOptions{}
+	llms.WithMetadata(map[string]interface{}{})(opts2)
+
+	apiMetadata2 := make(map[string]any)
+	for k, v := range opts2.Metadata {
+		if k == "thinking_config" {
+			continue
+		}
+		apiMetadata2[k] = v
+	}
+
+	store2 := len(apiMetadata2) > 0
+	if store2 {
+		t.Error("expected Store to be false when metadata is empty")
+	}
+}


### PR DESCRIPTION
Fixes issue #1484 where `llms.WithMetadata` causes HTTP 400 from OpenAI: 'The metadata parameter is only allowed when store is enabled'

- Add Store bool field to ChatRequest struct
- Set Store: true automatically when metadata is provided
- Add tests for Store field JSON serialization
- Add test for WithMetadata integration with Store field


### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
