### PR TITLE
fix(googleai): prevent index out of range panic on system-only messages (fix #1507)

### DIFF
--- a/llms/googleai/googleai.go
+++ b/llms/googleai/googleai.go
@@ -16,9 +16,10 @@ import (
 )
 
 var (
-	ErrNoContentInResponse   = errors.New("no content in generation response")
-	ErrUnknownPartInResponse = errors.New("unknown part type in generation response")
-	ErrInvalidMimeType       = errors.New("invalid mime type on content")
+	ErrNoContentInResponse     = errors.New("no content in generation response")
+	ErrUnknownPartInResponse   = errors.New("unknown part type in generation response")
+	ErrInvalidMimeType         = errors.New("invalid mime type on content")
+	ErrEmptyNonSystemMessages = errors.New("cannot generate content without non-system messages")
 )
 
 const (
@@ -330,6 +331,9 @@ func generateFromMessages(
 	// Given N total messages, genai's chat expects the first N-1 messages as
 	// history and the last message as the actual request.
 	n := len(history)
+	if n == 0 {
+		return nil, ErrEmptyNonSystemMessages
+	}
 	reqContent := history[n-1]
 	history = history[:n-1]
 

--- a/llms/googleai/googleai_test.go
+++ b/llms/googleai/googleai_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/generative-ai-go/genai"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/httputil"
@@ -588,4 +589,15 @@ func TestGoogleAIToolCallResponse(t *testing.T) {
 		require.NotNil(t, resp2)
 		assert.Contains(t, resp2.Choices[0].Content, "105")
 	}
+}
+
+func TestGenerateFromMessages_SystemOnlyMessages(t *testing.T) {
+	messages := []llms.MessageContent{
+		{
+			Role:  llms.ChatMessageTypeSystem,
+			Parts: []llms.ContentPart{llms.TextContent{Text: "You are a helpful assistant."}},
+		},
+	}
+	_, err := generateFromMessages(context.Background(), &genai.GenerativeModel{}, messages, &llms.CallOptions{})
+	assert.ErrorIs(t, err, ErrEmptyNonSystemMessages)
 }


### PR DESCRIPTION
Fixes #1507

### Problem
In llms/googleai/googleai.go generateFromMessages, when all input messages are system messages, they are extracted into model.SystemInstruction, leaving the history slice empty (len(history) == 0). Attempting to index eqContent := history[n-1] triggered a untime error: index out of range [-1] panic.

### Solution
- Guard history length in generateFromMessages and return ErrEmptyNonSystemMessages when no non-system messages are present.
- Added regression unit test TestGenerateFromMessages_SystemOnlyMessages in googleai_test.go.