### PR TITLE
llms/openai: don't require an embedding deployment for Azure chat

### DIFF
--- a/llms/openai/azure_test.go
+++ b/llms/openai/azure_test.go
@@ -1,0 +1,108 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// clearAzureEnv keeps the ambient environment from filling in what a case
+// deliberately leaves out
+func clearAzureEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(tokenEnvVarName, "")
+	t.Setenv(modelEnvVarName, "")
+	t.Setenv(baseURLEnvVarName, "")
+	t.Setenv(baseAPIBaseEnvVarName, "")
+}
+
+// chat completions do not touch the embeddings deployment, requiring one kept
+// Azure users from creating a chat client at all
+func TestAzureChatWithoutEmbeddingModel(t *testing.T) {
+	clearAzureEnv(t)
+
+	llm, err := New(
+		WithAPIType(APITypeAzure),
+		WithToken("token"),
+		WithModel("gpt-4o-deployment"),
+		WithBaseURL("https://resource.openai.azure.com"),
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if llm == nil {
+		t.Fatal("expected a client")
+	}
+}
+
+func TestAzureMissingModel(t *testing.T) {
+	clearAzureEnv(t)
+
+	for name, opts := range map[string][]Option{
+		"default api version": {
+			WithAPIType(APITypeAzure),
+			WithToken("token"),
+		},
+		// the check used to sit behind an empty api version and was skipped
+		// whenever one was passed
+		"explicit api version": {
+			WithAPIType(APITypeAzure),
+			WithToken("token"),
+			WithAPIVersion("2024-10-21"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := New(opts...); !errors.Is(err, ErrMissingAzureModel) {
+				t.Errorf("expected ErrMissingAzureModel, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAzureAPIVersion(t *testing.T) {
+	clearAzureEnv(t)
+
+	for name, tc := range map[string]struct {
+		opts []Option
+		want string
+	}{
+		"default":  {[]Option{}, DefaultAPIVersion},
+		"explicit": {[]Option{WithAPIVersion("2024-10-21")}, "2024-10-21"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			opts := append([]Option{
+				WithAPIType(APITypeAzure),
+				WithToken("token"),
+				WithModel("gpt-4o-deployment"),
+			}, tc.opts...)
+
+			options, _, err := newClient(opts...)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if options.apiVersion != tc.want {
+				t.Errorf("expected api version %q, got %q", tc.want, options.apiVersion)
+			}
+		})
+	}
+}
+
+// the embeddings deployment is part of the request path, so it is reported
+// where it is needed rather than at construction
+func TestAzureEmbeddingWithoutEmbeddingModel(t *testing.T) {
+	clearAzureEnv(t)
+
+	llm, err := New(
+		WithAPIType(APITypeAzure),
+		WithToken("token"),
+		WithModel("gpt-4o-deployment"),
+		WithBaseURL("https://resource.openai.azure.com"),
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if _, err := llm.CreateEmbedding(context.Background(), []string{"hello"}); !errors.Is(err, ErrMissingAzureEmbeddingModel) {
+		t.Errorf("expected ErrMissingAzureEmbeddingModel, got %v", err)
+	}
+}

--- a/llms/openai/internal/openaiclient/embeddings.go
+++ b/llms/openai/internal/openaiclient/embeddings.go
@@ -13,6 +13,10 @@ const (
 	defaultEmbeddingModel = "text-embedding-ada-002"
 )
 
+// ErrMissingAzureEmbeddingModel is returned when embeddings are created on
+// Azure without an embedding deployment, which the request path is built from
+var ErrMissingAzureEmbeddingModel = errors.New("embeddings model needs to be provided when using Azure API")
+
 type embeddingPayload struct {
 	Model      string   `json:"model"`
 	Input      []string `json:"input"`

--- a/llms/openai/internal/openaiclient/openaiclient.go
+++ b/llms/openai/internal/openaiclient/openaiclient.go
@@ -134,6 +134,12 @@ func (c *Client) makeEmbeddingPayload(r *EmbeddingRequest) *embeddingPayload {
 
 // CreateEmbedding creates embeddings.
 func (c *Client) CreateEmbedding(ctx context.Context, r *EmbeddingRequest) ([][]float32, error) {
+	// azure addresses the deployment through the url, an empty one would
+	// silently request /openai/deployments//embeddings
+	if IsAzure(c.apiType) && c.EmbeddingModel == "" {
+		return nil, ErrMissingAzureEmbeddingModel
+	}
+
 	if r.Model == "" {
 		r.Model = defaultEmbeddingModel
 	}

--- a/llms/openai/llm.go
+++ b/llms/openai/llm.go
@@ -12,7 +12,7 @@ var (
 	ErrEmptyResponse              = errors.New("no response")
 	ErrMissingToken               = errors.New("missing the OpenAI API key, set it in the OPENAI_API_KEY environment variable") //nolint:lll
 	ErrMissingAzureModel          = errors.New("model needs to be provided when using Azure API")
-	ErrMissingAzureEmbeddingModel = errors.New("embeddings model needs to be provided when using Azure API")
+	ErrMissingAzureEmbeddingModel = openaiclient.ErrMissingAzureEmbeddingModel
 
 	ErrUnexpectedResponseLength = errors.New("unexpected length of response")
 )
@@ -32,13 +32,15 @@ func newClient(opts ...Option) (*options, *openaiclient.Client, error) {
 		opt(options)
 	}
 	// set of options needed for Azure client
-	if openaiclient.IsAzure(openaiclient.APIType(options.apiType)) && options.apiVersion == "" {
-		options.apiVersion = DefaultAPIVersion
+	if openaiclient.IsAzure(openaiclient.APIType(options.apiType)) {
+		if options.apiVersion == "" {
+			options.apiVersion = DefaultAPIVersion
+		}
+		// the deployment name is part of the request path, there is no default.
+		// the embedding deployment is only needed once embeddings are created,
+		// which CreateEmbedding reports on its own
 		if options.model == "" {
 			return options, nil, ErrMissingAzureModel
-		}
-		if options.embeddingModel == "" {
-			return options, nil, ErrMissingAzureEmbeddingModel
 		}
 	}
 


### PR DESCRIPTION
Fixes #955

`openai.New` refused to build an Azure client without `WithEmbeddingModel`, so anyone who only wanted chat completions was blocked by `ErrMissingAzureEmbeddingModel`. That is what the issue reports: "When I set API type to Azure, I am forced to use an embeddings model, when I actually want to use gpt3.5-turbo from the Azure API."

The embedding deployment is only needed to build the embeddings request path, `/openai/deployments/{deployment}/embeddings`. Nothing on the chat path reads it. It is now reported by `CreateEmbedding`, where an empty value would otherwise produce `/openai/deployments//embeddings` and a confusing 404, instead of blocking construction of every Azure client. `openai.ErrMissingAzureEmbeddingModel` keeps its identity, so existing `errors.Is` checks are unaffected.

While in there: the same block was guarded by `... && options.apiVersion == ""`, so passing `WithAPIVersion` skipped the model check entirely. Applying the default api version and validating the deployment are now separate, and `ErrMissingAzureModel` is returned either way.

Tests are in `llms/openai/azure_test.go` and need no network or httprr recordings, since all four cases resolve before a request is built.

Two notes for the maintainers:

- `DefaultAPIVersion` is still `2023-05-15`, which predates tool calling, so `WithTools` silently does nothing on Azure unless the caller passes a newer `WithAPIVersion`. Happy to bump it to a GA version such as `2024-10-21` here or in a separate PR, whichever you prefer.
- Azure's v1 API (GA since August 2025) is plain OpenAI under `{endpoint}/openai/v1` and needs no `api-version` and no `APITypeAzure` at all, so it already works through the normal `WithBaseURL` path. Worth documenting as the recommended route for new deployments, if you'd like I can add that.

I looked at whether `github.com/Azure/azure-sdk-for-go/sdk/ai/azopenai` should back this instead. It is an extension module for `github.com/openai/openai-go`, providing Azure-specific models and convenience helpers on top of that client, not a standalone client. Since `llms/openai` has its own `internal/openaiclient`, adopting it would mean rebuilding the provider on openai-go rather than fixing this bug, so I left it out.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)