### PR TITLE
fix(anthropic): iterate all message parts in handleAIMessage and handleToolMessage

### DIFF
--- a/llms/anthropic/anthropicllm.go
+++ b/llms/anthropic/anthropicllm.go
@@ -384,34 +384,37 @@ func handleHumanMessage(msg llms.MessageContent) (anthropicclient.ChatMessage, e
 }
 
 func handleAIMessage(msg llms.MessageContent) (anthropicclient.ChatMessage, error) {
-	if toolCall, ok := msg.Parts[0].(llms.ToolCall); ok {
-		var inputStruct map[string]interface{}
-		err := json.Unmarshal([]byte(toolCall.FunctionCall.Arguments), &inputStruct)
-		if err != nil {
-			return anthropicclient.ChatMessage{}, fmt.Errorf("anthropic: failed to unmarshal tool call arguments: %w", err)
-		}
-		toolUse := anthropicclient.ToolUseContent{
-			Type:  "tool_use",
-			ID:    toolCall.ID,
-			Name:  toolCall.FunctionCall.Name,
-			Input: inputStruct,
-		}
-
-		return anthropicclient.ChatMessage{
-			Role:    RoleAssistant,
-			Content: []anthropicclient.Content{toolUse},
-		}, nil
-	}
-	if textContent, ok := msg.Parts[0].(llms.TextContent); ok {
-		return anthropicclient.ChatMessage{
-			Role: RoleAssistant,
-			Content: []anthropicclient.Content{&anthropicclient.TextContent{
+	var contents []anthropicclient.Content
+	for _, part := range msg.Parts {
+		switch p := part.(type) {
+		case llms.ToolCall:
+			var inputStruct map[string]interface{}
+			err := json.Unmarshal([]byte(p.FunctionCall.Arguments), &inputStruct)
+			if err != nil {
+				return anthropicclient.ChatMessage{}, fmt.Errorf("anthropic: failed to unmarshal tool call arguments: %w", err)
+			}
+			contents = append(contents, anthropicclient.ToolUseContent{
+				Type:  "tool_use",
+				ID:    p.ID,
+				Name:  p.FunctionCall.Name,
+				Input: inputStruct,
+			})
+		case llms.TextContent:
+			contents = append(contents, &anthropicclient.TextContent{
 				Type: "text",
-				Text: textContent.Text,
-			}},
-		}, nil
+				Text: p.Text,
+			})
+		default:
+			return anthropicclient.ChatMessage{}, fmt.Errorf("anthropic: %w for AI message", ErrInvalidContentType)
+		}
 	}
-	return anthropicclient.ChatMessage{}, fmt.Errorf("anthropic: %w for AI message", ErrInvalidContentType)
+	if len(contents) == 0 {
+		return anthropicclient.ChatMessage{}, fmt.Errorf("anthropic: %w for AI message", ErrInvalidContentType)
+	}
+	return anthropicclient.ChatMessage{
+		Role:    RoleAssistant,
+		Content: contents,
+	}, nil
 }
 
 type ToolResult struct {
@@ -421,19 +424,25 @@ type ToolResult struct {
 }
 
 func handleToolMessage(msg llms.MessageContent) (anthropicclient.ChatMessage, error) {
-	if toolCallResponse, ok := msg.Parts[0].(llms.ToolCallResponse); ok {
-		toolContent := anthropicclient.ToolResultContent{
+	var contents []anthropicclient.Content
+	for _, part := range msg.Parts {
+		toolCallResponse, ok := part.(llms.ToolCallResponse)
+		if !ok {
+			return anthropicclient.ChatMessage{}, fmt.Errorf("anthropic: %w for tool message", ErrInvalidContentType)
+		}
+		contents = append(contents, anthropicclient.ToolResultContent{
 			Type:      "tool_result",
 			ToolUseID: toolCallResponse.ToolCallID,
 			Content:   toolCallResponse.Content,
-		}
-
-		return anthropicclient.ChatMessage{
-			Role:    RoleUser,
-			Content: []anthropicclient.Content{toolContent},
-		}, nil
+		})
 	}
-	return anthropicclient.ChatMessage{}, fmt.Errorf("anthropic: %w for tool message", ErrInvalidContentType)
+	if len(contents) == 0 {
+		return anthropicclient.ChatMessage{}, fmt.Errorf("anthropic: %w for tool message", ErrInvalidContentType)
+	}
+	return anthropicclient.ChatMessage{
+		Role:    RoleUser,
+		Content: contents,
+	}, nil
 }
 
 // SupportsReasoning implements the ReasoningModel interface.

--- a/llms/anthropic/anthropicllm_test.go
+++ b/llms/anthropic/anthropicllm_test.go
@@ -4,7 +4,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/anthropic/internal/anthropicclient"
 )
 
 func TestNew(t *testing.T) {
@@ -141,6 +143,80 @@ func TestProcessMessages(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleAIMessagePreservesAllParts(t *testing.T) {
+	t.Parallel()
+
+	message, err := handleAIMessage(llms.MessageContent{
+		Role: llms.ChatMessageTypeAI,
+		Parts: []llms.ContentPart{
+			llms.TextContent{Text: "I'll check both locations."},
+			llms.ToolCall{
+				ID: "tool-1",
+				FunctionCall: &llms.FunctionCall{
+					Name:      "get_weather",
+					Arguments: `{"location":"Paris"}`,
+				},
+			},
+			llms.ToolCall{
+				ID: "tool-2",
+				FunctionCall: &llms.FunctionCall{
+					Name:      "get_weather",
+					Arguments: `{"location":"London"}`,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, RoleAssistant, message.Role)
+
+	contents, ok := message.Content.([]anthropicclient.Content)
+	require.True(t, ok)
+	require.Len(t, contents, 3)
+
+	text, ok := contents[0].(*anthropicclient.TextContent)
+	require.True(t, ok)
+	require.Equal(t, "I'll check both locations.", text.Text)
+
+	firstTool, ok := contents[1].(anthropicclient.ToolUseContent)
+	require.True(t, ok)
+	require.Equal(t, "tool-1", firstTool.ID)
+	require.Equal(t, "get_weather", firstTool.Name)
+	require.Equal(t, map[string]interface{}{"location": "Paris"}, firstTool.Input)
+
+	secondTool, ok := contents[2].(anthropicclient.ToolUseContent)
+	require.True(t, ok)
+	require.Equal(t, "tool-2", secondTool.ID)
+	require.Equal(t, map[string]interface{}{"location": "London"}, secondTool.Input)
+}
+
+func TestHandleToolMessagePreservesAllResults(t *testing.T) {
+	t.Parallel()
+
+	message, err := handleToolMessage(llms.MessageContent{
+		Role: llms.ChatMessageTypeTool,
+		Parts: []llms.ContentPart{
+			llms.ToolCallResponse{ToolCallID: "tool-1", Content: "sunny"},
+			llms.ToolCallResponse{ToolCallID: "tool-2", Content: "rainy"},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, RoleUser, message.Role)
+
+	contents, ok := message.Content.([]anthropicclient.Content)
+	require.True(t, ok)
+	require.Len(t, contents, 2)
+
+	firstResult, ok := contents[0].(anthropicclient.ToolResultContent)
+	require.True(t, ok)
+	require.Equal(t, "tool-1", firstResult.ToolUseID)
+	require.Equal(t, "sunny", firstResult.Content)
+
+	secondResult, ok := contents[1].(anthropicclient.ToolResultContent)
+	require.True(t, ok)
+	require.Equal(t, "tool-2", secondResult.ToolUseID)
+	require.Equal(t, "rainy", secondResult.Content)
 }
 
 func TestToolsToTools(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes #1468. `handleAIMessage` and `handleToolMessage` only checked `Parts[0]`, silently dropping text content when tool calls were present, or dropping subsequent tool calls in multi-part messages.

This caused Anthropic API errors like:
```
unexpected tool_use_id found in tool_result blocks
```

## Changes
- `llms/anthropic/anthropicllm.go`: Rewrote `handleAIMessage` to iterate all `msg.Parts` and collect both `TextContent` and `ToolCall` parts into a single `ChatMessage.Content` slice
- Same fix applied to `handleToolMessage` for consistency (multiple tool results in one message)

## Test plan
- `go test ./llms/anthropic -run 'Test(HandleAIMessagePreservesAllParts|HandleToolMessagePreservesAllResults|ProcessMessages)$'` — passes
- `go vet ./llms/anthropic/...` — passes
- The full package suite was also attempted; its existing live API cases require a valid Anthropic credential and returned 401 in this environment

## Risk
- Low. The change is backward-compatible: single-part messages (the previous only supported case) produce the same output as before.