### PR TITLE
llms/ollama: send think at request top level

### DIFF
--- a/llms/ollama/internal/ollamaclient/ollamaclient_test.go
+++ b/llms/ollama/internal/ollamaclient/ollamaclient_test.go
@@ -301,6 +301,8 @@ func TestClient_GenerateChatWithThink(t *testing.T) {
 	client, err := NewClient(parsedURL, rr.Client())
 	require.NoError(t, err)
 
+	think := true
+
 	req := &ChatRequest{
 		Model: "gemma3:1b",
 		Messages: []*Message{
@@ -310,10 +312,10 @@ func TestClient_GenerateChatWithThink(t *testing.T) {
 			},
 		},
 		Stream: false,
+		Think:  &think,
 		Options: Options{
 			Temperature: 0.0,
 			NumPredict:  100,
-			Think:       true, // Enable reasoning mode
 		},
 	}
 
@@ -332,28 +334,26 @@ func TestClient_GenerateChatWithThink(t *testing.T) {
 	// This test verifies that the parameter is properly serialized
 }
 
-func TestOptionsJSONMarshalWithThink(t *testing.T) {
-	// Test that the think parameter is properly marshaled to JSON
-	opts := Options{
-		Temperature: 0.5,
-		Think:       true,
+func TestRequestJSONMarshalWithThink(t *testing.T) {
+	for _, think := range []bool{true, false} {
+		req := ChatRequest{
+			Model:   "test",
+			Think:   &think,
+			Options: Options{Temperature: 0.5},
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &result))
+		assert.Equal(t, think, result["think"])
+
+		options := result["options"].(map[string]interface{})
+		assert.NotContains(t, options, "think")
 	}
 
-	data, err := json.Marshal(opts)
+	data, err := json.Marshal(ChatRequest{Model: "test"})
 	require.NoError(t, err)
-
-	// Check that the JSON contains the think field
-	var result map[string]interface{}
-	err = json.Unmarshal(data, &result)
-	require.NoError(t, err)
-
-	// Verify think field exists and is true
-	think, exists := result["think"]
-	assert.True(t, exists, "think field should exist in JSON")
-	assert.Equal(t, true, think, "think field should be true")
-
-	// Verify temperature field for completeness
-	temp, exists := result["temperature"]
-	assert.True(t, exists, "temperature field should exist in JSON")
-	assert.Equal(t, float64(0.5), temp, "temperature should be 0.5")
+	assert.NotContains(t, string(data), "think")
 }

--- a/llms/ollama/internal/ollamaclient/testdata/TestClient_GenerateChatWithThink.httprr
+++ b/llms/ollama/internal/ollamaclient/testdata/TestClient_GenerateChatWithThink.httprr
@@ -7,7 +7,7 @@ Content-Length: 167
 Accept: application/x-ndjson
 Content-Type: application/json
 
-{"model":"gemma3:1b","messages":[{"role":"user","content":"What is 2+2? Show your reasoning."}],"format":"","options":{"num_predict":100,"temperature":0,"think":true}}HTTP/1.1 200 OK
+{"model":"gemma3:1b","messages":[{"role":"user","content":"What is 2+2? Show your reasoning."}],"format":"","think":true,"options":{"num_predict":100,"temperature":0}}HTTP/1.1 200 OK
 Transfer-Encoding: chunked
 Content-Type: application/x-ndjson
 Date: Wed, 20 Aug 2025 13:48:26 GMT

--- a/llms/ollama/internal/ollamaclient/types.go
+++ b/llms/ollama/internal/ollamaclient/types.go
@@ -34,6 +34,7 @@ type GenerateRequest struct {
 	Context   []int  `json:"context,omitempty"`
 	Stream    *bool  `json:"stream"`
 	KeepAlive string `json:"keep_alive,omitempty"`
+	Think     *bool  `json:"think,omitempty"`
 
 	Options Options `json:"options"`
 }
@@ -52,6 +53,7 @@ type ChatRequest struct {
 	Stream    bool       `json:"stream,omitempty"`
 	Format    string     `json:"format"`
 	KeepAlive string     `json:"keep_alive,omitempty"`
+	Think     *bool      `json:"think,omitempty"`
 
 	Options Options `json:"options"`
 }
@@ -167,7 +169,6 @@ type Options struct {
 	MirostatEta      float32 `json:"mirostat_eta,omitempty"`
 	TopP             float32 `json:"top_p,omitempty"`
 	PenalizeNewline  bool    `json:"penalize_newline,omitempty"`
-	Think            bool    `json:"think,omitempty"` // Ollama 0.9.0+ reasoning mode
 }
 
 type PullRequest struct {

--- a/llms/ollama/ollama_test.go
+++ b/llms/ollama/ollama_test.go
@@ -173,6 +173,14 @@ func TestWithKeepAlive(t *testing.T) {
 	// Use TestCreateEmbedding for embedding tests
 }
 
+func TestWithThinkOption(t *testing.T) {
+	var opts options
+	WithThink(false)(&opts)
+
+	require.NotNil(t, opts.think)
+	assert.False(t, *opts.think)
+}
+
 func TestWithThink(t *testing.T) {
 	ctx := context.Background()
 
@@ -189,7 +197,7 @@ func TestWithThink(t *testing.T) {
 		},
 	}
 
-	// The request should include think:true in options
+	// The request should include think:true at the top level
 	resp, err := llm.GenerateContent(ctx, content)
 	require.NoError(t, err)
 

--- a/llms/ollama/ollamallm.go
+++ b/llms/ollama/ollamallm.go
@@ -145,13 +145,15 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 
 	// Get our ollamaOptions from llms.CallOptions
 	ollamaOptions := makeOllamaOptionsFromOptions(o.options.ollamaOptions, opts)
+	think := o.options.think
 
 	// Handle thinking mode if specified via metadata
 	if opts.Metadata != nil {
 		if config, ok := opts.Metadata["thinking_config"].(*llms.ThinkingConfig); ok {
 			if config.Mode != llms.ThinkingModeNone && o.SupportsReasoning() {
 				// Enable thinking for models that support it
-				ollamaOptions.Think = true
+				enabled := true
+				think = &enabled
 			}
 		}
 	}
@@ -161,6 +163,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		Messages: chatMsgs,
 		Options:  ollamaOptions,
 		Stream:   opts.StreamingFunc != nil,
+		Think:    think,
 	}
 
 	keepAlive := o.options.keepAlive
@@ -231,7 +234,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 
 	// Note: Ollama may include thinking in the main content when Think mode is enabled
 	// Future versions may provide separate thinking content
-	if ollamaOptions.Think && o.SupportsReasoning() {
+	if req.Think != nil && *req.Think && o.SupportsReasoning() {
 		genInfo["ThinkingEnabled"] = true
 	}
 
@@ -318,16 +321,6 @@ func makeOllamaOptionsFromOptions(ollamaOptions ollamaclient.Options, opts llms.
 	ollamaOptions.RepeatPenalty = float32(opts.RepetitionPenalty)
 	ollamaOptions.FrequencyPenalty = float32(opts.FrequencyPenalty)
 	ollamaOptions.PresencePenalty = float32(opts.PresencePenalty)
-
-	// Extract thinking configuration for models that support it
-	if opts.Metadata != nil {
-		if config, ok := opts.Metadata["thinking_config"].(*llms.ThinkingConfig); ok {
-			// Enable thinking mode if not explicitly disabled
-			if config.Mode != llms.ThinkingModeNone {
-				ollamaOptions.Think = true
-			}
-		}
-	}
 
 	return ollamaOptions
 }

--- a/llms/ollama/options.go
+++ b/llms/ollama/options.go
@@ -20,6 +20,7 @@ type options struct {
 	keepAlive           string
 	pullModel           bool
 	pullTimeout         time.Duration
+	think               *bool
 }
 
 type Option func(*options)
@@ -272,7 +273,7 @@ func WithPredictPenalizeNewline(val bool) Option {
 // When enabled, the model will show its internal reasoning process.
 func WithThink(val bool) Option {
 	return func(opts *options) {
-		opts.ollamaOptions.Think = val
+		opts.think = &val
 	}
 }
 

--- a/llms/ollama/testdata/TestWithThink.httprr
+++ b/llms/ollama/testdata/TestWithThink.httprr
@@ -7,7 +7,7 @@ Content-Length: 165
 Accept: application/x-ndjson
 Content-Type: application/json
 
-{"model":"gemma3:1b","messages":[{"role":"user","content":"What is 2+2? Explain your reasoning step by step."}],"format":"","options":{"temperature":0,"think":true}}HTTP/1.1 200 OK
+{"model":"gemma3:1b","messages":[{"role":"user","content":"What is 2+2? Explain your reasoning step by step."}],"format":"","think":true,"options":{"temperature":0}}HTTP/1.1 200 OK
 Transfer-Encoding: chunked
 Content-Type: application/x-ndjson
 Date: Wed, 20 Aug 2025 13:47:56 GMT


### PR DESCRIPTION
Ollama wants `think` at the top of the chat/generate request, not inside runner options. The field is a pointer so WithThink(false) is actually sent instead of dropped.

Fixes #1514