### PR TITLE
llms/ollama: send think as a top-level request field so WithThink works

### DIFF
--- a/llms/ollama/internal/ollamaclient/ollamaclient_test.go
+++ b/llms/ollama/internal/ollamaclient/ollamaclient_test.go
@@ -310,10 +310,10 @@ func TestClient_GenerateChatWithThink(t *testing.T) {
 			},
 		},
 		Stream: false,
+		Think:  boolPtr(true), // Enable reasoning mode (top-level per Ollama API)
 		Options: Options{
 			Temperature: 0.0,
 			NumPredict:  100,
-			Think:       true, // Enable reasoning mode
 		},
 	}
 
@@ -332,28 +332,63 @@ func TestClient_GenerateChatWithThink(t *testing.T) {
 	// This test verifies that the parameter is properly serialized
 }
 
-func TestOptionsJSONMarshalWithThink(t *testing.T) {
-	// Test that the think parameter is properly marshaled to JSON
-	opts := Options{
-		Temperature: 0.5,
-		Think:       true,
-	}
+func TestChatRequestJSONMarshalWithThink(t *testing.T) {
+	// The Ollama API defines "think" as a top-level field of the chat request,
+	// not as part of "options". See https://github.com/tmc/langchaingo/issues/1514.
+	t.Run("think true is top-level", func(t *testing.T) {
+		req := ChatRequest{
+			Model: "qwen3",
+			Think: boolPtr(true),
+			Options: Options{
+				Temperature: 0.5,
+			},
+		}
 
-	data, err := json.Marshal(opts)
-	require.NoError(t, err)
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
 
-	// Check that the JSON contains the think field
-	var result map[string]interface{}
-	err = json.Unmarshal(data, &result)
-	require.NoError(t, err)
+		var result map[string]any
+		require.NoError(t, json.Unmarshal(data, &result))
 
-	// Verify think field exists and is true
-	think, exists := result["think"]
-	assert.True(t, exists, "think field should exist in JSON")
-	assert.Equal(t, true, think, "think field should be true")
+		think, exists := result["think"]
+		assert.True(t, exists, "think field should exist at the top level")
+		assert.Equal(t, true, think, "think field should be true")
 
-	// Verify temperature field for completeness
-	temp, exists := result["temperature"]
-	assert.True(t, exists, "temperature field should exist in JSON")
-	assert.Equal(t, float64(0.5), temp, "temperature should be 0.5")
+		// think must not leak into the nested options object.
+		opts, ok := result["options"].(map[string]any)
+		require.True(t, ok, "options object should be present")
+		_, thinkInOptions := opts["think"]
+		assert.False(t, thinkInOptions, "think must not be nested inside options")
+	})
+
+	t.Run("think false is preserved", func(t *testing.T) {
+		// A plain bool with omitempty would drop false; the pointer keeps it so
+		// callers can explicitly disable thinking on models that think by default.
+		req := ChatRequest{Model: "qwen3", Think: boolPtr(false)}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var result map[string]any
+		require.NoError(t, json.Unmarshal(data, &result))
+
+		think, exists := result["think"]
+		assert.True(t, exists, "explicit false think field should be preserved")
+		assert.Equal(t, false, think, "think field should be false")
+	})
+
+	t.Run("think unset is omitted", func(t *testing.T) {
+		req := ChatRequest{Model: "qwen3"}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var result map[string]any
+		require.NoError(t, json.Unmarshal(data, &result))
+
+		_, exists := result["think"]
+		assert.False(t, exists, "unset think field should be omitted")
+	})
 }
+
+func boolPtr(b bool) *bool { return &b }

--- a/llms/ollama/internal/ollamaclient/testdata/TestClient_GenerateChatWithThink.httprr
+++ b/llms/ollama/internal/ollamaclient/testdata/TestClient_GenerateChatWithThink.httprr
@@ -7,7 +7,7 @@ Content-Length: 167
 Accept: application/x-ndjson
 Content-Type: application/json
 
-{"model":"gemma3:1b","messages":[{"role":"user","content":"What is 2+2? Show your reasoning."}],"format":"","options":{"num_predict":100,"temperature":0,"think":true}}HTTP/1.1 200 OK
+{"model":"gemma3:1b","messages":[{"role":"user","content":"What is 2+2? Show your reasoning."}],"format":"","think":true,"options":{"num_predict":100,"temperature":0}}HTTP/1.1 200 OK
 Transfer-Encoding: chunked
 Content-Type: application/x-ndjson
 Date: Wed, 20 Aug 2025 13:48:26 GMT

--- a/llms/ollama/internal/ollamaclient/types.go
+++ b/llms/ollama/internal/ollamaclient/types.go
@@ -34,6 +34,10 @@ type GenerateRequest struct {
 	Context   []int  `json:"context,omitempty"`
 	Stream    *bool  `json:"stream"`
 	KeepAlive string `json:"keep_alive,omitempty"`
+	// Think enables reasoning mode (Ollama 0.9.0+). It is a top-level field per
+	// the Ollama API, not part of Options. A nil pointer omits the field, so an
+	// explicit false (disable thinking) is distinguishable from "unset".
+	Think *bool `json:"think,omitempty"`
 
 	Options Options `json:"options"`
 }
@@ -52,6 +56,10 @@ type ChatRequest struct {
 	Stream    bool       `json:"stream,omitempty"`
 	Format    string     `json:"format"`
 	KeepAlive string     `json:"keep_alive,omitempty"`
+	// Think enables reasoning mode (Ollama 0.9.0+). It is a top-level field per
+	// the Ollama API, not part of Options. A nil pointer omits the field, so an
+	// explicit false (disable thinking) is distinguishable from "unset".
+	Think *bool `json:"think,omitempty"`
 
 	Options Options `json:"options"`
 }
@@ -167,7 +175,6 @@ type Options struct {
 	MirostatEta      float32 `json:"mirostat_eta,omitempty"`
 	TopP             float32 `json:"top_p,omitempty"`
 	PenalizeNewline  bool    `json:"penalize_newline,omitempty"`
-	Think            bool    `json:"think,omitempty"` // Ollama 0.9.0+ reasoning mode
 }
 
 type PullRequest struct {

--- a/llms/ollama/ollamallm.go
+++ b/llms/ollama/ollamallm.go
@@ -146,21 +146,18 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 	// Get our ollamaOptions from llms.CallOptions
 	ollamaOptions := makeOllamaOptionsFromOptions(o.options.ollamaOptions, opts)
 
-	// Handle thinking mode if specified via metadata
-	if opts.Metadata != nil {
-		if config, ok := opts.Metadata["thinking_config"].(*llms.ThinkingConfig); ok {
-			if config.Mode != llms.ThinkingModeNone && o.SupportsReasoning() {
-				// Enable thinking for models that support it
-				ollamaOptions.Think = true
-			}
-		}
-	}
+	// Resolve the reasoning-mode flag. It is sent as a top-level field per the
+	// Ollama API (not inside options), and uses a pointer so an explicit false
+	// (disable thinking) is distinguishable from "unset".
+	think := resolveThink(o.options.think, opts)
+
 	req := &ollamaclient.ChatRequest{
 		Model:    model,
 		Format:   format,
 		Messages: chatMsgs,
 		Options:  ollamaOptions,
 		Stream:   opts.StreamingFunc != nil,
+		Think:    think,
 	}
 
 	keepAlive := o.options.keepAlive
@@ -231,7 +228,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 
 	// Note: Ollama may include thinking in the main content when Think mode is enabled
 	// Future versions may provide separate thinking content
-	if ollamaOptions.Think && o.SupportsReasoning() {
+	if think != nil && *think && o.SupportsReasoning() {
 		genInfo["ThinkingEnabled"] = true
 	}
 
@@ -319,17 +316,21 @@ func makeOllamaOptionsFromOptions(ollamaOptions ollamaclient.Options, opts llms.
 	ollamaOptions.FrequencyPenalty = float32(opts.FrequencyPenalty)
 	ollamaOptions.PresencePenalty = float32(opts.PresencePenalty)
 
-	// Extract thinking configuration for models that support it
+	return ollamaOptions
+}
+
+// resolveThink determines the value of the top-level Ollama "think" field.
+// Per-call thinking configuration (via WithThinkingMode / the "thinking_config"
+// metadata) takes precedence over the client-level WithThink option. A nil
+// result omits the field entirely, leaving the server default in place.
+func resolveThink(clientThink *bool, opts llms.CallOptions) *bool {
 	if opts.Metadata != nil {
 		if config, ok := opts.Metadata["thinking_config"].(*llms.ThinkingConfig); ok {
-			// Enable thinking mode if not explicitly disabled
-			if config.Mode != llms.ThinkingModeNone {
-				ollamaOptions.Think = true
-			}
+			think := config.Mode != llms.ThinkingModeNone
+			return &think
 		}
 	}
-
-	return ollamaOptions
+	return clientThink
 }
 
 // pullModelIfNeeded pulls the model if it's not already available.

--- a/llms/ollama/options.go
+++ b/llms/ollama/options.go
@@ -20,6 +20,9 @@ type options struct {
 	keepAlive           string
 	pullModel           bool
 	pullTimeout         time.Duration
+	// think is the reasoning-mode flag sent as a top-level field to the Ollama
+	// API. A nil pointer leaves it unset so an explicit false is distinguishable.
+	think *bool
 }
 
 type Option func(*options)
@@ -268,11 +271,14 @@ func WithPredictPenalizeNewline(val bool) Option {
 	}
 }
 
-// WithThink enables reasoning mode for models that support it (Ollama 0.9.0+).
-// When enabled, the model will show its internal reasoning process.
+// WithThink enables or disables reasoning mode for models that support it
+// (Ollama 0.9.0+). When enabled, the model will show its internal reasoning
+// process. Passing false explicitly disables thinking for models (such as
+// qwen3 or deepseek-r1) that think by default. The flag is sent as a top-level
+// field to the Ollama API.
 func WithThink(val bool) Option {
 	return func(opts *options) {
-		opts.ollamaOptions.Think = val
+		opts.think = &val
 	}
 }
 

--- a/llms/ollama/testdata/TestWithThink.httprr
+++ b/llms/ollama/testdata/TestWithThink.httprr
@@ -7,7 +7,7 @@ Content-Length: 165
 Accept: application/x-ndjson
 Content-Type: application/json
 
-{"model":"gemma3:1b","messages":[{"role":"user","content":"What is 2+2? Explain your reasoning step by step."}],"format":"","options":{"temperature":0,"think":true}}HTTP/1.1 200 OK
+{"model":"gemma3:1b","messages":[{"role":"user","content":"What is 2+2? Explain your reasoning step by step."}],"format":"","think":true,"options":{"temperature":0}}HTTP/1.1 200 OK
 Transfer-Encoding: chunked
 Content-Type: application/x-ndjson
 Date: Wed, 20 Aug 2025 13:47:56 GMT


### PR DESCRIPTION
## What this PR does

`WithThink` (and the `ThinkingMode`-derived flag) is currently a silent no-op for the Ollama provider, due to two independent defects on the request side:

1. **Wrong placement.** `think` was serialized inside the `"options"` object, but the Ollama API defines it as a **top-level** field of `/api/chat` and `/api/generate` ([Ollama API docs](https://github.com/ollama/ollama/blob/main/docs/api.md): *"`think`: (for thinking models) should the model think before responding?"*). Unknown keys inside `options` are ignored by the server, so `WithThink(true)` never took effect.
2. **`omitempty` on a plain bool.** `false` is the zero value, so `WithThink(false)` serialized to nothing at all — making it impossible to explicitly *disable* thinking on models (qwen3, deepseek-r1, ...) that reason by default.

### Changes

- Move `Think` out of `ollamaclient.Options` onto `ChatRequest` and `GenerateRequest` as a top-level `*bool`. The pointer keeps `unset` distinguishable from an explicit `false`.
- Populate it from both the client-level `WithThink` option and the per-call `thinking_config` metadata via a new `resolveThink` helper (per-call config takes precedence).
- Update the recorded `httprr` fixtures (`TestWithThink`, `TestClient_GenerateChatWithThink`) to the corrected wire format.
- Rework the JSON-marshal test to assert `think` is top-level (not nested in `options`), that an explicit `false` is preserved, and that an unset value is omitted.

Fixes #1514

## Ready for review

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

### Notes

- The `think` request field mirrors the top-level parameter in the [Ollama API](https://github.com/ollama/ollama/blob/main/docs/api.md), the same shape used by the official Ollama clients.
- `golangci-lint` (v2.3.0, matching the repo's `lint-deps` target) reports `0 issues` on `./llms/ollama/...`.
- The replay-based tests (`TestWithThink`, `TestClient_GenerateChatWithThink`, `TestChatRequestJSONMarshalWithThink`) pass. The remaining tests in the package are integration tests that require a live Ollama server and are unaffected by this change.