### PR TITLE
chains: export ChainCallOptions so custom Chain implementations can read options

### DIFF
--- a/chains/llm.go
+++ b/chains/llm.go
@@ -30,10 +30,7 @@ var (
 
 // NewLLMChain creates a new LLMChain with an LLM and a prompt.
 func NewLLMChain(llm llms.Model, prompt prompts.FormatPrompter, opts ...ChainCallOption) *LLMChain {
-	opt := &chainCallOption{}
-	for _, o := range opts {
-		o(opt)
-	}
+	opt := ApplyChainCallOptions(opts...)
 	chain := &LLMChain{
 		Prompt:           prompt,
 		LLM:              llm,

--- a/chains/options.go
+++ b/chains/options.go
@@ -8,32 +8,36 @@ import (
 )
 
 // ChainCallOption is a function that can be used to modify the behavior of the Call function.
-type ChainCallOption func(*chainCallOption)
+type ChainCallOption func(*ChainCallOptions)
 
+// ChainCallOptions holds the resolved values for a chain call. Custom Chain
+// implementations outside this package can call [ApplyChainCallOptions] to
+// convert a slice of [ChainCallOption] into a ChainCallOptions value they can
+// read.
+//
 // For issue #626, each field here has a boolean "set" flag so we can
-// distinguish between the case where the option was actually set explicitly
-// on chainCallOption, or asked to remain default. The reason we need this is
-// that in translating options from ChainCallOption to llms.CallOption, the
-// notion of "default value the user didn't explicitly ask to change" is
-// violated.
+// distinguish between the case where the option was actually set explicitly,
+// or asked to remain default. The reason we need this is that in translating
+// options from ChainCallOption to llms.CallOption, the notion of "default
+// value the user didn't explicitly ask to change" is violated.
 // These flags are hopefully a temporary backwards-compatible solution, until
 // we find a more fundamental solution for #626.
-type chainCallOption struct {
+type ChainCallOptions struct {
 	// Model is the model to use in an LLM call.
 	Model    string
-	modelSet bool
+	ModelSet bool
 
 	// MaxTokens is the maximum number of tokens to generate to use in an LLM call.
 	MaxTokens    int
-	maxTokensSet bool
+	MaxTokensSet bool
 
 	// Temperature is the temperature for sampling to use in an LLM call, between 0 and 1.
 	Temperature    float64
-	temperatureSet bool
+	TemperatureSet bool
 
 	// StopWords is a list of words to stop on to use in an LLM call.
 	StopWords    []string
-	stopWordsSet bool
+	StopWordsSet bool
 
 	// StreamingFunc is a function to be called for each chunk of a streaming response.
 	// Return an error to stop streaming early.
@@ -41,122 +45,133 @@ type chainCallOption struct {
 
 	// TopK is the number of tokens to consider for top-k sampling in an LLM call.
 	TopK    int
-	topkSet bool
+	TopKSet bool
 
 	// TopP is the cumulative probability for top-p sampling in an LLM call.
 	TopP    float64
-	toppSet bool
+	TopPSet bool
 
 	// Seed is a seed for deterministic sampling in an LLM call.
 	Seed    int
-	seedSet bool
+	SeedSet bool
 
 	// MinLength is the minimum length of the generated text in an LLM call.
 	MinLength    int
-	minLengthSet bool
+	MinLengthSet bool
 
 	// MaxLength is the maximum length of the generated text in an LLM call.
 	MaxLength    int
-	maxLengthSet bool
+	MaxLengthSet bool
 
 	// RepetitionPenalty is the repetition penalty for sampling in an LLM call.
 	RepetitionPenalty    float64
-	repetitionPenaltySet bool
+	RepetitionPenaltySet bool
 
 	// CallbackHandler is the callback handler for Chain
 	CallbackHandler callbacks.Handler
 }
 
+// ApplyChainCallOptions resolves a slice of [ChainCallOption] into a
+// [ChainCallOptions] value. Custom [Chain] implementations that accept
+// ChainCallOption arguments use this to read the caller's choices.
+func ApplyChainCallOptions(options ...ChainCallOption) ChainCallOptions {
+	var opts ChainCallOptions
+	for _, option := range options {
+		option(&opts)
+	}
+	return opts
+}
+
 // WithModel is an option for LLM.Call.
 func WithModel(model string) ChainCallOption {
-	return func(o *chainCallOption) {
+	return func(o *ChainCallOptions) {
 		o.Model = model
-		o.modelSet = true
+		o.ModelSet = true
 	}
 }
 
 // WithMaxTokens is an option for LLM.Call.
 func WithMaxTokens(maxTokens int) ChainCallOption {
-	return func(o *chainCallOption) {
+	return func(o *ChainCallOptions) {
 		o.MaxTokens = maxTokens
-		o.maxTokensSet = true
+		o.MaxTokensSet = true
 	}
 }
 
 // WithTemperature is an option for LLM.Call.
 func WithTemperature(temperature float64) ChainCallOption {
-	return func(o *chainCallOption) {
+	return func(o *ChainCallOptions) {
 		o.Temperature = temperature
-		o.temperatureSet = true
+		o.TemperatureSet = true
 	}
 }
 
 // WithStreamingFunc is an option for LLM.Call that allows streaming responses.
 func WithStreamingFunc(streamingFunc func(ctx context.Context, chunk []byte) error) ChainCallOption {
-	return func(o *chainCallOption) {
+	return func(o *ChainCallOptions) {
 		o.StreamingFunc = streamingFunc
 	}
 }
 
 // WithTopK will add an option to use top-k sampling for LLM.Call.
 func WithTopK(topK int) ChainCallOption {
-	return func(o *chainCallOption) {
+	return func(o *ChainCallOptions) {
 		o.TopK = topK
-		o.topkSet = true
+		o.TopKSet = true
 	}
 }
 
 // WithTopP	will add an option to use top-p sampling for LLM.Call.
 func WithTopP(topP float64) ChainCallOption {
-	return func(o *chainCallOption) {
+	return func(o *ChainCallOptions) {
 		o.TopP = topP
-		o.toppSet = true
+		o.TopPSet = true
 	}
 }
 
 // WithSeed will add an option to use deterministic sampling for LLM.Call.
 func WithSeed(seed int) ChainCallOption {
-	return func(o *chainCallOption) {
+	return func(o *ChainCallOptions) {
 		o.Seed = seed
-		o.seedSet = true
+		o.SeedSet = true
 	}
 }
 
 // WithMinLength will add an option to set the minimum length of the generated text for LLM.Call.
 func WithMinLength(minLength int) ChainCallOption {
-	return func(o *chainCallOption) {
+	return func(o *ChainCallOptions) {
 		o.MinLength = minLength
-		o.minLengthSet = true
+		o.MinLengthSet = true
 	}
 }
 
 // WithMaxLength will add an option to set the maximum length of the generated text for LLM.Call.
 func WithMaxLength(maxLength int) ChainCallOption {
-	return func(o *chainCallOption) {
+	return func(o *ChainCallOptions) {
 		o.MaxLength = maxLength
-		o.maxLengthSet = true
+		o.MaxLengthSet = true
 	}
 }
 
 // WithRepetitionPenalty will add an option to set the repetition penalty for sampling.
 func WithRepetitionPenalty(repetitionPenalty float64) ChainCallOption {
-	return func(o *chainCallOption) {
+	return func(o *ChainCallOptions) {
 		o.RepetitionPenalty = repetitionPenalty
-		o.repetitionPenaltySet = true
+		o.RepetitionPenaltySet = true
 	}
 }
 
 // WithStopWords is an option for setting the stop words for LLM.Call.
 func WithStopWords(stopWords []string) ChainCallOption {
-	return func(o *chainCallOption) {
+	return func(o *ChainCallOptions) {
 		o.StopWords = stopWords
-		o.stopWordsSet = true
+		o.StopWordsSet = true
 	}
 }
 
 // WithCallback allows setting a custom Callback Handler.
 func WithCallback(callbackHandler callbacks.Handler) ChainCallOption {
-	return func(o *chainCallOption) {
+	return func(o *ChainCallOptions) {
 		o.CallbackHandler = callbackHandler
 	}
 }
@@ -165,10 +180,7 @@ func WithCallback(callbackHandler callbacks.Handler) ChainCallOption {
 // This is useful for agents and other code that needs to propagate chain options
 // to direct LLM calls.
 func GetLLMCallOptions(options ...ChainCallOption) []llms.CallOption { //nolint:cyclop
-	opts := &chainCallOption{}
-	for _, option := range options {
-		option(opts)
-	}
+	opts := ApplyChainCallOptions(options...)
 	if opts.StreamingFunc == nil && opts.CallbackHandler != nil {
 		opts.StreamingFunc = func(ctx context.Context, chunk []byte) error {
 			opts.CallbackHandler.HandleStreamingFunc(ctx, chunk)
@@ -178,34 +190,34 @@ func GetLLMCallOptions(options ...ChainCallOption) []llms.CallOption { //nolint:
 
 	var chainCallOption []llms.CallOption
 
-	if opts.modelSet {
+	if opts.ModelSet {
 		chainCallOption = append(chainCallOption, llms.WithModel(opts.Model))
 	}
-	if opts.maxTokensSet {
+	if opts.MaxTokensSet {
 		chainCallOption = append(chainCallOption, llms.WithMaxTokens(opts.MaxTokens))
 	}
-	if opts.temperatureSet {
+	if opts.TemperatureSet {
 		chainCallOption = append(chainCallOption, llms.WithTemperature(opts.Temperature))
 	}
-	if opts.stopWordsSet {
+	if opts.StopWordsSet {
 		chainCallOption = append(chainCallOption, llms.WithStopWords(opts.StopWords))
 	}
-	if opts.topkSet {
+	if opts.TopKSet {
 		chainCallOption = append(chainCallOption, llms.WithTopK(opts.TopK))
 	}
-	if opts.toppSet {
+	if opts.TopPSet {
 		chainCallOption = append(chainCallOption, llms.WithTopP(opts.TopP))
 	}
-	if opts.seedSet {
+	if opts.SeedSet {
 		chainCallOption = append(chainCallOption, llms.WithSeed(opts.Seed))
 	}
-	if opts.minLengthSet {
+	if opts.MinLengthSet {
 		chainCallOption = append(chainCallOption, llms.WithMinLength(opts.MinLength))
 	}
-	if opts.maxLengthSet {
+	if opts.MaxLengthSet {
 		chainCallOption = append(chainCallOption, llms.WithMaxLength(opts.MaxLength))
 	}
-	if opts.repetitionPenaltySet {
+	if opts.RepetitionPenaltySet {
 		chainCallOption = append(chainCallOption, llms.WithRepetitionPenalty(opts.RepetitionPenalty))
 	}
 	chainCallOption = append(chainCallOption, llms.WithStreamingFunc(opts.StreamingFunc))

--- a/chains/options_test.go
+++ b/chains/options_test.go
@@ -1,0 +1,70 @@
+package chains_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tmc/langchaingo/chains"
+	"github.com/tmc/langchaingo/schema"
+)
+
+// externalChain is an example Chain implementation living outside the chains
+// package. Its existence is the regression test for issue #1085: before
+// ChainCallOptions was exported, no custom Chain could observe the values set
+// by the caller's ChainCallOption functions.
+type externalChain struct {
+	captured chains.ChainCallOptions
+}
+
+var _ chains.Chain = (*externalChain)(nil)
+
+func (c *externalChain) Call(_ context.Context, _ map[string]any, opts ...chains.ChainCallOption) (map[string]any, error) {
+	c.captured = chains.ApplyChainCallOptions(opts...)
+	return map[string]any{"out": ""}, nil
+}
+
+func (c *externalChain) GetMemory() schema.Memory { return nil }
+func (c *externalChain) GetInputKeys() []string   { return nil }
+func (c *externalChain) GetOutputKeys() []string  { return []string{"out"} }
+
+func TestApplyChainCallOptions_ExternalChain(t *testing.T) {
+	c := &externalChain{}
+
+	if _, err := c.Call(context.Background(), nil,
+		chains.WithModel("gpt-4o-mini"),
+		chains.WithMaxTokens(256),
+		chains.WithTemperature(0.2),
+		chains.WithStopWords([]string{"END"}),
+	); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+
+	got := c.captured
+	if !got.ModelSet || got.Model != "gpt-4o-mini" {
+		t.Errorf("Model = %q set=%v, want gpt-4o-mini set=true", got.Model, got.ModelSet)
+	}
+	if !got.MaxTokensSet || got.MaxTokens != 256 {
+		t.Errorf("MaxTokens = %d set=%v, want 256 set=true", got.MaxTokens, got.MaxTokensSet)
+	}
+	if !got.TemperatureSet || got.Temperature != 0.2 {
+		t.Errorf("Temperature = %v set=%v, want 0.2 set=true", got.Temperature, got.TemperatureSet)
+	}
+	if !got.StopWordsSet || len(got.StopWords) != 1 || got.StopWords[0] != "END" {
+		t.Errorf("StopWords = %v set=%v, want [END] set=true", got.StopWords, got.StopWordsSet)
+	}
+	if got.TopKSet || got.TopPSet || got.SeedSet {
+		t.Errorf("unset flags leaked: %+v", got)
+	}
+}
+
+func TestApplyChainCallOptions_Empty(t *testing.T) {
+	got := chains.ApplyChainCallOptions()
+	if got.ModelSet || got.MaxTokensSet || got.TemperatureSet || got.StopWordsSet ||
+		got.TopKSet || got.TopPSet || got.SeedSet ||
+		got.MinLengthSet || got.MaxLengthSet || got.RepetitionPenaltySet {
+		t.Errorf("empty apply produced set flags: %+v", got)
+	}
+	if got.StreamingFunc != nil || got.CallbackHandler != nil {
+		t.Errorf("empty apply produced non-nil closures: %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary

`ChainCallOption` is currently defined as:

```go
type ChainCallOption func(*chainCallOption)
```

where `chainCallOption` is unexported. That makes it impossible to implement the `chains.Chain` interface from outside the `chains` package while still respecting caller-supplied options — callers can pass a `[]ChainCallOption`, but a custom implementation has no way to construct a `*chainCallOption` to invoke the functions against, and no way to read the resulting field values.

This PR exports the struct as `ChainCallOptions` (plural, to avoid colliding with the existing `ChainCallOption` function type), exports the `*Set` flags, and adds a public `ApplyChainCallOptions` helper:

```go
type ChainCallOptions struct {
    Model    string
    ModelSet bool
    // ...
}

func ApplyChainCallOptions(options ...ChainCallOption) ChainCallOptions
```

Custom implementations can now write:

```go
func (c *MyChain) Call(ctx context.Context, in map[string]any, opts ...chains.ChainCallOption) (map[string]any, error) {
    resolved := chains.ApplyChainCallOptions(opts...)
    if resolved.ModelSet { /* ... */ }
    // ...
}
```

Internal usage (`NewLLMChain`, `GetLLMCallOptions`) was switched over to `ApplyChainCallOptions` for consistency.

### Compatibility

Renaming `chainCallOption` → `ChainCallOptions` and the `xxxSet` flags → `XxxSet` is non-breaking: external callers could not reference the private type, so no existing import path changes. The `ChainCallOption` function type itself is unchanged at the signature level.

Fixes #1085.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./chains/... ./agents/...` clean
- [x] New `TestApplyChainCallOptions_ExternalChain` in `chains_test` (external package) demonstrates implementing `chains.Chain` from outside and reading caller options
- [x] New `TestApplyChainCallOptions_Empty` covers the zero-value path
- [x] Existing `chains/` unit tests pass; only failing tests (`TestLLMChainWithGoogleAI`, `TestConstitutionalChain`) are pre-existing integration tests requiring external credentials