### PR TITLE
llms/googleai: support zero-argument tools

### DIFF
--- a/llms/googleai/googleai.go
+++ b/llms/googleai/googleai.go
@@ -446,9 +446,6 @@ func convertSchemaRecursive(schemaMap map[string]any, toolIndex int, propertyPat
 			}
 			schema.Properties[propName] = nestedSchema
 		}
-	} else if schema.Type == genai.TypeObject && propertyPath == "" {
-		// For top-level object schemas without properties, this is an error
-		return nil, fmt.Errorf("tool [%d]: expected to find a map of properties", toolIndex)
 	}
 
 	// Handle array items recursively

--- a/llms/googleai/googleai_unit_test.go
+++ b/llms/googleai/googleai_unit_test.go
@@ -347,23 +347,46 @@ func TestConvertTools(t *testing.T) { //nolint:funlen // comprehensive test //no
 		assert.Nil(t, result)
 	})
 
-	t.Run("missing properties in parameters", func(t *testing.T) {
+	t.Run("zero-argument function tool", func(t *testing.T) {
 		tools := []llms.Tool{
 			{
 				Type: "function",
 				Function: &llms.FunctionDefinition{
-					Name:        "test",
-					Description: "test function",
+					Name:        "get_current_time",
+					Description: "Get the current time",
 					Parameters: map[string]any{
 						"type": "object",
-						// missing properties
+					},
+				},
+			},
+		}
+		result, err := convertTools(tools)
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Len(t, result[0].FunctionDeclarations, 1)
+
+		funcDecl := result[0].FunctionDeclarations[0]
+		assert.Equal(t, "get_current_time", funcDecl.Name)
+		assert.Equal(t, "TypeObject", funcDecl.Parameters.Type.String())
+		assert.Empty(t, funcDecl.Parameters.Properties)
+	})
+
+	t.Run("invalid properties type", func(t *testing.T) {
+		tools := []llms.Tool{
+			{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Name: "test",
+					Parameters: map[string]any{
+						"type":       "object",
+						"properties": "invalid",
 					},
 				},
 			},
 		}
 		result, err := convertTools(tools)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "expected to find a map of properties")
+		assert.Contains(t, err.Error(), "expected map for properties")
 		assert.Nil(t, result)
 	})
 

--- a/llms/googleai/vertex/vertex.go
+++ b/llms/googleai/vertex/vertex.go
@@ -404,32 +404,34 @@ func convertTools(tools []llms.Tool) ([]*genai.Tool, error) {
 			schema.Type = convertToolSchemaType(tyString)
 		}
 
-		paramProperties, ok := params["properties"].(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("tool [%d]: expected to find a map of properties", i)
-		}
-
-		schema.Properties = make(map[string]*genai.Schema)
-		for propName, propValue := range paramProperties {
-			valueMap, ok := propValue.(map[string]any)
+		if properties, ok := params["properties"]; ok {
+			paramProperties, ok := properties.(map[string]any)
 			if !ok {
-				return nil, fmt.Errorf("tool [%d], property [%v]: expect to find a value map", i, propName)
+				return nil, fmt.Errorf("tool [%d]: expected to find a map of properties", i)
 			}
-			schema.Properties[propName] = &genai.Schema{}
 
-			if ty, ok := valueMap["type"]; ok {
-				tyString, ok := ty.(string)
+			schema.Properties = make(map[string]*genai.Schema)
+			for propName, propValue := range paramProperties {
+				valueMap, ok := propValue.(map[string]any)
 				if !ok {
-					return nil, fmt.Errorf("tool [%d]: expected string for type", i)
+					return nil, fmt.Errorf("tool [%d], property [%v]: expect to find a value map", i, propName)
 				}
-				schema.Properties[propName].Type = convertToolSchemaType(tyString)
-			}
-			if desc, ok := valueMap["description"]; ok {
-				descString, ok := desc.(string)
-				if !ok {
-					return nil, fmt.Errorf("tool [%d]: expected string for description", i)
+				schema.Properties[propName] = &genai.Schema{}
+
+				if ty, ok := valueMap["type"]; ok {
+					tyString, ok := ty.(string)
+					if !ok {
+						return nil, fmt.Errorf("tool [%d]: expected string for type", i)
+					}
+					schema.Properties[propName].Type = convertToolSchemaType(tyString)
 				}
-				schema.Properties[propName].Description = descString
+				if desc, ok := valueMap["description"]; ok {
+					descString, ok := desc.(string)
+					if !ok {
+						return nil, fmt.Errorf("tool [%d]: expected string for description", i)
+					}
+					schema.Properties[propName].Description = descString
+				}
 			}
 		}
 

--- a/llms/googleai/vertex/vertex_unit_test.go
+++ b/llms/googleai/vertex/vertex_unit_test.go
@@ -512,6 +512,33 @@ func TestConvertTools(t *testing.T) { //nolint:funlen // comprehensive test //no
 			},
 		},
 		{
+			name: "zero-argument function tool",
+			tools: []llms.Tool{
+				{
+					Type: "function",
+					Function: &llms.FunctionDefinition{
+						Name:        "get_current_time",
+						Description: "Get the current time",
+						Parameters: map[string]any{
+							"type": "object",
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, result []*genai.Tool) {
+				fd := result[0].FunctionDeclarations[0]
+				if fd.Name != "get_current_time" {
+					t.Errorf("expected function name 'get_current_time', got %q", fd.Name)
+				}
+				if fd.Parameters.Type != genai.TypeObject {
+					t.Errorf("expected object type, got %v", fd.Parameters.Type)
+				}
+				if len(fd.Parameters.Properties) != 0 {
+					t.Errorf("expected no properties, got %v", fd.Parameters.Properties)
+				}
+			},
+		},
+		{
 			name: "unsupported tool type",
 			tools: []llms.Tool{
 				{


### PR DESCRIPTION
### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name the pull request clearly and prefix it with the affected package.
- [x] Checked that there is no open PR solving the same problem.
- [x] Reference the issue this solves.
- [x] No new concepts are introduced.
- [x] The behavior matches zero-argument object schemas used by OpenAI-compatible tools.
- [x] Contains regression coverage.
- [x] Passes golangci-lint for the changed code.

## What

Allow Google AI and Vertex AI tool conversion to accept an object schema without a `properties` field. This is the normal shape for a zero-argument function.

The existing validation still rejects a `properties` field when it is present with a non-object value.

Fixes #1446.

## Tests

- `go test ./llms/googleai -run ^TestConvertTools$`
- `go test ./llms/googleai/vertex -run ^TestConvertTools$`
- `go vet ./llms/googleai ./llms/googleai/vertex`
- `golangci-lint run --new-from-rev=HEAD ./llms/googleai/...` — 0 issues

The package-wide test command also includes credentialed Google integration tests; those cannot run locally without Application Default Credentials.
