### PR TITLE
Document Tuning Engines OpenAI-compatible endpoint

### DIFF
--- a/docs/docs/how-to/configure-llm-providers.md
+++ b/docs/docs/how-to/configure-llm-providers.md
@@ -28,6 +28,20 @@ llm, err := openai.New(
 )
 ```
 
+### OpenAI-compatible gateways
+
+You can also point the OpenAI client at a governed OpenAI-compatible endpoint such as [Tuning Engines](https://www.tuningengines.com/). LangChainGo keeps the application logic while the gateway centralizes model routing, policy controls, audit logs, traces, approvals, and cost visibility.
+
+```go
+import "os"
+
+llm, err := openai.New(
+    openai.WithToken(os.Getenv("TUNING_ENGINES_API_KEY")),
+    openai.WithModel("gpt-4o-mini"),
+    openai.WithBaseURL("https://api.tuningengines.com/v1"),
+)
+```
+
 ### Azure OpenAI
 
 ```go


### PR DESCRIPTION
## Summary

- Adds a small documentation example showing how to point this project’s existing OpenAI-compatible configuration at Tuning Engines.
- Keeps this project’s APIs and runtime behavior unchanged: no new dependency, adapter, or code path.
- Shows a path for teams to keep this framework in charge of app, agent, tool, workflow, or retrieval logic while routing model calls through a governed OpenAI-compatible endpoint.

## Why this belongs here

Tuning Engines is an AI control plane for teams that want centralized model access, routing, tenant-scoped keys, policy/guardrail checks, audit logs, traces, approvals, and usage/cost visibility around existing AI applications.

This project already supports OpenAI-compatible endpoints. The docs change makes that existing capability discoverable for users who want governance and observability without rewriting their application around a separate SDK or changing this project’s runtime behavior.

## Testing

- `git diff --check`
