### PR TITLE
feat: add ReasoningContent field to support multi-turn thinking mode

### DIFF
--- a/llms/generatecontent.go
+++ b/llms/generatecontent.go
@@ -14,6 +14,11 @@ import (
 type MessageContent struct {
 	Role  ChatMessageType
 	Parts []ContentPart
+
+	// ReasoningContent holds the thinking/reasoning content from models that
+	// support extended thinking (e.g., Kimi, DeepSeek). This must be preserved
+	// and sent back in subsequent messages for multi-turn conversations.
+	ReasoningContent string
 }
 
 // TextPart creates TextContent from a given string.

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -145,7 +145,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 			continue
 		}
 
-		msg := &ChatMessage{MultiContent: mc.Parts}
+		msg := &ChatMessage{MultiContent: mc.Parts, ReasoningContent: mc.ReasoningContent}
 		switch mc.Role {
 		case llms.ChatMessageTypeSystem:
 			msg.Role = RoleSystem


### PR DESCRIPTION
Add ReasoningContent to MessageContent and pass it through to ChatMessage, preserving reasoning/thinking content from models like Kimi and DeepSeek in multi-turn conversations.