### PR TITLE
llms: support SystemChatMessage in ChatMessageModel.ToChatMessage

### DIFF
--- a/llms/chat_messages.go
+++ b/llms/chat_messages.go
@@ -186,6 +186,8 @@ func (c ChatMessageModel) ToChatMessage() ChatMessage {
 		return AIChatMessage{Content: c.Data.Content}
 	case string(ChatMessageTypeHuman):
 		return HumanChatMessage{Content: c.Data.Content}
+	case string(ChatMessageTypeSystem):
+		return SystemChatMessage{Content: c.Data.Content}
 	default:
 		slog.Warn("convert to chat message failed with invalid message type", "type", c.Type)
 		return nil

--- a/llms/chat_messages_test.go
+++ b/llms/chat_messages_test.go
@@ -68,3 +68,40 @@ type unsupportedChatMessage struct{}
 
 func (m unsupportedChatMessage) GetType() llms.ChatMessageType { return "unsupported" }
 func (m unsupportedChatMessage) GetContent() string            { return "Unsupported message" }
+
+func TestChatMessageModelRoundTrip(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name    string
+		message llms.ChatMessage
+	}{
+		{
+			name:    "AI message",
+			message: llms.AIChatMessage{Content: "I'm doing great!"},
+		},
+		{
+			name:    "Human message",
+			message: llms.HumanChatMessage{Content: "Hello, how are you?"},
+		},
+		{
+			name:    "System message",
+			message: llms.SystemChatMessage{Content: "Please be polite."},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := llms.ConvertChatMessageToModel(tc.message).ToChatMessage()
+			if got == nil {
+				t.Fatalf("ToChatMessage returned nil for %T", tc.message)
+			}
+			if got.GetType() != tc.message.GetType() {
+				t.Errorf("type mismatch: got %q, want %q", got.GetType(), tc.message.GetType())
+			}
+			if got.GetContent() != tc.message.GetContent() {
+				t.Errorf("content mismatch: got %q, want %q", got.GetContent(), tc.message.GetContent())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`ConvertChatMessageToModel` serializes any `ChatMessage` (including `SystemChatMessage`) into a `ChatMessageModel`, but `ChatMessageModel.ToChatMessage` only handled the AI and Human cases and returned `nil` for system messages. Callers such as the Mongo chat history (`memory/mongo`) could write a system message and silently lose it on read.

This adds the `ChatMessageTypeSystem` case and a round-trip test covering AI, Human, and System messages.

Fixes #1056

## Test plan

- [x] `go vet ./llms/...`
- [x] `go test ./llms/` passes
- [x] New `TestChatMessageModelRoundTrip` exercises the AI/Human/System round-trip via `ConvertChatMessageToModel` → `ToChatMessage`