### PR TITLE
anthropic: preserve all parts in AI message serialization

### DIFF
--- a/llms/anthropic/anthropicllm.go
+++ b/llms/anthropic/anthropicllm.go
@@ -384,34 +384,36 @@ func handleHumanMessage(msg llms.MessageContent) (anthropicclient.ChatMessage, e
 }
 
 func handleAIMessage(msg llms.MessageContent) (anthropicclient.ChatMessage, error) {
-	if toolCall, ok := msg.Parts[0].(llms.ToolCall); ok {
-		var inputStruct map[string]interface{}
-		err := json.Unmarshal([]byte(toolCall.FunctionCall.Arguments), &inputStruct)
-		if err != nil {
-			return anthropicclient.ChatMessage{}, fmt.Errorf("anthropic: failed to unmarshal tool call arguments: %w", err)
-		}
-		toolUse := anthropicclient.ToolUseContent{
-			Type:  "tool_use",
-			ID:    toolCall.ID,
-			Name:  toolCall.FunctionCall.Name,
-			Input: inputStruct,
-		}
-
-		return anthropicclient.ChatMessage{
-			Role:    RoleAssistant,
-			Content: []anthropicclient.Content{toolUse},
-		}, nil
-	}
-	if textContent, ok := msg.Parts[0].(llms.TextContent); ok {
-		return anthropicclient.ChatMessage{
-			Role: RoleAssistant,
-			Content: []anthropicclient.Content{&anthropicclient.TextContent{
+	contents := make([]anthropicclient.Content, 0, len(msg.Parts))
+	for _, part := range msg.Parts {
+		switch p := part.(type) {
+		case llms.TextContent:
+			contents = append(contents, &anthropicclient.TextContent{
 				Type: "text",
-				Text: textContent.Text,
-			}},
-		}, nil
+				Text: p.Text,
+			})
+		case llms.ToolCall:
+			var inputStruct map[string]interface{}
+			if err := json.Unmarshal([]byte(p.FunctionCall.Arguments), &inputStruct); err != nil {
+				return anthropicclient.ChatMessage{}, fmt.Errorf("anthropic: failed to unmarshal tool call arguments: %w", err)
+			}
+			contents = append(contents, anthropicclient.ToolUseContent{
+				Type:  "tool_use",
+				ID:    p.ID,
+				Name:  p.FunctionCall.Name,
+				Input: inputStruct,
+			})
+		default:
+			return anthropicclient.ChatMessage{}, fmt.Errorf("anthropic: %w for AI message", ErrInvalidContentType)
+		}
 	}
-	return anthropicclient.ChatMessage{}, fmt.Errorf("anthropic: %w for AI message", ErrInvalidContentType)
+	if len(contents) == 0 {
+		return anthropicclient.ChatMessage{}, fmt.Errorf("anthropic: %w for AI message", ErrInvalidContentType)
+	}
+	return anthropicclient.ChatMessage{
+		Role:    RoleAssistant,
+		Content: contents,
+	}, nil
 }
 
 type ToolResult struct {

--- a/llms/anthropic/anthropicllm_test.go
+++ b/llms/anthropic/anthropicllm_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/anthropic/internal/anthropicclient"
 )
 
 func TestNew(t *testing.T) {
@@ -141,6 +142,91 @@ func TestProcessMessages(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleAIMessage_MultipleParts(t *testing.T) {
+	msg := llms.MessageContent{
+		Role: llms.ChatMessageTypeAI,
+		Parts: []llms.ContentPart{
+			llms.TextContent{Text: "I'll check the weather."},
+			llms.ToolCall{
+				ID:   "toolu_1",
+				Type: "function",
+				FunctionCall: &llms.FunctionCall{
+					Name:      "get_weather",
+					Arguments: `{"location":"Paris"}`,
+				},
+			},
+			llms.ToolCall{
+				ID:   "toolu_2",
+				Type: "function",
+				FunctionCall: &llms.FunctionCall{
+					Name:      "get_weather",
+					Arguments: `{"location":"Berlin"}`,
+				},
+			},
+		},
+	}
+
+	got, err := handleAIMessage(msg)
+	if err != nil {
+		t.Fatalf("handleAIMessage() error = %v", err)
+	}
+	if got.Role != RoleAssistant {
+		t.Errorf("role = %q, want %q", got.Role, RoleAssistant)
+	}
+	contents, ok := got.Content.([]anthropicclient.Content)
+	if !ok {
+		t.Fatalf("content type = %T, want []anthropicclient.Content", got.Content)
+	}
+	if len(contents) != 3 {
+		t.Fatalf("content blocks = %d, want 3", len(contents))
+	}
+
+	text, ok := contents[0].(*anthropicclient.TextContent)
+	if !ok {
+		t.Fatalf("content[0] type = %T, want *TextContent", contents[0])
+	}
+	if text.Text != "I'll check the weather." {
+		t.Errorf("text = %q, want %q", text.Text, "I'll check the weather.")
+	}
+
+	for i, want := range []struct{ id, loc string }{{"toolu_1", "Paris"}, {"toolu_2", "Berlin"}} {
+		tu, ok := contents[i+1].(anthropicclient.ToolUseContent)
+		if !ok {
+			t.Fatalf("content[%d] type = %T, want ToolUseContent", i+1, contents[i+1])
+		}
+		if tu.ID != want.id {
+			t.Errorf("tool[%d] id = %q, want %q", i, tu.ID, want.id)
+		}
+		if tu.Input["location"] != want.loc {
+			t.Errorf("tool[%d] location = %v, want %q", i, tu.Input["location"], want.loc)
+		}
+	}
+}
+
+func TestHandleAIMessage_Errors(t *testing.T) {
+	t.Run("empty parts", func(t *testing.T) {
+		_, err := handleAIMessage(llms.MessageContent{Role: llms.ChatMessageTypeAI})
+		if err == nil {
+			t.Fatal("expected error for empty parts")
+		}
+	})
+
+	t.Run("invalid tool call arguments", func(t *testing.T) {
+		msg := llms.MessageContent{
+			Role: llms.ChatMessageTypeAI,
+			Parts: []llms.ContentPart{
+				llms.ToolCall{
+					ID:           "toolu_x",
+					FunctionCall: &llms.FunctionCall{Name: "x", Arguments: "not-json"},
+				},
+			},
+		}
+		if _, err := handleAIMessage(msg); err == nil {
+			t.Fatal("expected error for invalid tool call arguments")
+		}
+	})
 }
 
 func TestToolsToTools(t *testing.T) {


### PR DESCRIPTION
## Summary

`handleAIMessage` in `llms/anthropic/anthropicllm.go` only inspected `msg.Parts[0]`. When an assistant message contained both text and one or more tool calls (e.g. `[TextContent, ToolCall]` or `[TextContent, ToolCall, ToolCall]` for parallel tool use), every part after the first was silently dropped. The next `tool_result` message would then be rejected by Anthropic:

```
messages.N.content.0: unexpected `tool_use_id` found in `tool_result` blocks: toolu_...
Each `tool_result` block must have a corresponding `tool_use` block in the previous message.
```

This change iterates all parts and emits one Anthropic content block per part, mirroring the structure already used by `handleHumanMessage`.

Fixes #1468.

## Test plan
- [x] `go test ./llms/anthropic/...` unit tests pass
- [x] `go vet ./llms/anthropic/...` clean
- [x] New `TestHandleAIMessage_MultipleParts` covers text + multiple tool calls
- [x] New `TestHandleAIMessage_Errors` covers empty parts and invalid tool arguments