### PR TITLE
llms/googleai: return error instead of panicking on system-only message list

### DIFF
--- a/llms/googleai/googleai.go
+++ b/llms/googleai/googleai.go
@@ -19,6 +19,7 @@ var (
 	ErrNoContentInResponse   = errors.New("no content in generation response")
 	ErrUnknownPartInResponse = errors.New("unknown part type in generation response")
 	ErrInvalidMimeType       = errors.New("invalid mime type on content")
+	ErrNoMessageContent      = errors.New("no non-system message content to send")
 )
 
 const (
@@ -330,6 +331,10 @@ func generateFromMessages(
 	// Given N total messages, genai's chat expects the first N-1 messages as
 	// history and the last message as the actual request.
 	n := len(history)
+	if n == 0 {
+		// All input messages were system messages, so there is nothing to send.
+		return nil, ErrNoMessageContent
+	}
 	reqContent := history[n-1]
 	history = history[:n-1]
 

--- a/llms/googleai/googleai_unit_test.go
+++ b/llms/googleai/googleai_unit_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/generative-ai-go/genai"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/llms"
+	"google.golang.org/api/option"
 )
 
 func TestNew(t *testing.T) {
@@ -273,6 +276,23 @@ func TestErrorConstants(t *testing.T) {
 	assert.Equal(t, "no content in generation response", ErrNoContentInResponse.Error())
 	assert.Equal(t, "unknown part type in generation response", ErrUnknownPartInResponse.Error())
 	assert.Equal(t, "invalid mime type on content", ErrInvalidMimeType.Error())
+}
+
+func TestGenerateFromMessagesOnlySystem(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client, err := genai.NewClient(ctx, option.WithAPIKey("test-key"))
+	require.NoError(t, err)
+	defer client.Close()
+
+	model := client.GenerativeModel("gemini-pro")
+	messages := []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeSystem, "you are a helpful assistant"),
+	}
+
+	_, err = generateFromMessages(ctx, model, messages, &llms.CallOptions{})
+	assert.ErrorIs(t, err, ErrNoMessageContent)
 }
 
 func TestGoogleAIImplementsModelInterface(t *testing.T) {


### PR DESCRIPTION
Fixes #1507

`generateFromMessages` builds a `history` slice from the input messages, skipping any system message (it is routed to `model.SystemInstruction`). When every message has role `system`, the slice ends up empty and `history[n-1]` panics with `index out of range [-1]`.

This guards the empty case and returns a new `ErrNoMessageContent` error instead of panicking, so a system-only message list (including in stream mode) fails cleanly.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
