### PR TITLE
llms/googleai: return error instead of panicking on system-only message list

### DIFF
--- a/llms/googleai/generate_messages_unit_test.go
+++ b/llms/googleai/generate_messages_unit_test.go
@@ -1,0 +1,31 @@
+package googleai
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/generative-ai-go/genai"
+	"github.com/tmc/langchaingo/llms"
+)
+
+// TestGenerateFromMessagesSystemOnly verifies that a message list containing
+// only system messages returns ErrNoRequestMessage instead of panicking with
+// an index-out-of-range when selecting the request message from the history.
+func TestGenerateFromMessagesSystemOnly(t *testing.T) {
+	t.Parallel()
+
+	messages := []llms.MessageContent{
+		{
+			Role:  llms.ChatMessageTypeSystem,
+			Parts: []llms.ContentPart{llms.TextPart("you are a helpful assistant")},
+		},
+	}
+
+	model := &genai.GenerativeModel{}
+	_, err := generateFromMessages(context.Background(), model, messages, &llms.CallOptions{})
+
+	if !errors.Is(err, ErrNoRequestMessage) {
+		t.Fatalf("expected ErrNoRequestMessage, got %v", err)
+	}
+}

--- a/llms/googleai/googleai.go
+++ b/llms/googleai/googleai.go
@@ -19,6 +19,7 @@ var (
 	ErrNoContentInResponse   = errors.New("no content in generation response")
 	ErrUnknownPartInResponse = errors.New("unknown part type in generation response")
 	ErrInvalidMimeType       = errors.New("invalid mime type on content")
+	ErrNoRequestMessage      = errors.New("no request message: messages contain only system content")
 )
 
 const (
@@ -330,6 +331,9 @@ func generateFromMessages(
 	// Given N total messages, genai's chat expects the first N-1 messages as
 	// history and the last message as the actual request.
 	n := len(history)
+	if n == 0 {
+		return nil, ErrNoRequestMessage
+	}
 	reqContent := history[n-1]
 	history = history[:n-1]
 


### PR DESCRIPTION
Fixes #1507

When a message list contains only system messages, `generateFromMessages` builds an empty `history` (every system message is consumed into `model.SystemInstruction` and `continue`d), then indexes `history[n-1]` with `n == 0` and panics with `index out of range [-1]`.

This adds a length check that returns a new `ErrNoRequestMessage` sentinel before the index, so callers get an error rather than a panic. Covered by a unit test that drives a system-only list through `generateFromMessages`.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
