### PR TITLE
## Problem - Vertex AI PaLM hardcoded location

### DIFF
--- a/llms/googleai/internal/palmclient/palmclient.go
+++ b/llms/googleai/internal/palmclient/palmclient.go
@@ -35,6 +35,7 @@ const (
 type PaLMClient struct {
 	client             *aiplatform.PredictionClient
 	projectID          string
+	location		   string
 	embeddingModelName string
 	textModelName      string
 	chatModelName      string
@@ -67,6 +68,7 @@ func New(ctx context.Context, projectID, location string, opts ...Option) (*PaLM
 	return &PaLMClient{
 		client:             client,
 		projectID:          projectID,
+		location:           location,
 		embeddingModelName: pOpt.EmbeddingModelName,
 		textModelName:      pOpt.TextModelName,
 		chatModelName:      pOpt.ChatModelName,
@@ -296,7 +298,7 @@ func (c *PaLMClient) batchPredict(ctx context.Context, model string, prompts []s
 		instances = append(instances, structpb.NewStructValue(content))
 	}
 	resp, err := c.client.Predict(ctx, &aiplatformpb.PredictRequest{
-		Endpoint:   c.projectLocationPublisherModelPath(c.projectID, "us-central1", "google", model),
+		Endpoint:   c.projectLocationPublisherModelPath(c.projectID, c.location, "google", model),
 		Instances:  instances,
 		Parameters: structpb.NewStructValue(mergedParams),
 	})
@@ -335,7 +337,7 @@ func (c *PaLMClient) chat(ctx context.Context, r *ChatRequest) ([]*structpb.Valu
 		structpb.NewStructValue(instance),
 	}
 	resp, err := c.client.Predict(ctx, &aiplatformpb.PredictRequest{
-		Endpoint:   c.projectLocationPublisherModelPath(c.projectID, "us-central1", "google", c.chatModelName),
+		Endpoint:   c.projectLocationPublisherModelPath(c.projectID, c.location, "google", c.chatModelName),
 		Instances:  instances,
 		Parameters: structpb.NewStructValue(mergedParams),
 	})


### PR DESCRIPTION
The Vertex AI PaLM client was using a hardcoded `location`, preventing clients from connecting to the region provided when creating the client.

## Solution

* Store the `location` provided to `New()` in the `PaLMClient`
* Use the configured location when building the Vertex AI endpoint
* Use the configured location when building the model resource path
* Remove the dependency on a hardcoded location

## Side Effects

* Vertex AI requests are now sent to the region configured by the caller
* Clients can be instantiated for different Vertex AI locations
* Existing behavior is preserved for callers already providing the expected location

## Testing

* Verified that the configured `location` is propagated from `New()` to the client
* Verified that both prediction endpoints use the client location

